### PR TITLE
feature: introduce a prompt builder pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 .env
 .env.local
 .env.development.local
+.env.test
 .env.test.local
 .env.production.local
 

--- a/README.md
+++ b/README.md
@@ -610,8 +610,6 @@ ElevenLabs supports 32+ languages with automatic language name detection via `In
 
 ### Custom Prompts with `promptOverrides`
 
-summarization prompt:
-
 Customize specific sections of the summarization prompt for different use cases like SEO, social media, or technical analysis.
 
 **Tip:** Before adding overrides, read through the default summarization prompt template in `src/functions/summarization.ts` (the `summarizationPromptBuilder` config) so you have clear context on what each section does and what you’re changing.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ const reliableResult = await getSummaryAndTags('your-mux-asset-id', {
   },
   tone: 'professional'
 });
+
+// Customize for specific use cases with promptOverrides
+const seoResult = await getSummaryAndTags('your-mux-asset-id', {
+  promptOverrides: {
+    task: 'Generate SEO-optimized metadata for search engines.',
+    title: 'Create a search-optimized title (50-60 chars) with primary keyword.',
+    keywords: 'Focus on high search volume and long-tail keywords.',
+  },
+});
 ```
 
 ### Content Moderation
@@ -362,6 +371,12 @@ Analyzes a Mux video asset and returns AI-generated metadata.
   - `retryDelay?: number` - Base delay between retries in milliseconds (default: 1000)
   - `maxRetryDelay?: number` - Maximum delay between retries in milliseconds (default: 10000)
   - `exponentialBackoff?: boolean` - Whether to use exponential backoff (default: true)
+- `promptOverrides?: object` - Override specific sections of the prompt for custom use cases
+  - `task?: string` - Override the main task instruction
+  - `title?: string` - Override title generation guidance
+  - `description?: string` - Override description generation guidance
+  - `keywords?: string` - Override keywords generation guidance
+  - `qualityGuidelines?: string` - Override quality guidelines
 - `muxTokenId?: string` - Mux API token ID
 - `muxTokenSecret?: string` - Mux API token secret
 - `muxSigningKey?: string` - Signing key ID for signed playback policies
@@ -548,7 +563,7 @@ Generates AI-powered chapter markers by analyzing video captions. Creates logica
 // Perfect format for Mux Player
 player.addChapters([
   {startTime: 0, title: 'Introduction and Setup'},
-  {startTime: 45, title: 'Main Content Discussion'}, 
+  {startTime: 45, title: 'Main Content Discussion'},
   {startTime: 120, title: 'Conclusion'}
 ]);
 ```
@@ -593,17 +608,56 @@ Creates AI-dubbed audio tracks from existing video content using ElevenLabs voic
 **Supported Languages:**
 ElevenLabs supports 32+ languages with automatic language name detection via `Intl.DisplayNames`. Supported languages include English, Spanish, French, German, Italian, Portuguese, Polish, Japanese, Korean, Chinese, Russian, Arabic, Hindi, Thai, and many more. Track names are automatically generated (e.g., "Polish (auto-dubbed)").
 
-### Custom Prompts
+### Custom Prompts with `promptOverrides`
 
-Override the default summarization prompt:
+summarization prompt:
+
+Customize specific sections of the summarization prompt for different use cases like SEO, social media, or technical analysis:
 
 ```typescript
-const result = await getSummaryAndTags(
-  assetId, 
-  'Custom analysis prompt here',
-  { tone: 'professional' }
-);
+import { getSummaryAndTags } from '@mux/ai/functions';
+
+// SEO-optimized metadata
+const seoResult = await getSummaryAndTags(assetId, {
+  tone: 'professional',
+  promptOverrides: {
+    task: 'Generate SEO-optimized metadata that maximizes discoverability.',
+    title: 'Create a search-optimized title (50-60 chars) with primary keyword front-loaded.',
+    keywords: 'Focus on high search volume terms and long-tail keywords.',
+  },
+});
+
+// Social media optimized for engagement
+const socialResult = await getSummaryAndTags(assetId, {
+  promptOverrides: {
+    title: 'Create a scroll-stopping headline using emotional triggers or curiosity gaps.',
+    description: 'Write shareable copy that creates FOMO and works without watching the video.',
+    keywords: 'Generate hashtag-ready keywords for trending and niche community tags.',
+  },
+});
+
+// Technical/production analysis
+const technicalResult = await getSummaryAndTags(assetId, {
+  tone: 'professional',
+  promptOverrides: {
+    task: 'Analyze cinematography, lighting, and production techniques.',
+    title: 'Describe the production style or filmmaking technique.',
+    description: 'Provide a technical breakdown of camera work, lighting, and editing.',
+    keywords: 'Use industry-standard production terminology.',
+  },
+});
 ```
+
+**Available override sections:**
+| Section | Description |
+|---------|-------------|
+| `task` | Main instruction for what to analyze |
+| `title` | Guidance for generating the title |
+| `description` | Guidance for generating the description |
+| `keywords` | Guidance for generating keywords/tags |
+| `qualityGuidelines` | General quality instructions |
+
+Each override can be a simple string (replaces the section content) or a full `PromptSection` object for advanced control over XML tag names and attributes.
 
 ## Examples
 
@@ -680,7 +734,7 @@ npm run example:translate-audio abc123 fr
 
 ### Summarization Examples
 - **Basic Usage**: Default prompt with different tones
-- **Custom Prompts**: Override default behavior
+- **Custom Prompts**: Override prompt sections with presets (SEO, social, technical, ecommerce)
 - **Tone Variations**: Compare analysis styles
 
 ```bash
@@ -688,7 +742,15 @@ cd examples/summarization
 npm install
 npm run basic <your-asset-id> [provider]
 npm run tones <your-asset-id>
-npm run custom
+
+# Custom prompts with presets
+npm run custom <your-asset-id> --preset seo
+npm run custom <your-asset-id> --preset social
+npm run custom <your-asset-id> --preset technical
+npm run custom <your-asset-id> --preset ecommerce
+
+# Or provide individual overrides
+npm run custom <your-asset-id> --task "Focus on product features"
 ```
 
 ### Moderation Examples

--- a/README.md
+++ b/README.md
@@ -612,7 +612,9 @@ ElevenLabs supports 32+ languages with automatic language name detection via `In
 
 summarization prompt:
 
-Customize specific sections of the summarization prompt for different use cases like SEO, social media, or technical analysis:
+Customize specific sections of the summarization prompt for different use cases like SEO, social media, or technical analysis.
+
+**Tip:** Before adding overrides, read through the default summarization prompt template in `src/functions/summarization.ts` (the `summarizationPromptBuilder` config) so you have clear context on what each section does and what you’re changing.
 
 ```typescript
 import { getSummaryAndTags } from '@mux/ai/functions';

--- a/examples/summarization/README.md
+++ b/examples/summarization/README.md
@@ -50,13 +50,31 @@ Compares three tone styles:
 
 ### Custom Prompt Example (`custom-prompt-example.ts`)
 
-Demonstrates how to override the default prompt with your own:
+Demonstrates how to use `promptOverrides` to customize the summarization for specific use cases:
 
 ```bash
-npm run custom
+# Use a preset (seo, social, technical, ecommerce)
+npm run example:summarization:custom <asset-id> --preset seo
+
+# Custom override via CLI
+npm run example:summarization:custom <asset-id> --task "Focus on product features"
+
+# Combine preset with additional overrides
+npm run example:summarization:custom <asset-id> --preset social --title-guidance "Make it viral"
 ```
 
-Shows how to provide a custom prompt for specialized analysis needs.
+**Available Presets:**
+- `seo` - Search engine optimized metadata for discoverability
+- `social` - Social media optimized for engagement and shares
+- `technical` - Production/cinematography focused analysis
+- `ecommerce` - Product video metadata for conversions
+
+**Overridable Sections:**
+- `task` - Main instruction for what to analyze
+- `title` - Guidance for title generation
+- `description` - Guidance for description generation
+- `keywords` - Guidance for keyword/tag generation
+- `qualityGuidelines` - General quality instructions
 
 ## Configuration Options
 
@@ -67,7 +85,44 @@ Key options for `getSummaryAndTags`:
 - `tone`: `'normal' | 'sassy' | 'professional'` (default: `'normal'`)
 - `includeTranscript`: Include the asset transcript when available (default: `true`)
 - `imageSubmissionMode`: `'url' | 'base64'` storyboard transport (default: `'url'`)
+- `promptOverrides`: Override specific sections of the prompt (see below)
 - Credential overrides (all fall back to env vars): `muxTokenId`, `muxTokenSecret`, `openaiApiKey`, `anthropicApiKey`, `googleApiKey`
+
+### Using `promptOverrides`
+
+The `promptOverrides` option lets you customize specific sections of the prompt while keeping the rest of the defaults:
+
+```typescript
+import { getSummaryAndTags } from '@mux/ai/functions';
+
+// SEO-optimized metadata
+const seoResult = await getSummaryAndTags(assetId, {
+  promptOverrides: {
+    task: 'Generate SEO-optimized metadata for search engines.',
+    title: 'Create a search-optimized title (50-60 chars) with primary keyword front-loaded.',
+    keywords: 'Focus on high search volume terms and long-tail keywords.',
+  },
+});
+
+// Social media optimized
+const socialResult = await getSummaryAndTags(assetId, {
+  promptOverrides: {
+    title: 'Create a scroll-stopping headline using emotional triggers or curiosity gaps.',
+    description: 'Write shareable copy that creates FOMO and works without watching the video.',
+    keywords: 'Generate hashtag-ready keywords for trending and niche community tags.',
+  },
+});
+
+// Technical/production analysis
+const technicalResult = await getSummaryAndTags(assetId, {
+  tone: 'professional',
+  promptOverrides: {
+    task: 'Analyze cinematography, lighting, and production techniques.',
+    title: 'Describe the production style or filmmaking technique.',
+    keywords: 'Use industry-standard production terminology.',
+  },
+});
+```
 
 ## What You'll Get
 

--- a/examples/summarization/basic-example.ts
+++ b/examples/summarization/basic-example.ts
@@ -60,6 +60,10 @@ program
         openaiApiKey: process.env.OPENAI_API_KEY,
         anthropicApiKey: process.env.ANTHROPIC_API_KEY,
         googleApiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+        promptOverrides: {
+          task: 'Generate SEO-optimized metadata for this product video.',
+          title: 'Create a click-worthy title under 60 characters for YouTube.',
+        },
       });
 
       console.log('📝 Title:');

--- a/examples/summarization/basic-example.ts
+++ b/examples/summarization/basic-example.ts
@@ -60,10 +60,6 @@ program
         openaiApiKey: process.env.OPENAI_API_KEY,
         anthropicApiKey: process.env.ANTHROPIC_API_KEY,
         googleApiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
-        promptOverrides: {
-          task: 'Generate SEO-optimized metadata for this product video.',
-          title: 'Create a click-worthy title under 60 characters for YouTube.',
-        },
       });
 
       console.log('📝 Title:');

--- a/examples/summarization/custom-prompt-example.ts
+++ b/examples/summarization/custom-prompt-example.ts
@@ -1,9 +1,35 @@
+/**
+ * Custom Prompt Example
+ *
+ * This example demonstrates how to use `promptOverrides` to customize the
+ * summarization output for specific use cases like SEO, social media, or
+ * technical analysis.
+ *
+ * Available override sections:
+ *   - task: The main instruction for what to analyze
+ *   - title: Guidance for generating the title
+ *   - description: Guidance for generating the description
+ *   - keywords: Guidance for generating keywords/tags
+ *   - qualityGuidelines: General quality instructions
+ *
+ * Usage:
+ *   # Use a preset (seo, social, technical)
+ *   npm run example:summarization:custom <asset-id> --preset seo
+ *
+ *   # Or provide custom overrides via CLI
+ *   npm run example:summarization:custom <asset-id> --task "Focus on product features"
+ *
+ *   # Combine preset with additional overrides
+ *   npm run example:summarization:custom <asset-id> --preset social --title-guidance "Make it viral"
+ */
+
 import 'dotenv/config';
 import { Command } from 'commander';
-import { getSummaryAndTags } from '@mux/ai/functions';
+import { getSummaryAndTags, SummarizationPromptOverrides } from '@mux/ai/functions';
 import { ToneType } from '@mux/ai';
 
 type Provider = 'openai' | 'anthropic' | 'google';
+type Preset = 'seo' | 'social' | 'technical' | 'ecommerce';
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: 'gpt-5-mini',
@@ -11,21 +37,136 @@ const DEFAULT_MODELS: Record<Provider, string> = {
   google: 'gemini-2.5-flash',
 };
 
-const DEFAULT_PROMPT = 'Provide a detailed technical analysis of this video, focusing on production quality, visual composition, and any technical elements visible.';
+/**
+ * Preset prompt overrides for common use cases.
+ * These demonstrate how to tailor the summarization for different purposes.
+ */
+const PRESETS: Record<Preset, SummarizationPromptOverrides> = {
+  // SEO-optimized metadata for search engines and video platforms
+  seo: {
+    task: 'Generate SEO-optimized metadata that maximizes discoverability in search engines and video platforms.',
+    title: `
+      Create a search-optimized title (50-60 characters ideal for SERP display).
+      Front-load the primary keyword. Include a compelling hook or benefit.
+      Avoid clickbait but make it enticing. Consider search intent.
+      Example: "How to Cook Perfect Pasta | 5-Minute Italian Recipe"
+    `,
+    description: `
+      Write a meta description (150-160 characters) that:
+      - Includes primary and secondary keywords naturally
+      - Contains a clear value proposition
+      - Ends with a subtle call-to-action
+      - Would encourage clicks from search results
+    `,
+    keywords: `
+      Generate search-focused keywords including:
+      - Primary topic keywords (high search volume)
+      - Long-tail keyword phrases
+      - Related semantic keywords
+      - Question-based keywords (how to, what is, etc.)
+      Use lowercase. Prioritize searchability over creativity.
+    `,
+  },
+
+  // Social media optimized for engagement
+  social: {
+    task: 'Generate social media-optimized metadata designed to maximize engagement, shares, and comments.',
+    title: `
+      Create a scroll-stopping headline that works across social platforms.
+      Use emotional triggers, curiosity gaps, or unexpected angles.
+      Keep it punchy (under 8 words ideal). Consider how it appears in feeds.
+      Emojis are acceptable if they add value.
+    `,
+    description: `
+      Write social-ready copy (2-3 sentences) that:
+      - Hooks immediately with the most interesting element
+      - Creates FOMO or curiosity
+      - Is shareable and quotable
+      - Works without watching the full video
+    `,
+    keywords: `
+      Generate hashtag-ready keywords:
+      - Trending topic tags
+      - Niche community tags
+      - Branded or campaign tags if apparent
+      - Emotional or reaction tags
+      Format as lowercase, no spaces (hashtag-ready).
+    `,
+  },
+
+  // Technical/production analysis
+  technical: {
+    task: 'Analyze the storyboard with focus on production quality, cinematography, and technical filmmaking elements.',
+    title: `
+      Create a technical headline describing the production style or technique.
+      Focus on cinematography, editing, or production quality rather than narrative.
+      Examples: "Handheld Documentary Interview", "Aerial Drone Tracking Shot"
+    `,
+    description: `
+      Provide a technical breakdown analyzing:
+      - Camera work: angles, movement, framing, lens choices
+      - Lighting: natural vs artificial, mood, color temperature
+      - Editing: pacing, transitions, visual effects
+      - Audio indicators: interview setup, ambient, music-driven
+      Write for a filmmaker or video professional audience.
+    `,
+    keywords: `
+      Generate industry-standard production terms:
+      - Camera techniques (handheld, steadicam, dolly, drone, gimbal)
+      - Shot types (close-up, wide, medium, tracking, POV)
+      - Lighting (key light, backlight, natural, studio)
+      - Style (documentary, cinematic, vlog, commercial)
+      Use professional terminology.
+    `,
+  },
+
+  // E-commerce product videos
+  ecommerce: {
+    task: 'Generate e-commerce optimized metadata for product videos that drive conversions.',
+    title: `
+      Create a product-focused title that highlights key selling points.
+      Include product category and primary benefit.
+      Format: "[Product Type] - [Key Benefit] | [Brand if visible]"
+    `,
+    description: `
+      Write conversion-focused copy that:
+      - Highlights visible product features and benefits
+      - Addresses potential buyer questions
+      - Creates desire without over-promising
+      - Suitable for product detail pages
+    `,
+    keywords: `
+      Generate shopping-intent keywords:
+      - Product category and type
+      - Key features and attributes
+      - Use cases and benefits
+      - Comparison terms (best, top, vs)
+      - Purchase-intent modifiers (buy, review, demo)
+    `,
+  },
+};
 
 const program = new Command();
 
 program
   .name('custom-prompt')
-  .description('Generate summary with a custom prompt')
+  .description('Generate summary with custom prompt overrides')
   .argument('<asset-id>', 'Mux asset ID to analyze')
-  .option('--prompt <text>', 'Custom prompt text', DEFAULT_PROMPT)
+  .option('--preset <name>', 'Use a preset: seo, social, technical, ecommerce')
+  .option('--task <text>', 'Override the task description')
+  .option('--title-guidance <text>', 'Override title generation guidance')
+  .option('--description-guidance <text>', 'Override description generation guidance')
+  .option('--keywords-guidance <text>', 'Override keywords generation guidance')
   .option('-p, --provider <provider>', 'AI provider (openai, anthropic, google)', 'openai')
   .option('-m, --model <model>', 'Model name (overrides default for provider)')
   .option('-t, --tone <tone>', 'Tone for summary (normal, sassy, professional)', 'professional')
   .option('--no-transcript', 'Exclude transcript from analysis')
   .action(async (assetId: string, options: {
-    prompt: string;
+    preset?: string;
+    task?: string;
+    titleGuidance?: string;
+    descriptionGuidance?: string;
+    keywordsGuidance?: string;
     provider: Provider;
     model?: string;
     tone: ToneType;
@@ -43,23 +184,50 @@ program
       process.exit(1);
     }
 
+    // Validate preset if provided
+    if (options.preset && !Object.keys(PRESETS).includes(options.preset)) {
+      console.error(`❌ Unknown preset "${options.preset}". Choose from: ${Object.keys(PRESETS).join(', ')}`);
+      process.exit(1);
+    }
+
     const model = options.model || DEFAULT_MODELS[options.provider];
 
-    console.log('🎯 Using a custom prompt to override the default...\n');
+    // Start with preset if provided, then layer on CLI overrides
+    const promptOverrides: SummarizationPromptOverrides = {
+      ...(options.preset ? PRESETS[options.preset as Preset] : {}),
+    };
+
+    // CLI options override preset values
+    if (options.task) promptOverrides.task = options.task;
+    if (options.titleGuidance) promptOverrides.title = options.titleGuidance;
+    if (options.descriptionGuidance) promptOverrides.description = options.descriptionGuidance;
+    if (options.keywordsGuidance) promptOverrides.keywords = options.keywordsGuidance;
+
+    const hasOverrides = Object.keys(promptOverrides).length > 0;
+
+    console.log('🎯 Generating summary with custom prompt overrides...\n');
     console.log(`Provider: ${options.provider} (${model})`);
-    console.log(`Prompt: ${options.prompt}\n`);
+    console.log(`Tone: ${options.tone}`);
+    if (options.preset) {
+      console.log(`Preset: ${options.preset}`);
+    }
+    if (hasOverrides) {
+      console.log(`Overridden sections: ${Object.keys(promptOverrides).join(', ')}`);
+    }
+    console.log();
 
     try {
-      const result = await getSummaryAndTags(assetId, options.prompt, {
+      const result = await getSummaryAndTags(assetId, {
         tone: options.tone,
         provider: options.provider,
         model,
         includeTranscript: options.transcript,
+        promptOverrides: hasOverrides ? promptOverrides : undefined,
       });
 
-      console.log('📋 Custom Analysis:');
+      console.log('📋 Analysis Result:');
       console.log(`Title: ${result.title}`);
-      console.log(`Description: ${result.description}`);
+      console.log(`\nDescription: ${result.description}`);
       console.log('\n🏷️  Tags:');
       console.log(result.tags.join(', '));
       console.log('\n🖼️  Storyboard URL:');

--- a/src/functions/summarization.ts
+++ b/src/functions/summarization.ts
@@ -338,14 +338,28 @@ export async function getSummaryAndTags(
     }
   } catch (error: unknown) {
     throw new Error(
-      `Failed to analyze video content with ${provider}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      `Failed to analyze video content with ${provider}: ${
+        error instanceof Error ? error.message : 'Unknown error'
+      }`
     );
+  }
+
+  if (!aiAnalysis) {
+    throw new Error(`Failed to analyze video content for asset ${assetId}`);
+  }
+
+  if (!aiAnalysis.title) {
+    throw new Error(`Failed to generate title for asset ${assetId}`);
+  }
+
+  if (!aiAnalysis.description) {
+    throw new Error(`Failed to generate description for asset ${assetId}`);
   }
 
   return {
     assetId,
-    title: aiAnalysis.title || 'No title available',
-    description: aiAnalysis.description || 'No description available',
+    title: aiAnalysis.title,
+    description: aiAnalysis.description,
     tags: normalizeKeywords(aiAnalysis.keywords),
     storyboardUrl: imageUrl,
   };

--- a/src/lib/prompt-builder.ts
+++ b/src/lib/prompt-builder.ts
@@ -1,0 +1,200 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A single section of a prompt, rendered as an XML-like tag.
+ */
+export interface PromptSection {
+  /** The XML tag name for this section */
+  tag: string;
+  /** The content inside the tag */
+  content: string;
+  /** Optional attributes to add to the tag (e.g., { format: "plain text" }) */
+  attributes?: Record<string, string>;
+}
+
+/**
+ * Configuration for building a prompt section.
+ * Can be a full PromptSection object, just a string (content only), or undefined to use default.
+ */
+export type SectionOverride = string | PromptSection | undefined;
+
+/**
+ * A template defining the default sections for a prompt.
+ * Keys are section identifiers, values are the default PromptSection definitions.
+ */
+export type PromptTemplate<TSections extends string> = Record<TSections, PromptSection>;
+
+/**
+ * User-provided overrides for prompt sections.
+ * Each key can override the corresponding section's content or full definition.
+ */
+export type PromptOverrides<TSections extends string> = Partial<Record<TSections, SectionOverride>>;
+
+/**
+ * Configuration for the prompt builder.
+ */
+export interface PromptBuilderConfig<TSections extends string> {
+  /** Default sections that make up the prompt template */
+  template: PromptTemplate<TSections>;
+  /** Order in which sections should appear in the final prompt */
+  sectionOrder: TSections[];
+}
+
+/**
+ * A configured prompt builder instance with methods to build prompts.
+ */
+export interface PromptBuilder<TSections extends string> {
+  /** The default template sections */
+  template: PromptTemplate<TSections>;
+  /** Build a prompt string, optionally overriding specific sections */
+  build(overrides?: PromptOverrides<TSections>): string;
+  /** Build a prompt with additional dynamic sections appended */
+  buildWithContext(
+    overrides?: PromptOverrides<TSections>,
+    additionalSections?: PromptSection[]
+  ): string;
+  /** Get a single section's content (useful for partial rendering) */
+  getSection(section: TSections, override?: SectionOverride): string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Renders a PromptSection as an XML-like string.
+ */
+export function renderSection(section: PromptSection): string {
+  const { tag, content, attributes } = section;
+
+  if (!content.trim()) {
+    return '';
+  }
+
+  const attrString = attributes
+    ? ' ' + Object.entries(attributes)
+        .map(([key, value]) => `${key}="${value}"`)
+        .join(' ')
+    : '';
+
+  return `<${tag}${attrString}>\n${content.trim()}\n</${tag}>`;
+}
+
+/**
+ * Resolves a section override to a full PromptSection.
+ */
+function resolveSection(
+  defaultSection: PromptSection,
+  override?: SectionOverride
+): PromptSection {
+  if (override === undefined) {
+    return defaultSection;
+  }
+
+  if (typeof override === 'string') {
+    return { ...defaultSection, content: override };
+  }
+
+  return override;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a type-safe prompt builder from a template configuration.
+ *
+ * @example
+ * ```typescript
+ * const builder = createPromptBuilder({
+ *   template: {
+ *     task: { tag: 'task', content: 'Analyze the image...' },
+ *     tone: { tag: 'tone', content: 'Be professional.' },
+ *   },
+ *   sectionOrder: ['task', 'tone'],
+ * });
+ *
+ * // Use defaults
+ * const prompt1 = builder.build();
+ *
+ * // Override specific sections
+ * const prompt2 = builder.build({
+ *   tone: 'Be casual and friendly.',
+ * });
+ * ```
+ */
+export function createPromptBuilder<TSections extends string>(
+  config: PromptBuilderConfig<TSections>
+): PromptBuilder<TSections> {
+  const { template, sectionOrder } = config;
+
+  const getSection = (section: TSections, override?: SectionOverride): string => {
+    const resolved = resolveSection(template[section], override);
+    return renderSection(resolved);
+  };
+
+  const build = (overrides?: PromptOverrides<TSections>): string => {
+    const sections = sectionOrder
+      .map((sectionKey) => getSection(sectionKey, overrides?.[sectionKey]))
+      .filter(Boolean);
+
+    return sections.join('\n\n');
+  };
+
+  const buildWithContext = (
+    overrides?: PromptOverrides<TSections>,
+    additionalSections?: PromptSection[]
+  ): string => {
+    const basePrompt = build(overrides);
+
+    if (!additionalSections?.length) {
+      return basePrompt;
+    }
+
+    const additional = additionalSections
+      .map(renderSection)
+      .filter(Boolean)
+      .join('\n\n');
+
+    return additional ? `${basePrompt}\n\n${additional}` : basePrompt;
+  };
+
+  return {
+    template,
+    build,
+    buildWithContext,
+    getSection,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Common Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a transcript section for inclusion in prompts.
+ */
+export function createTranscriptSection(
+  transcriptText: string,
+  format: 'plain text' | 'WebVTT' = 'plain text'
+): PromptSection {
+  return {
+    tag: 'transcript',
+    content: transcriptText,
+    attributes: { format },
+  };
+}
+
+/**
+ * Creates a tone section for inclusion in prompts.
+ */
+export function createToneSection(instruction: string): PromptSection {
+  return {
+    tag: 'tone',
+    content: instruction,
+  };
+}
+

--- a/tests/unit/prompt-builder.test.ts
+++ b/tests/unit/prompt-builder.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from 'vitest';
+import {
+  renderSection,
+  createPromptBuilder,
+  createTranscriptSection,
+  createToneSection,
+  PromptSection,
+} from '../../src/lib/prompt-builder';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// renderSection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('renderSection', () => {
+  it('renders a basic section with tag and content', () => {
+    const section: PromptSection = {
+      tag: 'task',
+      content: 'Analyze the video.',
+    };
+
+    const result = renderSection(section);
+
+    expect(result).toBe('<task>\nAnalyze the video.\n</task>');
+  });
+
+  it('renders a section with attributes', () => {
+    const section: PromptSection = {
+      tag: 'transcript',
+      content: 'Hello world.',
+      attributes: { format: 'plain text' },
+    };
+
+    const result = renderSection(section);
+
+    expect(result).toBe('<transcript format="plain text">\nHello world.\n</transcript>');
+  });
+
+  it('renders a section with multiple attributes', () => {
+    const section: PromptSection = {
+      tag: 'data',
+      content: 'Some data.',
+      attributes: { format: 'json', version: '1.0' },
+    };
+
+    const result = renderSection(section);
+
+    expect(result).toContain('<data');
+    expect(result).toContain('format="json"');
+    expect(result).toContain('version="1.0"');
+    expect(result).toContain('Some data.');
+    expect(result).toContain('</data>');
+  });
+
+  it('trims whitespace from content', () => {
+    const section: PromptSection = {
+      tag: 'task',
+      content: '  \n  Analyze this.  \n  ',
+    };
+
+    const result = renderSection(section);
+
+    expect(result).toBe('<task>\nAnalyze this.\n</task>');
+  });
+
+  it('returns empty string for empty content', () => {
+    const section: PromptSection = {
+      tag: 'task',
+      content: '',
+    };
+
+    expect(renderSection(section)).toBe('');
+  });
+
+  it('returns empty string for whitespace-only content', () => {
+    const section: PromptSection = {
+      tag: 'task',
+      content: '   \n\t  ',
+    };
+
+    expect(renderSection(section)).toBe('');
+  });
+
+  describe('XML safety', () => {
+    it('escapes < and > in content', () => {
+      const section: PromptSection = {
+        tag: 'code',
+        content: 'if (a < b && b > c) { return true; }',
+      };
+
+      const result = renderSection(section);
+
+      expect(result).toContain('&lt;');
+      expect(result).toContain('&gt;');
+      expect(result).not.toContain('< b');
+      expect(result).not.toContain('> c');
+    });
+
+    it('escapes & in content', () => {
+      const section: PromptSection = {
+        tag: 'text',
+        content: 'Tom & Jerry',
+      };
+
+      const result = renderSection(section);
+
+      expect(result).toContain('Tom &amp; Jerry');
+    });
+
+    it('escapes quotes in attribute values', () => {
+      const section: PromptSection = {
+        tag: 'quote',
+        content: 'Some content.',
+        attributes: { source: 'He said "hello"' },
+      };
+
+      const result = renderSection(section);
+
+      expect(result).toContain('source="He said &quot;hello&quot;"');
+    });
+
+    it('escapes special characters in attribute values', () => {
+      const section: PromptSection = {
+        tag: 'data',
+        content: 'Content here.',
+        attributes: { query: 'a < b & c > d' },
+      };
+
+      const result = renderSection(section);
+
+      expect(result).toContain('query="a &lt; b &amp; c &gt;');
+    });
+
+    it('throws for invalid tag names', () => {
+      const section: PromptSection = {
+        tag: '123invalid',
+        content: 'Content.',
+      };
+
+      expect(() => renderSection(section)).toThrow('Invalid XML tag name');
+    });
+
+    it('throws for tag names with spaces', () => {
+      const section: PromptSection = {
+        tag: 'my tag',
+        content: 'Content.',
+      };
+
+      expect(() => renderSection(section)).toThrow('Invalid XML tag name');
+    });
+
+    it('throws for invalid attribute names', () => {
+      const section: PromptSection = {
+        tag: 'valid',
+        content: 'Content.',
+        attributes: { '123attr': 'value' },
+      };
+
+      expect(() => renderSection(section)).toThrow('Invalid XML attribute name');
+    });
+
+    it('allows valid XML names with underscores, colons, and dots', () => {
+      const section: PromptSection = {
+        tag: 'my_tag:name.v1',
+        content: 'Content.',
+        attributes: { 'data_attr:v1.0': 'value' },
+      };
+
+      const result = renderSection(section);
+
+      expect(result).toContain('<my_tag:name.v1');
+      expect(result).toContain('data_attr:v1.0="value"');
+    });
+
+    it('allows tags starting with underscore', () => {
+      const section: PromptSection = {
+        tag: '_private',
+        content: 'Private content.',
+      };
+
+      const result = renderSection(section);
+
+      expect(result).toBe('<_private>\nPrivate content.\n</_private>');
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createPromptBuilder
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createPromptBuilder', () => {
+  type TestSections = 'task' | 'tone' | 'format';
+
+  const createTestBuilder = () =>
+    createPromptBuilder<TestSections>({
+      template: {
+        task: { tag: 'task', content: 'Default task.' },
+        tone: { tag: 'tone', content: 'Be professional.' },
+        format: { tag: 'format', content: 'Return JSON.' },
+      },
+      sectionOrder: ['task', 'tone', 'format'],
+    });
+
+  describe('build', () => {
+    it('builds prompt with default sections', () => {
+      const builder = createTestBuilder();
+      const result = builder.build();
+
+      expect(result).toContain('<task>\nDefault task.\n</task>');
+      expect(result).toContain('<tone>\nBe professional.\n</tone>');
+      expect(result).toContain('<format>\nReturn JSON.\n</format>');
+    });
+
+    it('separates sections with double newlines', () => {
+      const builder = createTestBuilder();
+      const result = builder.build();
+
+      expect(result).toContain('</task>\n\n<tone>');
+      expect(result).toContain('</tone>\n\n<format>');
+    });
+
+    it('respects section order', () => {
+      const builder = createPromptBuilder<TestSections>({
+        template: {
+          task: { tag: 'task', content: 'Task.' },
+          tone: { tag: 'tone', content: 'Tone.' },
+          format: { tag: 'format', content: 'Format.' },
+        },
+        sectionOrder: ['format', 'task', 'tone'],
+      });
+
+      const result = builder.build();
+      const formatIndex = result.indexOf('<format>');
+      const taskIndex = result.indexOf('<task>');
+      const toneIndex = result.indexOf('<tone>');
+
+      expect(formatIndex).toBeLessThan(taskIndex);
+      expect(taskIndex).toBeLessThan(toneIndex);
+    });
+
+    it('overrides section content with string', () => {
+      const builder = createTestBuilder();
+      const result = builder.build({
+        task: 'Custom task instruction.',
+      });
+
+      expect(result).toContain('<task>\nCustom task instruction.\n</task>');
+      expect(result).toContain('<tone>\nBe professional.\n</tone>');
+    });
+
+    it('overrides section with full PromptSection', () => {
+      const builder = createTestBuilder();
+      const result = builder.build({
+        task: {
+          tag: 'custom_task',
+          content: 'Completely custom.',
+          attributes: { priority: 'high' },
+        },
+      });
+
+      expect(result).toContain('<custom_task priority="high">');
+      expect(result).toContain('Completely custom.');
+    });
+
+    it('omits sections with empty content', () => {
+      const builder = createTestBuilder();
+      const result = builder.build({
+        tone: '',
+      });
+
+      expect(result).toContain('<task>');
+      expect(result).not.toContain('<tone>');
+      expect(result).toContain('<format>');
+    });
+  });
+
+  describe('buildWithContext', () => {
+    it('appends additional sections', () => {
+      const builder = createTestBuilder();
+      const result = builder.buildWithContext(undefined, [
+        { tag: 'transcript', content: 'Hello world.' },
+      ]);
+
+      expect(result).toContain('<task>');
+      expect(result).toContain('<transcript>\nHello world.\n</transcript>');
+    });
+
+    it('combines overrides with additional sections', () => {
+      const builder = createTestBuilder();
+      const result = builder.buildWithContext(
+        { task: 'Overridden task.' },
+        [{ tag: 'context', content: 'Extra context.' }]
+      );
+
+      expect(result).toContain('<task>\nOverridden task.\n</task>');
+      expect(result).toContain('<context>\nExtra context.\n</context>');
+    });
+
+    it('handles empty additional sections array', () => {
+      const builder = createTestBuilder();
+      const withEmpty = builder.buildWithContext(undefined, []);
+      const withoutAdditional = builder.build();
+
+      expect(withEmpty).toBe(withoutAdditional);
+    });
+
+    it('handles undefined additional sections', () => {
+      const builder = createTestBuilder();
+      const withUndefined = builder.buildWithContext(undefined, undefined);
+      const withoutAdditional = builder.build();
+
+      expect(withUndefined).toBe(withoutAdditional);
+    });
+
+    it('filters out empty additional sections', () => {
+      const builder = createTestBuilder();
+      const result = builder.buildWithContext(undefined, [
+        { tag: 'valid', content: 'Has content.' },
+        { tag: 'empty', content: '' },
+        { tag: 'also_valid', content: 'Also has content.' },
+      ]);
+
+      expect(result).toContain('<valid>');
+      expect(result).not.toContain('<empty>');
+      expect(result).toContain('<also_valid>');
+    });
+  });
+
+  describe('getSection', () => {
+    it('returns single section with defaults', () => {
+      const builder = createTestBuilder();
+      const result = builder.getSection('task');
+
+      expect(result).toBe('<task>\nDefault task.\n</task>');
+    });
+
+    it('returns single section with string override', () => {
+      const builder = createTestBuilder();
+      const result = builder.getSection('task', 'Custom content.');
+
+      expect(result).toBe('<task>\nCustom content.\n</task>');
+    });
+
+    it('returns single section with full override', () => {
+      const builder = createTestBuilder();
+      const result = builder.getSection('task', {
+        tag: 'custom',
+        content: 'Full override.',
+        attributes: { type: 'special' },
+      });
+
+      expect(result).toContain('<custom type="special">');
+      expect(result).toContain('Full override.');
+    });
+  });
+
+  describe('template access', () => {
+    it('exposes the template for inspection', () => {
+      const builder = createTestBuilder();
+
+      expect(builder.template.task.content).toBe('Default task.');
+      expect(builder.template.tone.tag).toBe('tone');
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createTranscriptSection', () => {
+  it('creates transcript section with plain text format by default', () => {
+    const section = createTranscriptSection('Hello world.');
+
+    expect(section.tag).toBe('transcript');
+    expect(section.content).toBe('Hello world.');
+    expect(section.attributes).toEqual({ format: 'plain text' });
+  });
+
+  it('creates transcript section with WebVTT format', () => {
+    const section = createTranscriptSection('WEBVTT\n\n00:00.000 --> 00:01.000\nHello', 'WebVTT');
+
+    expect(section.tag).toBe('transcript');
+    expect(section.attributes).toEqual({ format: 'WebVTT' });
+  });
+});
+
+describe('createToneSection', () => {
+  it('creates tone section with instruction', () => {
+    const section = createToneSection('Be friendly and casual.');
+
+    expect(section.tag).toBe('tone');
+    expect(section.content).toBe('Be friendly and casual.');
+    expect(section.attributes).toBeUndefined();
+  });
+});
+


### PR DESCRIPTION
## Summary

Introduces a prompt builder abstraction and refactors `getSummaryAndTags` to support customizable prompt sections via `promptOverrides`.

addresses [this issue](https://github.com/muxinc/ai/issues/13)

## Why

Users need to tailor summarization output for different use cases (SEO, social media, e-commerce, etc.) without rewriting entire prompts. The existing string-based custom prompt approach was all-or-nothing.

## What Changed

### New: `src/lib/prompt-builder.ts`

Reusable, type-safe prompt builder for XML-structured prompts:

- `createPromptBuilder<T>()` - Factory for creating typed builders
- `PromptOverrides<T>` - Partial overrides for template sections
- `renderSection()` - Renders sections as XML tags
- Helper functions: `createTranscriptSection()`, `createToneSection()`

### Updated: `src/functions/summarization.ts`

- **New types**: `SummarizationPromptSections`, `SummarizationPromptOverrides`
- **New option**: `promptOverrides` in `SummarizationOptions`
- **Refactored prompts**: XML-structured system and user prompts
- **Simplified API**: Removed overloaded signature (`assetId, prompt?, options?` → `assetId, options?`)
- **Schema relaxed**: Removed `.max()` constraints to fix Anthropic compatibility

### Updated: Examples & Docs

- `custom-prompt-example.ts` - Presets (seo, social, technical, ecommerce) + CLI overrides
- `examples/summarization/README.md` - Usage docs for `promptOverrides`
- Root `README.md` - API reference and examples updated

## Usage

```typescript
const result = await getSummaryAndTags(assetId, {
  promptOverrides: {
    task: 'Generate SEO-optimized metadata.',
    title: 'Create a search-optimized title (50-60 chars).',
    keywords: 'Focus on high search volume terms.',
  },
});
```

## Breaking Changes

- `getSummaryAndTags(assetId, customPrompt, options)` signature removed
- Use `promptOverrides` instead of passing a custom prompt string

