### PR TITLE
chore: added google integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,6 +32,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           HIVE_API_KEY: ${{ secrets.HIVE_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
           S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
           S3_REGION: ${{ secrets.S3_REGION }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/tests/integration/burned-in-captions.test.ts
+++ b/tests/integration/burned-in-captions.test.ts
@@ -98,4 +98,47 @@ describe('Burned-in Captions Integration Tests', () => {
       expect(result.confidence).toBeLessThanOrEqual(1);
     });
   });
+
+  describe('Google provider - with captions', () => {
+    it.each(assetsWithCaptions)('should detect burned-in captions with >80% confidence for asset %s', async (assetId) => {
+      const result = await hasBurnedInCaptions(assetId, {
+        provider: 'google',
+      });
+
+      // Assert that the result exists
+      expect(result).toBeDefined();
+      expect(result.hasBurnedInCaptions).toBe(true);
+
+      // Assert confidence is greater than 80%
+      expect(result.confidence).toBeGreaterThan(0.8);
+
+      // Verify result structure
+      expect(result).toHaveProperty('assetId');
+      expect(result).toHaveProperty('confidence');
+      expect(result).toHaveProperty('detectedLanguage');
+      expect(typeof result.confidence).toBe('number');
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('Google provider - without captions', () => {
+    it.each(assetsWithoutCaptions)('should NOT detect burned-in captions for asset %s', async (assetId) => {
+      const result = await hasBurnedInCaptions(assetId, {
+        provider: 'google',
+      });
+
+      // Assert that the result exists
+      expect(result).toBeDefined();
+      expect(result.hasBurnedInCaptions).toBe(false);
+
+      // Verify result structure
+      expect(result).toHaveProperty('assetId');
+      expect(result).toHaveProperty('confidence');
+      expect(result).toHaveProperty('detectedLanguage');
+      expect(typeof result.confidence).toBe('number');
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    });
+  });
 });

--- a/tests/integration/chapters.test.ts
+++ b/tests/integration/chapters.test.ts
@@ -53,4 +53,28 @@ describe('Chapters Integration Tests', () => {
       expect(typeof chapter.title).toBe('string');
     });
   });
+
+  it('should generate chapters with Google provider', async () => {
+    const result = await generateChapters(assetId, languageCode, {
+      provider: 'google',
+    });
+
+    // Assert that the result exists
+    expect(result).toBeDefined();
+
+    // Assert that chapters array exists
+    expect(result.chapters).toBeDefined();
+    expect(Array.isArray(result.chapters)).toBe(true);
+
+    // Assert that at least one chapter was generated
+    expect(result.chapters.length).toBeGreaterThan(0);
+
+    // Verify chapter structure
+    result.chapters.forEach((chapter) => {
+      expect(chapter).toHaveProperty('startTime');
+      expect(chapter).toHaveProperty('title');
+      expect(typeof chapter.startTime).toBe('number');
+      expect(typeof chapter.title).toBe('string');
+    });
+  });
 });

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -78,4 +78,41 @@ describe('Summarization Integration Tests', () => {
       expect(typeof tag).toBe('string');
     });
   });
+
+  it('should generate summary and tags with Google provider', async () => {
+    const result = await getSummaryAndTags(assetId, {
+      provider: 'google',
+      tone: 'normal',
+      includeTranscript: true,
+    });
+
+    // Assert that the result exists
+    expect(result).toBeDefined();
+
+    // Verify structure
+    expect(result).toHaveProperty('assetId');
+    expect(result).toHaveProperty('title');
+    expect(result).toHaveProperty('description');
+    expect(result).toHaveProperty('tags');
+
+    // Verify assetId matches
+    expect(result.assetId).toBe(assetId);
+
+    // Verify title
+    expect(typeof result.title).toBe('string');
+    expect(result.title.length).toBeGreaterThan(0);
+    expect(result.title.length).toBeLessThanOrEqual(100);
+
+    // Verify description
+    expect(typeof result.description).toBe('string');
+    expect(result.description.length).toBeGreaterThan(0);
+    expect(result.description.length).toBeLessThanOrEqual(1000);
+
+    // Verify tags
+    expect(Array.isArray(result.tags)).toBe(true);
+    expect(result.tags.length).toBeGreaterThan(0);
+    result.tags.forEach((tag) => {
+      expect(typeof tag).toBe('string');
+    });
+  });
 });

--- a/tests/integration/translate-captions.test.ts
+++ b/tests/integration/translate-captions.test.ts
@@ -45,4 +45,45 @@ describe('Captions Translation Integration Tests', () => {
     expect(result.uploadedTrackId).toBeUndefined();
     expect(result.presignedUrl).toBeUndefined();
   });
+
+  it('should translate captions from English to French with Google provider without uploading to Mux', async () => {
+    const result = await translateCaptions(assetId, 'en', 'fr', {
+      provider: 'google',
+      uploadToMux: false,
+    });
+
+    // Assert that the result exists
+    expect(result).toBeDefined();
+
+    // Verify structure
+    expect(result).toHaveProperty('assetId');
+    expect(result).toHaveProperty('sourceLanguageCode');
+    expect(result).toHaveProperty('targetLanguageCode');
+    expect(result).toHaveProperty('originalVtt');
+    expect(result).toHaveProperty('translatedVtt');
+
+    // Verify asset ID matches
+    expect(result.assetId).toBe(assetId);
+
+    // Verify language codes
+    expect(result.sourceLanguageCode).toBe('en');
+    expect(result.targetLanguageCode).toBe('fr');
+
+    // Verify original VTT exists and has content
+    expect(typeof result.originalVtt).toBe('string');
+    expect(result.originalVtt.length).toBeGreaterThan(0);
+    expect(result.originalVtt).toContain('WEBVTT');
+
+    // Verify translated VTT exists and has content
+    expect(typeof result.translatedVtt).toBe('string');
+    expect(result.translatedVtt.length).toBeGreaterThan(0);
+    expect(result.translatedVtt).toContain('WEBVTT');
+
+    // Verify the translation is different from the original
+    expect(result.translatedVtt).not.toBe(result.originalVtt);
+
+    // Since uploadToMux is false, these should not be present
+    expect(result.uploadedTrackId).toBeUndefined();
+    expect(result.presignedUrl).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Overview

Adds basic integration coverage for Google as an LLM provider within the existing provider abstraction.

## What’s Included

- Introduces Google as a first-class LLM provider option
- Wires Google models into the shared provider resolution layer
- Establishes baseline support for use across existing primitives and functions
- Lays groundwork for expanded Google-specific capabilities