### PR TITLE
chore: add translate captions evals

### DIFF
--- a/src/lib/language-codes.ts
+++ b/src/lib/language-codes.ts
@@ -1,0 +1,248 @@
+/**
+ * Language Code Conversion Utilities
+ *
+ * Provides bidirectional mapping between:
+ * - ISO 639-1 (2-letter codes) - Used by browsers, BCP-47, most video players
+ * - ISO 639-3 (3-letter codes) - Used by various APIs and language processing systems
+ *
+ * This is essential for interoperability between different systems:
+ * - Mux uses ISO 639-1 for track language codes
+ * - Browser players expect BCP-47 compliant codes (based on ISO 639-1)
+ * - Some APIs require ISO 639-3 (3-letter) codes
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Language Code Mapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mapping from ISO 639-1 (2-letter) to ISO 639-3 (3-letter) codes.
+ * Covers the most common languages used in video translation.
+ *
+ * Reference: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+ */
+const ISO639_1_TO_3 = {
+  // Major world languages
+  en: "eng", // English
+  es: "spa", // Spanish
+  fr: "fra", // French
+  de: "deu", // German
+  it: "ita", // Italian
+  pt: "por", // Portuguese
+  ru: "rus", // Russian
+  zh: "zho", // Chinese
+  ja: "jpn", // Japanese
+  ko: "kor", // Korean
+  ar: "ara", // Arabic
+  hi: "hin", // Hindi
+
+  // European languages
+  nl: "nld", // Dutch
+  pl: "pol", // Polish
+  sv: "swe", // Swedish
+  da: "dan", // Danish
+  no: "nor", // Norwegian
+  fi: "fin", // Finnish
+  el: "ell", // Greek
+  cs: "ces", // Czech
+  hu: "hun", // Hungarian
+  ro: "ron", // Romanian
+  bg: "bul", // Bulgarian
+  hr: "hrv", // Croatian
+  sk: "slk", // Slovak
+  sl: "slv", // Slovenian
+  uk: "ukr", // Ukrainian
+  tr: "tur", // Turkish
+
+  // Asian languages
+  th: "tha", // Thai
+  vi: "vie", // Vietnamese
+  id: "ind", // Indonesian
+  ms: "msa", // Malay
+  tl: "tgl", // Tagalog/Filipino
+
+  // Other languages
+  he: "heb", // Hebrew
+  fa: "fas", // Persian/Farsi
+  bn: "ben", // Bengali
+  ta: "tam", // Tamil
+  te: "tel", // Telugu
+  mr: "mar", // Marathi
+  gu: "guj", // Gujarati
+  kn: "kan", // Kannada
+  ml: "mal", // Malayalam
+  pa: "pan", // Punjabi
+  ur: "urd", // Urdu
+  sw: "swa", // Swahili
+  af: "afr", // Afrikaans
+  ca: "cat", // Catalan
+  eu: "eus", // Basque
+  gl: "glg", // Galician
+  is: "isl", // Icelandic
+  et: "est", // Estonian
+  lv: "lav", // Latvian
+  lt: "lit", // Lithuanian
+} as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Supported ISO 639-1 two-letter language codes.
+ * These are the language codes supported for translation workflows.
+ */
+export type SupportedISO639_1 = keyof typeof ISO639_1_TO_3;
+
+/**
+ * Supported ISO 639-3 three-letter language codes.
+ * These are the language codes supported for translation workflows.
+ */
+export type SupportedISO639_3 = (typeof ISO639_1_TO_3)[SupportedISO639_1];
+
+/** ISO 639-1 two-letter language code (e.g., "en", "fr", "es") */
+export type ISO639_1 = SupportedISO639_1 | (string & {});
+
+/** ISO 639-3 three-letter language code (e.g., "eng", "fra", "spa") */
+export type ISO639_3 = SupportedISO639_3 | (string & {});
+
+/** Structured language code result containing both formats */
+export interface LanguageCodePair {
+  /** ISO 639-1 two-letter code (BCP-47 compatible) */
+  iso639_1: ISO639_1;
+  /** ISO 639-3 three-letter code */
+  iso639_3: ISO639_3;
+}
+
+/**
+ * Reverse mapping from ISO 639-3 (3-letter) to ISO 639-1 (2-letter) codes.
+ * Generated from ISO639_1_TO_3 for consistency.
+ */
+const ISO639_3_TO_1 = Object.fromEntries(
+  Object.entries(ISO639_1_TO_3).map(([iso1, iso3]) => [iso3, iso1]),
+) as Record<SupportedISO639_3, SupportedISO639_1>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Conversion Functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Converts an ISO 639-1 (2-letter) code to ISO 639-3 (3-letter) code.
+ *
+ * @param code - ISO 639-1 two-letter language code (e.g., "en", "fr")
+ * @returns ISO 639-3 three-letter code, or the original if not found
+ *
+ * @example
+ * ```typescript
+ * toISO639_3("en") // "eng"
+ * toISO639_3("fr") // "fra"
+ * toISO639_3("ja") // "jpn"
+ * ```
+ */
+export function toISO639_3(code: string): ISO639_3 {
+  const normalized = code.toLowerCase().trim();
+
+  // If it's already a 3-letter code, return as-is
+  if (normalized.length === 3) {
+    return normalized;
+  }
+
+  return (ISO639_1_TO_3 as Record<string, string>)[normalized] ?? normalized;
+}
+
+/**
+ * Converts an ISO 639-3 (3-letter) code to ISO 639-1 (2-letter) code.
+ *
+ * @param code - ISO 639-3 three-letter language code (e.g., "eng", "fra")
+ * @returns ISO 639-1 two-letter code, or the original if not found
+ *
+ * @example
+ * ```typescript
+ * toISO639_1("eng") // "en"
+ * toISO639_1("fra") // "fr"
+ * toISO639_1("jpn") // "ja"
+ * ```
+ */
+export function toISO639_1(code: string): ISO639_1 {
+  const normalized = code.toLowerCase().trim();
+
+  // If it's already a 2-letter code, return as-is
+  if (normalized.length === 2) {
+    return normalized;
+  }
+
+  return (ISO639_3_TO_1 as Record<string, string>)[normalized] ?? normalized;
+}
+
+/**
+ * Returns both ISO 639-1 and ISO 639-3 codes for a given language code.
+ * Accepts either format as input and normalizes to both.
+ *
+ * @param code - Language code in either ISO 639-1 or ISO 639-3 format
+ * @returns Object containing both code formats
+ *
+ * @example
+ * ```typescript
+ * getLanguageCodePair("en")  // { iso639_1: "en", iso639_3: "eng" }
+ * getLanguageCodePair("fra") // { iso639_1: "fr", iso639_3: "fra" }
+ * ```
+ */
+export function getLanguageCodePair(code: string): LanguageCodePair {
+  const normalized = code.toLowerCase().trim();
+
+  if (normalized.length === 2) {
+    // Input is ISO 639-1
+    return {
+      iso639_1: normalized,
+      iso639_3: toISO639_3(normalized),
+    };
+  } else if (normalized.length === 3) {
+    // Input is ISO 639-3
+    return {
+      iso639_1: toISO639_1(normalized),
+      iso639_3: normalized,
+    };
+  }
+
+  // Unknown format, return as-is for both
+  return {
+    iso639_1: normalized,
+    iso639_3: normalized,
+  };
+}
+
+/**
+ * Validates if a code is a known ISO 639-1 code.
+ *
+ * @param code - Code to validate
+ * @returns true if the code is a known ISO 639-1 code
+ */
+export function isValidISO639_1(code: string): boolean {
+  return code.length === 2 && code.toLowerCase() in ISO639_1_TO_3;
+}
+
+/**
+ * Validates if a code is a known ISO 639-3 code.
+ *
+ * @param code - Code to validate
+ * @returns true if the code is a known ISO 639-3 code
+ */
+export function isValidISO639_3(code: string): boolean {
+  return code.length === 3 && code.toLowerCase() in ISO639_3_TO_1;
+}
+
+/**
+ * Gets the human-readable language name for a given code.
+ *
+ * @param code - Language code in either ISO 639-1 or ISO 639-3 format
+ * @returns Human-readable language name (e.g., "English", "French")
+ */
+export function getLanguageName(code: string): string {
+  const iso639_1 = toISO639_1(code);
+  try {
+    const displayNames = new Intl.DisplayNames(["en"], { type: "language" });
+    return displayNames.of(iso639_1) ?? code.toUpperCase();
+  } catch {
+    return code.toUpperCase();
+  }
+}

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -41,8 +41,8 @@ export interface ResolvedModel<P extends SupportedProvider = SupportedProvider> 
 }
 
 export const DEFAULT_LANGUAGE_MODELS: { [K in SupportedProvider]: ModelIdByProvider[K] } = {
-  openai: "gpt-5-mini",
-  anthropic: "claude-haiku-4-5",
+  openai: "gpt-5.1",
+  anthropic: "claude-sonnet-4-5",
   google: "gemini-2.5-flash",
 };
 
@@ -87,21 +87,21 @@ export interface ModelPricing {
  * Prices are subject to change. Verify against official sources before production use.
  */
 export const THIRD_PARTY_MODEL_PRICING: { [K in SupportedProvider]: ModelPricing } = {
-  // OpenAI GPT-5 Mini
+  // OpenAI GPT-5.1
   // Reference: https://openai.com/api/pricing
   openai: {
-    inputPerMillion: 0.25,
-    outputPerMillion: 2.00,
-    cachedInputPerMillion: 0.025,
+    inputPerMillion: 1.25,
+    outputPerMillion: 10.00,
+    cachedInputPerMillion: 0.125,
     pricingUrl: "https://openai.com/api/pricing",
   },
 
-  // Anthropic Claude Haiku 4.5
+  // Anthropic Claude Sonnet 4.5
   // Reference: https://www.anthropic.com/pricing
   anthropic: {
-    inputPerMillion: 1.00,
-    outputPerMillion: 5.00,
-    cachedInputPerMillion: 0.10, // Prompt caching read cost
+    inputPerMillion: 3.00,
+    outputPerMillion: 15.00,
+    cachedInputPerMillion: 0.30, // Prompt caching read cost (≤200K tokens)
     pricingUrl: "https://www.anthropic.com/pricing",
   },
 

--- a/tests/eval/summarization.eval.ts
+++ b/tests/eval/summarization.eval.ts
@@ -64,13 +64,13 @@ import "../../src/env";
  *
  * 1. LATENCY
  *    - Wall clock time from request to response
- *    - Target: <5s for good UX, <15s for acceptable UX
- *    - Benchmark: Anthropic ~4s, Google ~10s, OpenAI ~14s
+ *    - Target: <8s for good UX, <20s for acceptable UX
+ *    - Benchmark: OpenAI ~5-12s, Anthropic ~8s, Google ~9-11s
  *
  * 2. TOKEN EFFICIENCY
  *    - Total tokens consumed per summarization
  *    - Target: <4000 tokens for efficient operation
- *    - Benchmark: Google ~2300, Anthropic ~3400, OpenAI ~3700
+ *    - Benchmark: OpenAI ~1700, Google ~2200, Anthropic ~3500
  *
  * ─────────────────────────────────────────────────────────────────────────────
  * EXPENSE GOALS — "How much does it cost?"
@@ -85,7 +85,7 @@ import "../../src/env";
  *    - Calculate estimated USD cost per request using THIRD_PARTY_MODEL_PRICING
  *    - Compare costs across providers for budget optimization
  *    - Target: <$0.005 per request for cost-effective operation
- *    - Benchmark: Google ~$0.0008, OpenAI ~$0.002, Anthropic ~$0.004
+ *    - Benchmark: Google ~$0.0008, OpenAI ~$0.002, Anthropic ~$0.013
  *
  * Model Pricing Sources (verify periodically):
  *    - OpenAI: https://openai.com/api/pricing
@@ -116,14 +116,15 @@ const DESCRIPTION_MAX_LENGTH = 1000;
 
 /**
  * Maximum acceptable latency in milliseconds for "good" performance.
+ * Benchmark: OpenAI ~5-12s, Anthropic ~8s
  */
-const LATENCY_THRESHOLD_GOOD_MS = 5000;
+const LATENCY_THRESHOLD_GOOD_MS = 8000;
 
 /**
  * Maximum acceptable latency in milliseconds for "acceptable" performance.
- * Benchmark: All providers under 15s
+ * Benchmark: All providers under 12s
  */
-const LATENCY_THRESHOLD_ACCEPTABLE_MS = 15000;
+const LATENCY_THRESHOLD_ACCEPTABLE_MS = 20000;
 
 /**
  * Maximum total tokens considered efficient for this task.
@@ -132,9 +133,9 @@ const TOKEN_THRESHOLD_EFFICIENT = 4000;
 
 /**
  * Maximum cost per request considered acceptable (USD).
- * Benchmark: Google ~$0.0008, OpenAI ~$0.002, Anthropic ~$0.004
+ * Benchmark: Google ~$0.0008, OpenAI ~$0.002, Anthropic ~$0.013
  */
-const COST_THRESHOLD_USD = 0.005;
+const COST_THRESHOLD_USD = 0.015;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -467,7 +468,7 @@ evalite("Summarization", {
     // LATENCY: Wall clock time performance
     {
       name: "latency-performance",
-      description: `Scores latency: 1.0 for <${LATENCY_THRESHOLD_GOOD_MS}ms, scaled down to 0 for >${LATENCY_THRESHOLD_ACCEPTABLE_MS}ms.`,
+      description: `Scores latency: 1.0 for <8000ms, scaled down to 0 for >20000ms.`,
       scorer: ({ output }: { output: EvalOutput }) => {
         const { latencyMs } = output;
         if (latencyMs <= LATENCY_THRESHOLD_GOOD_MS) {
@@ -517,7 +518,7 @@ evalite("Summarization", {
     // COST ANALYSIS: Estimated cost per request
     {
       name: "cost-within-budget",
-      description: `Scores cost efficiency: 1.0 for <$${COST_THRESHOLD_USD}, scaled down for higher costs.`,
+      description: `Scores cost efficiency: 1.0 for <$0.015, scaled down for higher costs.`,
       scorer: ({ output }: { output: EvalOutput }) => {
         const { estimatedCostUsd } = output;
         if (estimatedCostUsd <= COST_THRESHOLD_USD) {

--- a/tests/eval/summarization.eval.ts
+++ b/tests/eval/summarization.eval.ts
@@ -1,0 +1,545 @@
+import { openai } from "@ai-sdk/openai";
+import dedent from "dedent";
+import { evalite } from "evalite";
+import { answerSimilarity } from "evalite/scorers";
+import { reportTrace } from "evalite/traces";
+
+import { calculateCost, DEFAULT_LANGUAGE_MODELS } from "../../src/lib/providers";
+import type { ModelIdByProvider, SupportedProvider } from "../../src/lib/providers";
+import type { TokenUsage } from "../../src/types";
+import { getSummaryAndTags, SUMMARY_KEYWORD_LIMIT } from "../../src/workflows";
+import type { SummaryAndTagsResult } from "../../src/workflows";
+
+import "../../src/env";
+
+/**
+ * Summarization Evaluation
+ *
+ * This eval measures the efficacy, efficiency, and expense of the `getSummaryAndTags`
+ * function across multiple AI providers (OpenAI, Anthropic, Google) to ensure consistent,
+ * high-quality, fast, and cost-effective video metadata generation.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * EFFICACY GOALS — "Does it produce quality output?"
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * 1. TITLE QUALITY
+ *    - Non-empty, compelling headline
+ *    - Reasonable length (typically under 10 words / 100 chars)
+ *    - Does NOT start with "A video of" or similar phrasing
+ *    - Uses active, specific language
+ *
+ * 2. DESCRIPTION QUALITY
+ *    - Non-empty, meaningful summary
+ *    - Reasonable length (2-4 sentences, up to 1000 chars)
+ *    - Describes observable content
+ *
+ * 3. TAGS QUALITY
+ *    - Non-empty array of keywords
+ *    - Up to 10 tags (respects SUMMARY_KEYWORD_LIMIT)
+ *    - No duplicates (case-insensitive)
+ *    - Lowercase format (per prompt requirements)
+ *    - Concrete nouns and action verbs over abstract concepts
+ *
+ * 4. RESPONSE INTEGRITY
+ *    - All required fields populated correctly
+ *    - Types match expected schema
+ *    - Storyboard URL properly generated
+ *
+ * 5. NO FILLER PHRASES
+ *    - Description should NOT contain "the image shows", "the video shows", etc.
+ *    - Content should be described directly without meta-references to the medium
+ *
+ * 6. TITLE SIMILARITY (embeddings)
+ *    - Compares generated title to reference title using cosine similarity
+ *    - Allows flexible phrasing - good when multiple wordings are valid
+ *
+ * 7. DESCRIPTION SIMILARITY (embeddings)
+ *    - Compares generated description to reference using cosine similarity
+ *    - Allows flexible phrasing - good when multiple wordings are valid
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * EFFICIENCY GOALS — "How fast and scalable is it?"
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * 1. LATENCY
+ *    - Wall clock time from request to response
+ *    - Target: <5s for good UX, <15s for acceptable UX
+ *    - Benchmark: Anthropic ~4s, Google ~10s, OpenAI ~14s
+ *
+ * 2. TOKEN EFFICIENCY
+ *    - Total tokens consumed per summarization
+ *    - Target: <4000 tokens for efficient operation
+ *    - Benchmark: Google ~2300, Anthropic ~3400, OpenAI ~3700
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * EXPENSE GOALS — "How much does it cost?"
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * 1. TOKEN CONSUMPTION
+ *    - Track inputTokens, outputTokens, totalTokens per request
+ *    - Compare token usage across providers
+ *    - Identify opportunities for prompt optimization
+ *
+ * 2. COST ESTIMATION
+ *    - Calculate estimated USD cost per request using THIRD_PARTY_MODEL_PRICING
+ *    - Compare costs across providers for budget optimization
+ *    - Target: <$0.005 per request for cost-effective operation
+ *    - Benchmark: Google ~$0.0008, OpenAI ~$0.002, Anthropic ~$0.004
+ *
+ * Model Pricing Sources (verify periodically):
+ *    - OpenAI: https://openai.com/api/pricing
+ *    - Anthropic: https://www.anthropic.com/pricing
+ *    - Google: https://ai.google.dev/pricing
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * TEST ASSETS
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * A variety of video content types to test metadata generation quality:
+ * - Different durations and content types
+ * - Videos with and without dialogue/narration
+ * - Various visual styles and subjects
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Thresholds
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Maximum acceptable title length in characters. */
+const TITLE_MAX_LENGTH = 100;
+
+/** Maximum acceptable description length in characters. */
+const DESCRIPTION_MAX_LENGTH = 1000;
+
+/**
+ * Maximum acceptable latency in milliseconds for "good" performance.
+ */
+const LATENCY_THRESHOLD_GOOD_MS = 5000;
+
+/**
+ * Maximum acceptable latency in milliseconds for "acceptable" performance.
+ * Benchmark: All providers under 15s
+ */
+const LATENCY_THRESHOLD_ACCEPTABLE_MS = 15000;
+
+/**
+ * Maximum total tokens considered efficient for this task.
+ */
+const TOKEN_THRESHOLD_EFFICIENT = 4000;
+
+/**
+ * Maximum cost per request considered acceptable (USD).
+ * Benchmark: Google ~$0.0008, OpenAI ~$0.002, Anthropic ~$0.004
+ */
+const COST_THRESHOLD_USD = 0.005;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Extended output including provider/model metadata and performance metrics. */
+interface EvalOutput extends SummaryAndTagsResult {
+  provider: SupportedProvider;
+  model: ModelIdByProvider[SupportedProvider];
+  /** Wall clock latency in milliseconds. */
+  latencyMs: number;
+  /** Token usage from the AI provider. */
+  usage: TokenUsage;
+  /** Estimated cost in USD based on token usage and provider pricing. */
+  estimatedCostUsd: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test Assets
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Video assets for summarization testing with reference answers for similarity evaluation.
+ * Selected to represent different content types and complexities.
+ */
+interface TestAsset {
+  assetId: string;
+  /** Reference title for answerCorrectness evaluation */
+  referenceTitle: string;
+  /** Reference description for answerCorrectness evaluation */
+  referenceDescription: string;
+}
+
+const testAssets: TestAsset[] = [
+  {
+    // Mux thumbnail and GIF demo video
+    assetId: "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk",
+    referenceTitle: "Mux API thumbnail and GIF demo",
+    referenceDescription: dedent`
+      A presenter demonstrates how to use the Mux API to grab thumbnails and GIFs from video.
+      The demonstration shows using query parameters and a simple GET request to create stills and animated GIFs.
+      The presenter sits at a desk with headphones, gestures while explaining the features, and gives a thumbs-up.
+      The video promotes Mux's video capabilities with the tagline 'video is fun with Mux'.`,
+  },
+];
+
+/** AI providers to test for cross-provider consistency. */
+const providers: SupportedProvider[] = [
+  "openai",
+  "anthropic",
+  "google",
+];
+
+const data = providers.flatMap(provider =>
+  testAssets.map(asset => ({
+    input: { assetId: asset.assetId, provider },
+    expected: {
+      referenceTitle: asset.referenceTitle,
+      referenceDescription: asset.referenceDescription,
+    },
+  })),
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+evalite("Summarization", {
+  data,
+  task: async ({ assetId, provider }): Promise<EvalOutput> => {
+    const startTime = performance.now();
+    const result = await getSummaryAndTags(assetId, {
+      provider,
+      includeTranscript: true,
+    });
+    const latencyMs = performance.now() - startTime;
+
+    const usage = result.usage ?? {};
+    const estimatedCostUsd = calculateCost(
+      provider,
+      usage.inputTokens ?? 0,
+      usage.outputTokens ?? 0,
+      usage.cachedInputTokens ?? 0,
+    );
+
+    reportTrace({
+      input: { assetId, provider },
+      output: result,
+      usage: {
+        inputTokens: usage.inputTokens ?? 0,
+        outputTokens: usage.outputTokens ?? 0,
+        totalTokens: usage.totalTokens ?? 0,
+      },
+      start: startTime,
+      end: startTime + latencyMs,
+    });
+
+    return {
+      ...result,
+      provider,
+      model: DEFAULT_LANGUAGE_MODELS[provider],
+      latencyMs,
+      usage,
+      estimatedCostUsd,
+    };
+  },
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Scorers
+  // ───────────────────────────────────────────────────────────────────────────
+  //
+  // Each scorer returns a value between 0 and 1. The eval framework aggregates
+  // these scores across all test cases and providers.
+  //
+  // EFFICACY METRICS (content quality):
+  // - Title Quality: Is the title well-formed and compelling?
+  // - Title Similarity: Is title semantically similar to reference? (embeddings)
+  // - Description Quality: Is the description informative?
+  // - Tags Quality: Are tags relevant, unique, and properly formatted?
+  // - Response Integrity: Are all fields valid and properly formatted?
+  // - No Filler Phrases: Does description avoid "the image shows" etc.?
+  // - Description Similarity: Is description semantically similar to reference? (embeddings)
+  //
+  // EFFICIENCY METRICS (continuous 0-1 scale):
+  // - Latency: How fast is the response? (normalized against thresholds)
+  // - Token Efficiency: How many tokens consumed? (normalized against threshold)
+  //
+  // EXPENSE METRICS (raw values for cost analysis):
+  // - Token usage breakdown for cost estimation
+  // ───────────────────────────────────────────────────────────────────────────
+
+  scorers: [
+    // ─────────────────────────────────────────────────────────────────────────
+    // EFFICACY SCORERS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // TITLE QUALITY: Non-empty, reasonable length, doesn't start with filler phrases
+    {
+      name: "title-quality",
+      description: "Validates title is non-empty, under 100 chars, and doesn't start with 'A video of'.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { title } = output;
+
+        // Must be non-empty
+        if (!title || title.trim().length === 0) {
+          return 0;
+        }
+
+        // Must be reasonable length
+        if (title.length > TITLE_MAX_LENGTH) {
+          return 0.5;
+        }
+
+        // Should NOT start with filler phrases
+        const fillerPhrases = [
+          "a video of",
+          "this video shows",
+          "the video shows",
+          "video of",
+          "this is a video",
+        ];
+        const lowerTitle = title.toLowerCase().trim();
+        if (fillerPhrases.some(phrase => lowerTitle.startsWith(phrase))) {
+          return 0.5;
+        }
+
+        return 1;
+      },
+    },
+
+    // TITLE SIMILARITY: Compare title against reference using semantic similarity
+    {
+      name: "title-similarity",
+      description: "Evaluates title similarity to reference using embeddings (allows flexible phrasing).",
+      scorer: async ({ output, expected }: { output: EvalOutput; expected: { referenceTitle: string } }) => {
+        const result = await answerSimilarity({
+          answer: output.title,
+          reference: expected.referenceTitle,
+          embeddingModel: openai.embedding("text-embedding-3-small"),
+        });
+
+        return {
+          score: result.score,
+        };
+      },
+    },
+
+    // DESCRIPTION QUALITY: Non-empty, reasonable length
+    {
+      name: "description-quality",
+      description: "Validates description is non-empty and under 1000 chars.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { description } = output;
+
+        // Must be non-empty
+        if (!description || description.trim().length === 0) {
+          return 0;
+        }
+
+        // Must be reasonable length
+        if (description.length > DESCRIPTION_MAX_LENGTH) {
+          return 0.5;
+        }
+
+        return 1;
+      },
+    },
+
+    // TAGS QUALITY: Array with valid items, no duplicates, respects limit
+    {
+      name: "tags-quality",
+      description: `Validates tags are an array of unique strings, up to ${SUMMARY_KEYWORD_LIMIT} items.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { tags } = output;
+
+        // Must be an array
+        if (!Array.isArray(tags)) {
+          return 0;
+        }
+
+        // Must have at least one tag
+        if (tags.length === 0) {
+          return 0;
+        }
+
+        // Must not exceed limit
+        if (tags.length > SUMMARY_KEYWORD_LIMIT) {
+          return 0.5;
+        }
+
+        // Check for duplicates (case-insensitive)
+        const lowerTags = tags.map(t => (typeof t === "string" ? t.toLowerCase() : ""));
+        const uniqueTags = new Set(lowerTags);
+        if (uniqueTags.size !== tags.length) {
+          return 0.5;
+        }
+
+        // All items must be non-empty strings
+        const allValid = tags.every(tag => typeof tag === "string" && tag.trim().length > 0);
+        if (!allValid) {
+          return 0.5;
+        }
+
+        return 1;
+      },
+    },
+
+    // RESPONSE INTEGRITY: Schema and shape validation
+    {
+      name: "response-integrity",
+      description: "Validates all required fields are present and properly typed.",
+      scorer: ({ output, input }: { output: EvalOutput; input: { assetId: string } }) => {
+        const assetIdValid = output.assetId === input.assetId;
+        const titleValid = typeof output.title === "string" && output.title.length > 0;
+        const descriptionValid = typeof output.description === "string" && output.description.length > 0;
+        const tagsValid = Array.isArray(output.tags);
+        const storyboardValid = typeof output.storyboardUrl === "string" && output.storyboardUrl.startsWith("https://");
+
+        return assetIdValid && titleValid && descriptionValid && tagsValid && storyboardValid ? 1 : 0;
+      },
+    },
+
+    // NO FILLER PHRASES: Description should describe content directly without meta-references
+    {
+      name: "no-filler-phrases",
+      description: "Validates description doesn't use meta-descriptive phrases like 'the image shows' or 'the video shows'.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { description, title } = output;
+
+        // Filler phrases that reference the medium rather than describe content directly
+        const fillerPhrases = [
+          "the image shows",
+          "the storyboard shows",
+          "the video shows",
+          "this video shows",
+          "in this video",
+          "this video features",
+          "the frames depict",
+          "the footage shows",
+          "we can see",
+          "you can see",
+          "the clip shows",
+          "the scene shows",
+          "the image depicts",
+          "the video depicts",
+        ];
+
+        const lowerDescription = description.toLowerCase();
+        const lowerTitle = title.toLowerCase();
+        const matchedPhrases: string[] = [];
+
+        for (const phrase of fillerPhrases) {
+          if (lowerDescription.includes(phrase) || lowerTitle.includes(phrase)) {
+            matchedPhrases.push(phrase);
+          }
+        }
+
+        if (matchedPhrases.length > 0) {
+          return {
+            score: 0,
+            metadata: { matchedPhrases, message: "Found meta-descriptive filler phrases" },
+          };
+        }
+
+        return 1;
+      },
+    },
+
+    // DESCRIPTION SIMILARITY: Compare description against reference using semantic similarity
+    {
+      name: "description-similarity",
+      description: "Evaluates description similarity to reference using embeddings (allows flexible phrasing).",
+      scorer: async ({ output, expected }: { output: EvalOutput; expected: { referenceDescription: string } }) => {
+        const result = await answerSimilarity({
+          answer: output.description,
+          reference: expected.referenceDescription,
+          embeddingModel: openai.embedding("text-embedding-3-small"),
+        });
+
+        return {
+          score: result.score,
+        };
+      },
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // EFFICIENCY SCORERS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // LATENCY: Wall clock time performance
+    {
+      name: "latency-performance",
+      description: `Scores latency: 1.0 for <${LATENCY_THRESHOLD_GOOD_MS}ms, scaled down to 0 for >${LATENCY_THRESHOLD_ACCEPTABLE_MS}ms.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { latencyMs } = output;
+        if (latencyMs <= LATENCY_THRESHOLD_GOOD_MS) {
+          return 1;
+        }
+        if (latencyMs >= LATENCY_THRESHOLD_ACCEPTABLE_MS) {
+          return Math.max(0, 1 - (latencyMs - LATENCY_THRESHOLD_ACCEPTABLE_MS) / LATENCY_THRESHOLD_ACCEPTABLE_MS);
+        }
+        // Linear interpolation between good and acceptable
+        return 1 - 0.5 * ((latencyMs - LATENCY_THRESHOLD_GOOD_MS) / (LATENCY_THRESHOLD_ACCEPTABLE_MS - LATENCY_THRESHOLD_GOOD_MS));
+      },
+    },
+
+    // TOKEN EFFICIENCY: Total token consumption
+    {
+      name: "token-efficiency",
+      description: `Scores token usage: 1.0 for <${TOKEN_THRESHOLD_EFFICIENT} tokens, scaled down for higher usage.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const totalTokens = output.usage?.totalTokens ?? 0;
+        if (totalTokens === 0) {
+          return 0; // No usage data is a problem
+        }
+        if (totalTokens <= TOKEN_THRESHOLD_EFFICIENT) {
+          return 1;
+        }
+        // Gradual decline for over-threshold usage
+        return Math.max(0, 1 - (totalTokens - TOKEN_THRESHOLD_EFFICIENT) / TOKEN_THRESHOLD_EFFICIENT);
+      },
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // EXPENSE SCORERS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // USAGE DATA PRESENCE: Validates that usage metrics are available
+    {
+      name: "usage-data-present",
+      description: "Ensures token usage data is returned for cost analysis.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const hasUsage = output.usage &&
+          typeof output.usage.totalTokens === "number" &&
+          output.usage.totalTokens > 0;
+        return hasUsage ? 1 : 0;
+      },
+    },
+
+    // COST ANALYSIS: Estimated cost per request
+    {
+      name: "cost-within-budget",
+      description: `Scores cost efficiency: 1.0 for <$${COST_THRESHOLD_USD}, scaled down for higher costs.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { estimatedCostUsd } = output;
+        if (estimatedCostUsd <= COST_THRESHOLD_USD) {
+          return 1;
+        }
+        // Gradual decline for over-budget costs
+        return Math.max(0, 1 - (estimatedCostUsd - COST_THRESHOLD_USD) / COST_THRESHOLD_USD);
+      },
+    },
+  ],
+
+  columns: async ({ input, output }: { input: { assetId: string }; output: EvalOutput }) => {
+    return [
+      { label: "Asset ID", value: input.assetId },
+      { label: "Provider", value: output.provider },
+      { label: "Model", value: output.model },
+      { label: "Title", value: output.title },
+      { label: "Description", value: output.description },
+      { label: "Tags Count", value: output.tags.length },
+      { label: "Latency", value: `${Math.round(output.latencyMs)}ms` },
+      { label: "Tokens", value: output.usage?.totalTokens ?? 0 },
+      { label: "Cost", value: `$${output.estimatedCostUsd.toFixed(6)}` },
+    ];
+  },
+});

--- a/tests/eval/translate-captions.eval.ts
+++ b/tests/eval/translate-captions.eval.ts
@@ -1,0 +1,676 @@
+import { openai } from "@ai-sdk/openai";
+import { evalite } from "evalite";
+import { faithfulness } from "evalite/scorers";
+import { reportTrace } from "evalite/traces";
+
+import { isValidISO639_1, isValidISO639_3, toISO639_1, toISO639_3 } from "../../src/lib/language-codes";
+import { calculateCost, DEFAULT_LANGUAGE_MODELS } from "../../src/lib/providers";
+import type { ModelIdByProvider, SupportedProvider } from "../../src/lib/providers";
+import type { TokenUsage } from "../../src/types";
+import { translateCaptions } from "../../src/workflows";
+import type { TranslationResult } from "../../src/workflows";
+
+import "../../src/env";
+
+/**
+ * Caption Translation Evaluation
+ *
+ * This eval measures the efficacy, efficiency, and expense of the `translateCaptions`
+ * function across multiple AI providers (OpenAI, Anthropic, Google) to ensure consistent,
+ * high-quality, fast, and cost-effective VTT subtitle translation.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * EFFICACY GOALS — "Does it produce quality output?"
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * 1. VTT FORMAT PRESERVATION
+ *    - Output must start with "WEBVTT"
+ *    - Timestamps must be preserved in correct format (HH:MM:SS.mmm --> HH:MM:SS.mmm)
+ *    - Cue structure must be maintained
+ *
+ * 2. TRANSLATION COMPLETENESS
+ *    - All cues from original VTT must be present in translation
+ *    - No missing or dropped content
+ *
+ * 3. TRANSLATION FAITHFULNESS
+ *    - Translated text should faithfully represent the original content
+ *    - No hallucinations or invented content
+ *    - Semantic meaning must be preserved across languages
+ *
+ * 4. RESPONSE INTEGRITY
+ *    - All required fields populated correctly
+ *    - Language codes match request (ISO 639-1 and ISO 639-3)
+ *    - Asset ID preserved
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * EFFICIENCY GOALS — "How fast and scalable is it?"
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * 1. LATENCY
+ *    - Wall clock time from request to response
+ *    - Target: <8s for good UX, <15s for acceptable UX
+ *    - Benchmark: OpenAI ~5-6s, Google ~5-7s, Anthropic ~8-10s
+ *
+ * 2. TOKEN EFFICIENCY
+ *    - Total tokens consumed per translation
+ *    - Target: <2500 tokens for efficient operation
+ *    - Benchmark: OpenAI ~850-900, Anthropic ~1600, Google ~1700-2100
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * EXPENSE GOALS — "How much does it cost?"
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * 1. TOKEN CONSUMPTION
+ *    - Track inputTokens, outputTokens, totalTokens per request
+ *    - Compare token usage across providers
+ *
+ * 2. COST ESTIMATION
+ *    - Calculate estimated USD cost per request
+ *    - Target: <$0.012 per request for cost-effective operation
+ *    - Benchmark: Google ~$0.002, OpenAI ~$0.005, Anthropic ~$0.011
+ *
+ * Model Pricing Sources (verify periodically):
+ *    - OpenAI: https://openai.com/api/pricing
+ *    - Anthropic: https://www.anthropic.com/pricing
+ *    - Google: https://ai.google.dev/pricing
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * TEST ASSETS
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Assets with existing English captions translated to Spanish, French, and Japanese.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Thresholds
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Maximum acceptable latency in milliseconds for "good" performance.
+ * Benchmark: OpenAI ~5-6s, Google ~5-7s, Anthropic ~8-10s
+ */
+const LATENCY_THRESHOLD_GOOD_MS = 8000;
+
+/**
+ * Maximum acceptable latency in milliseconds for "acceptable" performance.
+ * All providers consistently under 10s for short VTT files.
+ */
+const LATENCY_THRESHOLD_ACCEPTABLE_MS = 15000;
+
+/**
+ * Maximum total tokens considered efficient for this task.
+ * Benchmark: OpenAI ~850-900, Anthropic ~1600, Google ~1700-2100
+ */
+const TOKEN_THRESHOLD_EFFICIENT = 2500;
+
+/**
+ * Maximum cost per request considered acceptable (USD).
+ * Benchmark: Google ~$0.002, OpenAI ~$0.005, Anthropic ~$0.011
+ */
+const COST_THRESHOLD_USD = 0.012;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Source Transcript
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Original English transcript for the test asset.
+ * Used as ground truth for faithfulness evaluation.
+ */
+const ORIGINAL_TRANSCRIPT = `Ouch! Dang thumbs. You know, there is an easier way to get thumbnails. Quickly grab a still from anywhere in your video with the Mux API. All it takes is some query params. Thumbnail. What about GIFs? What? Not you, Jeff. GIFs. I thought it was GIFs. GIFs, GIFS, it's all the same to Mux with a simple get request. Because video is fun with Mux.`;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Extended output including provider/model metadata and performance metrics. */
+interface EvalOutput extends TranslationResult {
+  provider: SupportedProvider;
+  model: ModelIdByProvider[SupportedProvider];
+  /** Wall clock latency in milliseconds. */
+  latencyMs: number;
+  /** Token usage from the AI provider. */
+  usage: TokenUsage;
+  /** Estimated cost in USD based on token usage and provider pricing. */
+  estimatedCostUsd: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test Assets
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Video assets for translation testing.
+ */
+interface TestAsset {
+  assetId: string;
+  /** ISO 639-1 (2-letter) source language code */
+  sourceLanguage: string;
+  /** ISO 639-1 (2-letter) target language code */
+  targetLanguage: string;
+  /** Expected ISO 639-3 (3-letter) source language code */
+  expectedSourceISO639_3: string;
+  /** Expected ISO 639-3 (3-letter) target language code */
+  expectedTargetISO639_3: string;
+  /** Human-readable target language name for display */
+  targetLanguageName: string;
+}
+
+const testAssets: TestAsset[] = [
+  // Spanish translation
+  {
+    assetId: "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk",
+    sourceLanguage: "en",
+    targetLanguage: "es",
+    expectedSourceISO639_3: "eng",
+    expectedTargetISO639_3: "spa",
+    targetLanguageName: "Spanish",
+  },
+  // French translation
+  {
+    assetId: "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk",
+    sourceLanguage: "en",
+    targetLanguage: "fr",
+    expectedSourceISO639_3: "eng",
+    expectedTargetISO639_3: "fra",
+    targetLanguageName: "French",
+  },
+  // Japanese translation
+  {
+    assetId: "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk",
+    sourceLanguage: "en",
+    targetLanguage: "ja",
+    expectedSourceISO639_3: "eng",
+    expectedTargetISO639_3: "jpn",
+    targetLanguageName: "Japanese",
+  },
+];
+
+/** AI providers to test for cross-provider consistency. */
+const providers: SupportedProvider[] = [
+  "openai",
+  "anthropic",
+  "google",
+];
+
+const data = providers.flatMap(provider =>
+  testAssets.map(asset => ({
+    input: {
+      assetId: asset.assetId,
+      provider,
+      sourceLanguage: asset.sourceLanguage,
+      targetLanguage: asset.targetLanguage,
+      targetLanguageName: asset.targetLanguageName,
+    },
+    expected: {
+      sourceLanguage: asset.sourceLanguage,
+      targetLanguage: asset.targetLanguage,
+      expectedSourceISO639_3: asset.expectedSourceISO639_3,
+      expectedTargetISO639_3: asset.expectedTargetISO639_3,
+    },
+  })),
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Regex to match VTT timestamp lines (e.g., "00:00:00.000 --> 00:00:05.000") */
+const VTT_TIMESTAMP_REGEX = /\d{2}:\d{2}:\d{2}\.\d{3}\s*-->\s*\d{2}:\d{2}:\d{2}\.\d{3}/g;
+
+/**
+ * Count the number of cues in a VTT file by counting timestamp lines.
+ */
+function countVttCues(vttContent: string): number {
+  const matches = vttContent.match(VTT_TIMESTAMP_REGEX);
+  return matches?.length ?? 0;
+}
+
+/**
+ * Extract text content from VTT (excluding headers, timestamps, and cue identifiers).
+ */
+function extractVttTextContent(vttContent: string): string {
+  const lines = vttContent.split("\n");
+  const textLines: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    // Skip WEBVTT header, empty lines, timestamps, and numeric cue identifiers
+    if (
+      trimmed === "" ||
+      trimmed.startsWith("WEBVTT") ||
+      trimmed.startsWith("NOTE") ||
+      VTT_TIMESTAMP_REGEX.test(trimmed) ||
+      /^\d+$/.test(trimmed)
+    ) {
+      continue;
+    }
+    textLines.push(trimmed);
+  }
+
+  return textLines.join(" ");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+evalite("Caption Translation", {
+  data,
+  task: async ({ assetId, provider, sourceLanguage, targetLanguage }): Promise<EvalOutput> => {
+    const startTime = performance.now();
+    const result = await translateCaptions(assetId, sourceLanguage, targetLanguage, {
+      provider,
+      uploadToMux: false, // Don't upload during evals
+    });
+    const latencyMs = performance.now() - startTime;
+
+    const usage = result.usage ?? {};
+    const estimatedCostUsd = calculateCost(
+      provider,
+      usage.inputTokens ?? 0,
+      usage.outputTokens ?? 0,
+      usage.cachedInputTokens ?? 0,
+    );
+
+    reportTrace({
+      input: { assetId, provider, sourceLanguage, targetLanguage },
+      output: result,
+      usage: {
+        inputTokens: usage.inputTokens ?? 0,
+        outputTokens: usage.outputTokens ?? 0,
+        totalTokens: usage.totalTokens ?? 0,
+      },
+      start: startTime,
+      end: startTime + latencyMs,
+    });
+
+    return {
+      ...result,
+      provider,
+      model: DEFAULT_LANGUAGE_MODELS[provider],
+      latencyMs,
+      usage,
+      estimatedCostUsd,
+    };
+  },
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // Scorers
+  // ───────────────────────────────────────────────────────────────────────────
+  //
+  // Each scorer returns a value between 0 and 1. The eval framework aggregates
+  // these scores across all test cases and providers.
+  //
+  // EFFICACY METRICS (translation quality):
+  // - VTT Format: Is the output valid VTT format?
+  // - Timestamp Preservation: Are timestamps correctly preserved?
+  // - Cue Count Consistency: Does translation have same number of cues?
+  // - Translation Faithfulness: Is the translation faithful to the original?
+  // - Response Integrity: Are all fields valid and properly formatted?
+  //
+  // EFFICIENCY METRICS (continuous 0-1 scale):
+  // - Latency: How fast is the response? (normalized against thresholds)
+  // - Token Efficiency: How many tokens consumed? (normalized against threshold)
+  //
+  // EXPENSE METRICS:
+  // - Token usage presence for cost analysis
+  // - Cost within budget
+  // ───────────────────────────────────────────────────────────────────────────
+
+  scorers: [
+    // ─────────────────────────────────────────────────────────────────────────
+    // EFFICACY SCORERS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // VTT FORMAT: Output must be valid VTT format
+    {
+      name: "vtt-format",
+      description: "Validates that the translated output starts with WEBVTT and contains valid VTT structure.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { translatedVtt } = output;
+
+        if (!translatedVtt || translatedVtt.trim().length === 0) {
+          return 0;
+        }
+
+        // Must start with WEBVTT
+        if (!translatedVtt.trim().startsWith("WEBVTT")) {
+          return 0;
+        }
+
+        // Must contain at least one timestamp line
+        if (!VTT_TIMESTAMP_REGEX.test(translatedVtt)) {
+          return 0.5;
+        }
+
+        return 1;
+      },
+    },
+
+    // TIMESTAMP PRESERVATION: Timestamps must be correctly formatted
+    {
+      name: "timestamp-preservation",
+      description: "Validates that timestamps are preserved in the correct VTT format.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { originalVtt, translatedVtt } = output;
+
+        const originalTimestamps = originalVtt.match(VTT_TIMESTAMP_REGEX) ?? [];
+        const translatedTimestamps = translatedVtt.match(VTT_TIMESTAMP_REGEX) ?? [];
+
+        if (originalTimestamps.length === 0) {
+          return 0; // No timestamps to compare
+        }
+
+        // Check if all original timestamps are present in translation
+        const originalSet = new Set(originalTimestamps);
+        const translatedSet = new Set(translatedTimestamps);
+
+        let matchCount = 0;
+        for (const ts of originalSet) {
+          if (translatedSet.has(ts)) {
+            matchCount++;
+          }
+        }
+
+        return matchCount / originalSet.size;
+      },
+    },
+
+    // CUE COUNT CONSISTENCY: Translation should have same number of cues
+    {
+      name: "cue-count-consistency",
+      description: "Validates that the translated VTT has the same number of cues as the original.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { originalVtt, translatedVtt } = output;
+
+        const originalCues = countVttCues(originalVtt);
+        const translatedCues = countVttCues(translatedVtt);
+
+        if (originalCues === 0) {
+          return 0;
+        }
+
+        if (translatedCues === originalCues) {
+          return 1;
+        }
+
+        // Partial credit for close match
+        const ratio = Math.min(translatedCues, originalCues) / Math.max(translatedCues, originalCues);
+        return ratio;
+      },
+    },
+
+    // TRANSLATION FAITHFULNESS: Verify translation is faithful to original content
+    {
+      name: "translation-faithfulness",
+      description: "Evaluates whether the translation faithfully represents the original content without hallucinations.",
+      scorer: async ({
+        output,
+        input,
+      }: {
+        output: EvalOutput;
+        input: { targetLanguage: string; targetLanguageName: string };
+      }) => {
+        const translatedText = extractVttTextContent(output.translatedVtt);
+
+        // Use faithfulness scorer to check if translation is grounded in the original
+        const result = await faithfulness({
+          question: `Translate the following English transcript to ${input.targetLanguageName}: "${ORIGINAL_TRANSCRIPT}"`,
+          answer: translatedText,
+          groundTruth: [ORIGINAL_TRANSCRIPT],
+          model: openai("gpt-5.1"),
+        });
+
+        return {
+          score: result.score,
+          metadata: result.metadata,
+        };
+      },
+    },
+
+    // RESPONSE INTEGRITY: Schema and shape validation
+    {
+      name: "response-integrity",
+      description: "Validates all required fields are present and properly typed.",
+      scorer: ({
+        output,
+        input,
+        expected,
+      }: {
+        output: EvalOutput;
+        input: { assetId: string };
+        expected: { sourceLanguage: string; targetLanguage: string };
+      }) => {
+        const assetIdValid = output.assetId === input.assetId;
+        const sourceValid = output.sourceLanguageCode === expected.sourceLanguage;
+        const targetValid = output.targetLanguageCode === expected.targetLanguage;
+        const originalVttValid = typeof output.originalVtt === "string" && output.originalVtt.length > 0;
+        const translatedVttValid = typeof output.translatedVtt === "string" && output.translatedVtt.length > 0;
+
+        const validFields = [assetIdValid, sourceValid, targetValid, originalVttValid, translatedVttValid];
+        const validCount = validFields.filter(Boolean).length;
+
+        return validCount / validFields.length;
+      },
+    },
+
+    // TRANSLATION IS DIFFERENT: Ensure translation is actually different from original
+    {
+      name: "translation-is-different",
+      description: "Validates that the translated content is different from the original.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { originalVtt, translatedVtt } = output;
+
+        // Exact match means no translation happened
+        if (originalVtt === translatedVtt) {
+          return 0;
+        }
+
+        // Extract text content and compare
+        const originalText = extractVttTextContent(originalVtt).toLowerCase();
+        const translatedText = extractVttTextContent(translatedVtt).toLowerCase();
+
+        // If text content is identical, translation likely failed
+        if (originalText === translatedText) {
+          return 0;
+        }
+
+        return 1;
+      },
+    },
+
+    // LANGUAGE CODE FORMAT: Validate ISO 639-1 and ISO 639-3 codes are correct
+    {
+      name: "language-code-format",
+      description: "Validates that both ISO 639-1 (2-letter) and ISO 639-3 (3-letter) codes are returned correctly.",
+      scorer: ({
+        output,
+        expected,
+      }: {
+        output: EvalOutput;
+        expected: {
+          sourceLanguage: string;
+          targetLanguage: string;
+          expectedSourceISO639_3: string;
+          expectedTargetISO639_3: string;
+        };
+      }) => {
+        const checks: { name: string; passed: boolean }[] = [];
+
+        // Check sourceLanguage structure exists
+        const hasSourceLanguage = output.sourceLanguage &&
+          typeof output.sourceLanguage.iso639_1 === "string" &&
+          typeof output.sourceLanguage.iso639_3 === "string";
+        checks.push({ name: "sourceLanguage structure", passed: hasSourceLanguage });
+
+        // Check targetLanguage structure exists
+        const hasTargetLanguage = output.targetLanguage &&
+          typeof output.targetLanguage.iso639_1 === "string" &&
+          typeof output.targetLanguage.iso639_3 === "string";
+        checks.push({ name: "targetLanguage structure", passed: hasTargetLanguage });
+
+        if (hasSourceLanguage) {
+          // Validate source ISO 639-1 format (2 letters)
+          const sourceISO639_1Valid = output.sourceLanguage.iso639_1.length === 2 &&
+            output.sourceLanguage.iso639_1 === expected.sourceLanguage;
+          checks.push({ name: "source ISO 639-1", passed: sourceISO639_1Valid });
+
+          // Validate source ISO 639-3 format (3 letters)
+          const sourceISO639_3Valid = output.sourceLanguage.iso639_3.length === 3 &&
+            output.sourceLanguage.iso639_3 === expected.expectedSourceISO639_3;
+          checks.push({ name: "source ISO 639-3", passed: sourceISO639_3Valid });
+
+          // Validate source codes are consistent (can convert between them)
+          const sourceConsistent = toISO639_3(output.sourceLanguage.iso639_1) === output.sourceLanguage.iso639_3 &&
+            toISO639_1(output.sourceLanguage.iso639_3) === output.sourceLanguage.iso639_1;
+          checks.push({ name: "source code consistency", passed: sourceConsistent });
+        }
+
+        if (hasTargetLanguage) {
+          // Validate target ISO 639-1 format (2 letters)
+          const targetISO639_1Valid = output.targetLanguage.iso639_1.length === 2 &&
+            output.targetLanguage.iso639_1 === expected.targetLanguage;
+          checks.push({ name: "target ISO 639-1", passed: targetISO639_1Valid });
+
+          // Validate target ISO 639-3 format (3 letters)
+          const targetISO639_3Valid = output.targetLanguage.iso639_3.length === 3 &&
+            output.targetLanguage.iso639_3 === expected.expectedTargetISO639_3;
+          checks.push({ name: "target ISO 639-3", passed: targetISO639_3Valid });
+
+          // Validate target codes are consistent (can convert between them)
+          const targetConsistent = toISO639_3(output.targetLanguage.iso639_1) === output.targetLanguage.iso639_3 &&
+            toISO639_1(output.targetLanguage.iso639_3) === output.targetLanguage.iso639_1;
+          checks.push({ name: "target code consistency", passed: targetConsistent });
+        }
+
+        const passedCount = checks.filter(c => c.passed).length;
+        const failedChecks = checks.filter(c => !c.passed).map(c => c.name);
+
+        return {
+          score: passedCount / checks.length,
+          metadata: failedChecks.length > 0 ? { failedChecks } : undefined,
+        };
+      },
+    },
+
+    // LANGUAGE CODE VALIDITY: Validate codes are recognized ISO standards
+    {
+      name: "language-code-validity",
+      description: "Validates that language codes are recognized ISO 639-1 and ISO 639-3 standards.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const checks: boolean[] = [];
+
+        if (output.sourceLanguage) {
+          checks.push(isValidISO639_1(output.sourceLanguage.iso639_1));
+          checks.push(isValidISO639_3(output.sourceLanguage.iso639_3));
+        }
+
+        if (output.targetLanguage) {
+          checks.push(isValidISO639_1(output.targetLanguage.iso639_1));
+          checks.push(isValidISO639_3(output.targetLanguage.iso639_3));
+        }
+
+        if (checks.length === 0) {
+          return 0;
+        }
+
+        return checks.filter(Boolean).length / checks.length;
+      },
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // EFFICIENCY SCORERS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // LATENCY: Wall clock time performance
+    {
+      name: "latency-performance",
+      description: `Scores latency: 1.0 for <${LATENCY_THRESHOLD_GOOD_MS}ms, scaled down to 0 for >${LATENCY_THRESHOLD_ACCEPTABLE_MS}ms.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { latencyMs } = output;
+        if (latencyMs <= LATENCY_THRESHOLD_GOOD_MS) {
+          return 1;
+        }
+        if (latencyMs >= LATENCY_THRESHOLD_ACCEPTABLE_MS) {
+          return Math.max(0, 1 - (latencyMs - LATENCY_THRESHOLD_ACCEPTABLE_MS) / LATENCY_THRESHOLD_ACCEPTABLE_MS);
+        }
+        // Linear interpolation between good and acceptable
+        return 1 - 0.5 * ((latencyMs - LATENCY_THRESHOLD_GOOD_MS) / (LATENCY_THRESHOLD_ACCEPTABLE_MS - LATENCY_THRESHOLD_GOOD_MS));
+      },
+    },
+
+    // TOKEN EFFICIENCY: Total token consumption
+    {
+      name: "token-efficiency",
+      description: `Scores token usage: 1.0 for <${TOKEN_THRESHOLD_EFFICIENT} tokens, scaled down for higher usage.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const totalTokens = output.usage?.totalTokens ?? 0;
+        if (totalTokens === 0) {
+          return 0; // No usage data is a problem
+        }
+        if (totalTokens <= TOKEN_THRESHOLD_EFFICIENT) {
+          return 1;
+        }
+        // Gradual decline for over-threshold usage
+        return Math.max(0, 1 - (totalTokens - TOKEN_THRESHOLD_EFFICIENT) / TOKEN_THRESHOLD_EFFICIENT);
+      },
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // EXPENSE SCORERS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // USAGE DATA PRESENCE: Validates that usage metrics are available
+    {
+      name: "usage-data-present",
+      description: "Ensures token usage data is returned for cost analysis.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const hasUsage = output.usage &&
+          typeof output.usage.totalTokens === "number" &&
+          output.usage.totalTokens > 0;
+        return hasUsage ? 1 : 0;
+      },
+    },
+
+    // COST ANALYSIS: Estimated cost per request
+    {
+      name: "cost-within-budget",
+      description: `Scores cost efficiency: 1.0 for <$${COST_THRESHOLD_USD}, scaled down for higher costs.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { estimatedCostUsd } = output;
+        if (estimatedCostUsd <= COST_THRESHOLD_USD) {
+          return 1;
+        }
+        // Gradual decline for over-budget costs
+        return Math.max(0, 1 - (estimatedCostUsd - COST_THRESHOLD_USD) / COST_THRESHOLD_USD);
+      },
+    },
+  ],
+
+  columns: async ({
+    input,
+    output,
+  }: {
+    input: { assetId: string; sourceLanguage: string; targetLanguage: string; targetLanguageName: string };
+    output: EvalOutput;
+  }) => {
+    const srcLang = output.sourceLanguage;
+    const tgtLang = output.targetLanguage;
+
+    return [
+      { label: "Asset ID", value: input.assetId },
+      { label: "Provider", value: output.provider },
+      { label: "Model", value: output.model },
+      { label: "Source (ISO 639-1/3)", value: srcLang ? `${srcLang.iso639_1}/${srcLang.iso639_3}` : "N/A" },
+      { label: "Target (ISO 639-1/3)", value: tgtLang ? `${tgtLang.iso639_1}/${tgtLang.iso639_3}` : "N/A" },
+      { label: "Original Cues", value: countVttCues(output.originalVtt) },
+      { label: "Translated Cues", value: countVttCues(output.translatedVtt) },
+      { label: "Latency", value: `${Math.round(output.latencyMs)}ms` },
+      { label: "Tokens", value: output.usage?.totalTokens ?? 0 },
+      { label: "Cost", value: `$${output.estimatedCostUsd.toFixed(6)}` },
+    ];
+  },
+});

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -1,120 +1,21 @@
 import { describe, expect, it } from "vitest";
 
+import type { SupportedProvider } from "../../src/lib/providers";
 import { getSummaryAndTags } from "../../src/workflows";
 
 import "../../src/env";
 
 describe("summarization Integration Tests", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const testAssetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
-  it("should generate summary and tags with OpenAI provider", async () => {
-    const result = await getSummaryAndTags(assetId, {
-      provider: "openai",
-      tone: "normal",
-      includeTranscript: true,
-    });
+  it.each(providers)("should return valid result for %s provider", async (provider) => {
+    const result = await getSummaryAndTags(testAssetId, { provider });
 
-    // Assert that the result exists
     expect(result).toBeDefined();
-
-    // Verify structure
-    expect(result).toHaveProperty("assetId");
+    expect(result).toHaveProperty("assetId", testAssetId);
     expect(result).toHaveProperty("title");
     expect(result).toHaveProperty("description");
     expect(result).toHaveProperty("tags");
-
-    // Verify assetId matches
-    expect(result.assetId).toBe(assetId);
-
-    // Verify title
-    expect(typeof result.title).toBe("string");
-    expect(result.title.length).toBeGreaterThan(0);
-    expect(result.title.length).toBeLessThanOrEqual(100);
-
-    // Verify description
-    expect(typeof result.description).toBe("string");
-    expect(result.description.length).toBeGreaterThan(0);
-    expect(result.description.length).toBeLessThanOrEqual(1000);
-
-    // Verify tags
-    expect(Array.isArray(result.tags)).toBe(true);
-    expect(result.tags.length).toBeGreaterThan(0);
-    result.tags.forEach((tag) => {
-      expect(typeof tag).toBe("string");
-    });
-  });
-
-  it("should generate summary and tags with Anthropic provider", async () => {
-    const result = await getSummaryAndTags(assetId, {
-      provider: "anthropic",
-      tone: "normal",
-      includeTranscript: true,
-    });
-
-    // Assert that the result exists
-    expect(result).toBeDefined();
-
-    // Verify structure
-    expect(result).toHaveProperty("assetId");
-    expect(result).toHaveProperty("title");
-    expect(result).toHaveProperty("description");
-    expect(result).toHaveProperty("tags");
-
-    // Verify assetId matches
-    expect(result.assetId).toBe(assetId);
-
-    // Verify title
-    expect(typeof result.title).toBe("string");
-    expect(result.title.length).toBeGreaterThan(0);
-    expect(result.title.length).toBeLessThanOrEqual(100);
-
-    // Verify description
-    expect(typeof result.description).toBe("string");
-    expect(result.description.length).toBeGreaterThan(0);
-    expect(result.description.length).toBeLessThanOrEqual(1000);
-
-    // Verify tags
-    expect(Array.isArray(result.tags)).toBe(true);
-    expect(result.tags.length).toBeGreaterThan(0);
-    result.tags.forEach((tag) => {
-      expect(typeof tag).toBe("string");
-    });
-  });
-
-  it("should generate summary and tags with Google provider", async () => {
-    const result = await getSummaryAndTags(assetId, {
-      provider: "google",
-      tone: "normal",
-      includeTranscript: true,
-    });
-
-    // Assert that the result exists
-    expect(result).toBeDefined();
-
-    // Verify structure
-    expect(result).toHaveProperty("assetId");
-    expect(result).toHaveProperty("title");
-    expect(result).toHaveProperty("description");
-    expect(result).toHaveProperty("tags");
-
-    // Verify assetId matches
-    expect(result.assetId).toBe(assetId);
-
-    // Verify title
-    expect(typeof result.title).toBe("string");
-    expect(result.title.length).toBeGreaterThan(0);
-    expect(result.title.length).toBeLessThanOrEqual(100);
-
-    // Verify description
-    expect(typeof result.description).toBe("string");
-    expect(result.description.length).toBeGreaterThan(0);
-    expect(result.description.length).toBeLessThanOrEqual(1000);
-
-    // Verify tags
-    expect(Array.isArray(result.tags)).toBe(true);
-    expect(result.tags.length).toBeGreaterThan(0);
-    result.tags.forEach((tag) => {
-      expect(typeof tag).toBe("string");
-    });
   });
 });

--- a/tests/integration/translate-captions.test.ts
+++ b/tests/integration/translate-captions.test.ts
@@ -1,91 +1,29 @@
 import { describe, expect, it } from "vitest";
 
+import type { SupportedProvider } from "../../src/lib/providers";
 import { translateCaptions } from "../../src/workflows";
 
 import "../../src/env";
 
-describe("captions Translation Integration Tests", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+describe("translateCaptions Integration Tests", () => {
+  const testAssetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
-  it("should translate captions from English to French without uploading to Mux", async () => {
-    const result = await translateCaptions(assetId, "en", "fr", {
-      provider: "anthropic",
+  it.each(providers)("should return valid result for %s provider", async (provider) => {
+    const result = await translateCaptions(testAssetId, "en", "fr", {
+      provider,
       uploadToMux: false,
     });
 
-    // Assert that the result exists
     expect(result).toBeDefined();
-
-    // Verify structure
-    expect(result).toHaveProperty("assetId");
-    expect(result).toHaveProperty("sourceLanguageCode");
-    expect(result).toHaveProperty("targetLanguageCode");
+    expect(result).toHaveProperty("assetId", testAssetId);
+    expect(result).toHaveProperty("sourceLanguageCode", "en");
+    expect(result).toHaveProperty("targetLanguageCode", "fr");
     expect(result).toHaveProperty("originalVtt");
     expect(result).toHaveProperty("translatedVtt");
 
-    // Verify asset ID matches
-    expect(result.assetId).toBe(assetId);
-
-    // Verify language codes
-    expect(result.sourceLanguageCode).toBe("en");
-    expect(result.targetLanguageCode).toBe("fr");
-
-    // Verify original VTT exists and has content
-    expect(typeof result.originalVtt).toBe("string");
-    expect(result.originalVtt.length).toBeGreaterThan(0);
-    expect(result.originalVtt).toContain("WEBVTT");
-
-    // Verify translated VTT exists and has content
-    expect(typeof result.translatedVtt).toBe("string");
-    expect(result.translatedVtt.length).toBeGreaterThan(0);
-    expect(result.translatedVtt).toContain("WEBVTT");
-
-    // Verify the translation is different from the original
-    expect(result.translatedVtt).not.toBe(result.originalVtt);
-
-    // Since uploadToMux is false, these should not be present
-    expect(result.uploadedTrackId).toBeUndefined();
-    expect(result.presignedUrl).toBeUndefined();
-  });
-
-  it("should translate captions from English to French with Google provider without uploading to Mux", async () => {
-    const result = await translateCaptions(assetId, "en", "fr", {
-      provider: "google",
-      uploadToMux: false,
-    });
-
-    // Assert that the result exists
-    expect(result).toBeDefined();
-
-    // Verify structure
-    expect(result).toHaveProperty("assetId");
-    expect(result).toHaveProperty("sourceLanguageCode");
-    expect(result).toHaveProperty("targetLanguageCode");
-    expect(result).toHaveProperty("originalVtt");
-    expect(result).toHaveProperty("translatedVtt");
-
-    // Verify asset ID matches
-    expect(result.assetId).toBe(assetId);
-
-    // Verify language codes
-    expect(result.sourceLanguageCode).toBe("en");
-    expect(result.targetLanguageCode).toBe("fr");
-
-    // Verify original VTT exists and has content
-    expect(typeof result.originalVtt).toBe("string");
-    expect(result.originalVtt.length).toBeGreaterThan(0);
-    expect(result.originalVtt).toContain("WEBVTT");
-
-    // Verify translated VTT exists and has content
-    expect(typeof result.translatedVtt).toBe("string");
-    expect(result.translatedVtt.length).toBeGreaterThan(0);
-    expect(result.translatedVtt).toContain("WEBVTT");
-
-    // Verify the translation is different from the original
-    expect(result.translatedVtt).not.toBe(result.originalVtt);
-
-    // Since uploadToMux is false, these should not be present
-    expect(result.uploadedTrackId).toBeUndefined();
-    expect(result.presignedUrl).toBeUndefined();
+    // Verify ISO 639-1 and ISO 639-3 language code pairs
+    expect(result.sourceLanguage).toEqual({ iso639_1: "en", iso639_3: "eng" });
+    expect(result.targetLanguage).toEqual({ iso639_1: "fr", iso639_3: "fra" });
   });
 });


### PR DESCRIPTION
## Summary

should help address #43 

This branch adds evaluation infrastructure for translate-captions, improves workflow result types for cost/efficiency analysis, and adds ISO 639 language code utilities.

<img width="1938" height="470" alt="CleanShot 2025-12-04 at 15 03 11@2x" src="https://github.com/user-attachments/assets/99558ac2-85a3-4a06-bbdb-3ddedaad61a6" />

---

## Key Changes

### 1. Language Code Utilities (`src/lib/language-codes.ts`)

Reference: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

New module for ISO 639-1 ↔ ISO 639-3 bidirectional conversion:
- `toISO639_3("en")` → `"eng"`
- `toISO639_1("fra")` → `"fr"`
- `getLanguageCodePair("en")` → `{ iso639_1: "en", iso639_3: "eng" }`
- Supports ~50 common languages

**Why:** Different systems require different code formats (browsers use ISO 639-1/BCP-47, some APIs require ISO 639-3).

---

### 2. Workflow Result Enhancements

**`translateCaptions` now returns:**
- `sourceLanguage` / `targetLanguage` as `LanguageCodePair` objects
- `usage?: TokenUsage` for cost/efficiency tracking
- Removed noisy console.log statements

---

### 3. Default Model Updates (`src/lib/providers.ts`)

| Provider  | Before              | After               |
|-----------|---------------------|---------------------|
| OpenAI    | `gpt-5-mini`        | `gpt-5.1`           |
| Anthropic | `claude-haiku-4-5`  | `claude-sonnet-4-5` |

Pricing constants updated accordingly. This was in large part because `claude-haiku-4-5` doesn't currently reliably support structured outputs

---

### 4. Integration Test Refactoring

Consolidated repetitive provider-specific tests into `it.each()` patterns:
- `translate-captions.test.ts`
- `summarization.test.ts`

---

## Translate Captions Eval Breakdown

`tests/eval/translate-captions.eval.ts` runs 3 providers × 3 target languages (es, fr, ja) = 9 test cases.

### Efficacy Scorers (Quality)

| Scorer                     | What it checks                                                             |
| -------------------------- | -------------------------------------------------------------------------- |
| `vtt-format`               | Output starts with `WEBVTT`, contains valid timestamp lines                |
| `timestamp-preservation`   | All original timestamps preserved in translation                           |
| `cue-count-consistency`    | Same number of cues in translated vs original                              |
| `translation-faithfulness` | Uses evalite's `faithfulness` scorer against original transcript           |
| `response-integrity`       | All required fields present (`assetId`, `sourceLanguageCode`, etc.)        |
| `translation-is-different` | Translation text differs from original (translation actually happened)     |
| `language-code-format`     | ISO 639-1/639-3 codes match expected values                                |
| `language-code-validity`   | Codes are recognized ISO standards via `isValidISO639_1`/`isValidISO639_3` |

### Efficiency Scorers (Speed)

| Scorer                | Thresholds                              |
| --------------------- | --------------------------------------- |
| `latency-performance` | 1.0 for <8s, linear decay to 0.5 at 15s |
| `token-efficiency`    | 1.0 for <2500 tokens, decay above       |

### Expense Scorers (Cost)

| Scorer               | What it checks                     |
| -------------------- | ---------------------------------- |
| `usage-data-present` | `usage.totalTokens` exists and > 0 |
| `cost-within-budget` | 1.0 for <$0.012/request            |

### Observed Benchmarks

| Provider  | Model              | Avg Quality | Worst Case  | Avg Latency              | Cost per Run                 | Variance |
| --------- | ------------------ | ----------- | ----------- | ------------------------ | ---------------------------- | -------- |
| OpenAI    | gpt-5.1            | 99–100%     | 98% (ja)    | ~5.3–6.1s fastest        | ~$0.0047–$0.0053             | Low      |
| Anthropic | Claude Sonnet 4.5  | 99–100%     | 97–98% (ja) | ~7.0–11.4s slowest       | ~$0.0104–$0.0115 highest     | Very Low |
| Google    | Gemini 2.5 Flash   | 94–100%     | 82% (fr)    | ~6.0–15.0s highly variable | ~$0.0016–$0.0017 cheapest  | High     |

**Key Takeaways:**
- **OpenAI**: Best balance of quality, speed, and consistency
- **Anthropic**: Highest quality ceiling but slowest and most expensive
- **Google**: Cheapest by far but inconsistent quality (especially French translations)
