### PR TITLE
chore: add better tone instruction adherence

### DIFF
--- a/examples/summarization/basic-example.ts
+++ b/examples/summarization/basic-example.ts
@@ -8,7 +8,7 @@ import env from "../env";
 type Provider = "openai" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
-  openai: "gpt-5-mini",
+  openai: "gpt-5.1",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-2.5-flash",
 };

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -109,7 +109,7 @@ export interface SummarizationOptions extends MuxAIOptions {
 
 const TONE_INSTRUCTIONS: Record<ToneType, string> = {
   normal: "Provide a clear, straightforward analysis.",
-  sassy: "Answer with a sassy, playful attitude and personality.",
+  sassy: "Channel your inner diva! Answer with maximum sass, wit, and playful attitude. Don't hold back - be cheeky, clever, and delightfully snarky. Make it pop!",
   professional: "Provide a professional, executive-level analysis suitable for business reporting.",
 };
 
@@ -196,6 +196,13 @@ const SYSTEM_PROMPT = dedent`
     - Do not fabricate details or make unsupported assumptions
     - Return structured data matching the requested schema
   </constraints>
+
+  <tone_guidance>
+    Pay special attention to the <tone> section and lean heavily into those instructions.
+    Adapt your entire analysis and writing style to match the specified tone - this should influence
+    your word choice, personality, formality level, and overall presentation of the content.
+    The tone instructions are not suggestions but core requirements for how you should express yourself.
+  </tone_guidance>
 
   <language_guidelines>
     AVOID these meta-descriptive phrases that reference the medium rather than the content:


### PR DESCRIPTION
### Summary
- Strengthened the summarization **system prompt** to explicitly prioritize and heavily follow the provided `<tone>` instructions (word choice, personality, formality, presentation).
- Dialed up the **sassy** tone instruction to be more directive and noticeably higher-energy.
- Updated the summarization **example** default OpenAI model from `gpt-5-mini` to `gpt-5.1`.
- Update all mention and usage of `gpt-5-mini` to `gpt-5.1` to match what we do evals on w/r/t what we export from [DEFAULT_LANGUAGE_MODELS](https://github.com/muxinc/ai/blob/main/src/lib/providers.ts#L43)