### PR TITLE
improv: Refactor credentials handling so that explicit var overrides will work

### DIFF
--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -13,6 +13,8 @@ import {
  * Used internally by workflow steps.
  *
  * @param explicit - Credentials explicitly passed by the user (safe to use in step I/O)
+ * @param explicit.muxTokenId - Mux token ID
+ * @param explicit.muxTokenSecret - Mux token secret
  */
 export function getMuxCredentials(explicit?: { muxTokenId?: string; muxTokenSecret?: string }): { muxTokenId: string; muxTokenSecret: string } {
   const muxTokenId = explicit?.muxTokenId ?? env.MUX_TOKEN_ID;
@@ -33,6 +35,11 @@ export function getMuxCredentials(explicit?: { muxTokenId?: string; muxTokenSecr
  *
  * @param provider - The provider to get credentials for
  * @param explicit - Credentials explicitly passed by the user (safe to use in step I/O)
+ * @param explicit.openaiApiKey - OpenAI API key
+ * @param explicit.anthropicApiKey - Anthropic API key
+ * @param explicit.googleApiKey - Google API key
+ * @param explicit.hiveApiKey - Hive API key
+ * @param explicit.elevenLabsApiKey - ElevenLabs API key
  */
 export function getApiKey(
   provider: "openai" | "anthropic" | "google" | "hive" | "elevenlabs",

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -16,6 +16,55 @@ export interface ClientCredentials {
   googleApiKey?: string;
 }
 
+/**
+ * Gets Mux credentials from environment variables.
+ * Used internally by workflow steps to avoid passing credentials through step I/O.
+ * Throws if credentials are not available.
+ */
+export function getMuxCredentialsFromEnv(): { muxTokenId: string; muxTokenSecret: string } {
+  const muxTokenId = env.MUX_TOKEN_ID;
+  const muxTokenSecret = env.MUX_TOKEN_SECRET;
+
+  if (!muxTokenId || !muxTokenSecret) {
+    throw new Error(
+      "Mux credentials are required. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET environment variables.",
+    );
+  }
+
+  return { muxTokenId, muxTokenSecret };
+}
+
+/**
+ * Gets an API key from environment variables for the specified provider.
+ * Used internally by workflow steps to avoid passing credentials through step I/O.
+ * Throws if the API key is not available.
+ */
+export function getApiKeyFromEnv(provider: "openai" | "anthropic" | "google" | "hive" | "elevenlabs"): string {
+  const envVarMap: Record<string, string | undefined> = {
+    openai: env.OPENAI_API_KEY,
+    anthropic: env.ANTHROPIC_API_KEY,
+    google: env.GOOGLE_GENERATIVE_AI_API_KEY,
+    hive: env.HIVE_API_KEY,
+    elevenlabs: env.ELEVENLABS_API_KEY,
+  };
+
+  const apiKey = envVarMap[provider];
+  if (!apiKey) {
+    const envVarNames: Record<string, string> = {
+      openai: "OPENAI_API_KEY",
+      anthropic: "ANTHROPIC_API_KEY",
+      google: "GOOGLE_GENERATIVE_AI_API_KEY",
+      hive: "HIVE_API_KEY",
+      elevenlabs: "ELEVENLABS_API_KEY",
+    };
+    throw new Error(
+      `${provider} API key is required. Set ${envVarNames[provider]} environment variable.`,
+    );
+  }
+
+  return apiKey;
+}
+
 export interface ValidatedCredentials {
   muxTokenId: string;
   muxTokenSecret: string;
@@ -25,13 +74,13 @@ export interface ValidatedCredentials {
 }
 
 /**
- * Validates and retrieves credentials from options or environment variables
+ * Validates and retrieves credentials from options or environment variables.
+ * This function is NOT a workflow step to avoid exposing credentials in step I/O.
  */
 export async function validateCredentials(
   options: ClientCredentials,
   requiredProvider?: SupportedProvider,
 ): Promise<ValidatedCredentials> {
-  "use step";
   const muxTokenId = options.muxTokenId ?? env.MUX_TOKEN_ID;
   const muxTokenSecret = options.muxTokenSecret ?? env.MUX_TOKEN_SECRET;
   const openaiApiKey = options.openaiApiKey ?? env.OPENAI_API_KEY;
@@ -72,21 +121,20 @@ export async function validateCredentials(
   };
 }
 
-/**
- * Validates credentials and resolves model configuration for a workflow.
- * Returns only serializable data suitable for passing to workflow steps.
- */
 export interface WorkflowConfig {
   credentials: ValidatedCredentials;
   provider: SupportedProvider;
   modelId: string;
 }
 
+/**
+ * Validates credentials and resolves model configuration for a workflow.
+ * This function is NOT a workflow step to avoid exposing credentials in step I/O.
+ */
 export async function createWorkflowConfig(
   options: ModelRequestOptions,
   provider?: SupportedProvider,
 ): Promise<WorkflowConfig> {
-  "use step";
   const providerToUse = provider || options.provider || "openai";
   const credentials = await validateCredentials(options, providerToUse);
   const resolved = resolveLanguageModel({

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -1,12 +1,12 @@
-import env from "../env";
+import env from "../env.ts";
 
 import type {
   ModelRequestOptions,
   SupportedProvider,
-} from "./providers";
+} from "./providers.ts";
 import {
   resolveLanguageModel,
-} from "./providers";
+} from "./providers.ts";
 
 /**
  * Gets Mux credentials, preferring explicit credentials over environment variables.

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -2,7 +2,7 @@ import Mux from "@mux/mux-node";
 
 import type { MuxAsset, PlaybackAsset, PlaybackPolicy } from "../types";
 
-import type { ValidatedCredentials } from "./client-factory";
+import { getMuxCredentialsFromEnv } from "./client-factory";
 
 /**
  * Finds a usable playback ID for the given asset.
@@ -31,13 +31,13 @@ function getPlaybackId(asset: MuxAsset): { id: string; policy: PlaybackPolicy } 
 }
 
 export async function getPlaybackIdForAsset(
-  credentials: ValidatedCredentials,
   assetId: string,
 ): Promise<PlaybackAsset> {
   "use step";
+  const { muxTokenId, muxTokenSecret } = getMuxCredentialsFromEnv();
   const mux = new Mux({
-    tokenId: credentials.muxTokenId,
-    tokenSecret: credentials.muxTokenSecret,
+    tokenId: muxTokenId,
+    tokenSecret: muxTokenSecret,
   });
 
   const asset = await mux.video.assets.retrieve(assetId);

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -2,7 +2,7 @@ import Mux from "@mux/mux-node";
 
 import type { MuxAsset, PlaybackAsset, PlaybackPolicy } from "../types";
 
-import { getMuxCredentialsFromEnv } from "./client-factory";
+import { getMuxCredentials } from "./client-factory";
 
 /**
  * Finds a usable playback ID for the given asset.
@@ -30,11 +30,18 @@ function getPlaybackId(asset: MuxAsset): { id: string; policy: PlaybackPolicy } 
   );
 }
 
+/** Explicit Mux credentials that can be passed through step I/O (user opted in). */
+export interface ExplicitMuxCredentials {
+  muxTokenId?: string;
+  muxTokenSecret?: string;
+}
+
 export async function getPlaybackIdForAsset(
   assetId: string,
+  explicitCredentials?: ExplicitMuxCredentials,
 ): Promise<PlaybackAsset> {
   "use step";
-  const { muxTokenId, muxTokenSecret } = getMuxCredentialsFromEnv();
+  const { muxTokenId, muxTokenSecret } = getMuxCredentials(explicitCredentials);
   const mux = new Mux({
     tokenId: muxTokenId,
     tokenSecret: muxTokenSecret,

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -158,30 +158,41 @@ function requireEnv(value: string | undefined, name: string): string {
   return value;
 }
 
+/** Explicit credentials that can be passed through step I/O (user opted in). */
+export interface ExplicitCredentials {
+  openaiApiKey?: string;
+  anthropicApiKey?: string;
+  googleApiKey?: string;
+}
+
 /**
  * Creates a language model instance from serializable config.
  * Use this in steps to instantiate models from config passed through workflow.
- * Fetches credentials internally from environment variables to avoid exposing them in step I/O.
+ *
+ * @param provider - The AI provider
+ * @param modelId - The model ID
+ * @param explicit - Credentials explicitly passed by the user (safe to pass through step I/O)
  */
 export function createLanguageModelFromConfig(
   provider: SupportedProvider,
   modelId: string,
+  explicit?: ExplicitCredentials,
 ): LanguageModel {
   switch (provider) {
     case "openai": {
-      const apiKey = env.OPENAI_API_KEY;
+      const apiKey = explicit?.openaiApiKey ?? env.OPENAI_API_KEY;
       requireEnv(apiKey, "OPENAI_API_KEY");
       const openai = createOpenAI({ apiKey });
       return openai(modelId);
     }
     case "anthropic": {
-      const apiKey = env.ANTHROPIC_API_KEY;
+      const apiKey = explicit?.anthropicApiKey ?? env.ANTHROPIC_API_KEY;
       requireEnv(apiKey, "ANTHROPIC_API_KEY");
       const anthropic = createAnthropic({ apiKey });
       return anthropic(modelId);
     }
     case "google": {
-      const apiKey = env.GOOGLE_GENERATIVE_AI_API_KEY;
+      const apiKey = explicit?.googleApiKey ?? env.GOOGLE_GENERATIVE_AI_API_KEY;
       requireEnv(apiKey, "GOOGLE_GENERATIVE_AI_API_KEY");
       const google = createGoogleGenerativeAI({ apiKey });
       return google(modelId);
@@ -196,21 +207,25 @@ export function createLanguageModelFromConfig(
 /**
  * Creates an embedding model instance from serializable config.
  * Use this in steps to instantiate embedding models from config passed through workflow.
- * Fetches credentials internally from environment variables to avoid exposing them in step I/O.
+ *
+ * @param provider - The embedding provider
+ * @param modelId - The model ID
+ * @param explicit - Credentials explicitly passed by the user (safe to pass through step I/O)
  */
 export function createEmbeddingModelFromConfig(
   provider: SupportedEmbeddingProvider,
   modelId: string,
+  explicit?: ExplicitCredentials,
 ): EmbeddingModel<string> {
   switch (provider) {
     case "openai": {
-      const apiKey = env.OPENAI_API_KEY;
+      const apiKey = explicit?.openaiApiKey ?? env.OPENAI_API_KEY;
       requireEnv(apiKey, "OPENAI_API_KEY");
       const openai = createOpenAI({ apiKey });
       return openai.embedding(modelId);
     }
     case "google": {
-      const apiKey = env.GOOGLE_GENERATIVE_AI_API_KEY;
+      const apiKey = explicit?.googleApiKey ?? env.GOOGLE_GENERATIVE_AI_API_KEY;
       requireEnv(apiKey, "GOOGLE_GENERATIVE_AI_API_KEY");
       const google = createGoogleGenerativeAI({ apiKey });
       return google.textEmbeddingModel(modelId);

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -161,31 +161,27 @@ function requireEnv(value: string | undefined, name: string): string {
 /**
  * Creates a language model instance from serializable config.
  * Use this in steps to instantiate models from config passed through workflow.
+ * Fetches credentials internally from environment variables to avoid exposing them in step I/O.
  */
 export function createLanguageModelFromConfig(
   provider: SupportedProvider,
   modelId: string,
-  credentials: {
-    openaiApiKey?: string;
-    anthropicApiKey?: string;
-    googleApiKey?: string;
-  },
 ): LanguageModel {
   switch (provider) {
     case "openai": {
-      const apiKey = credentials.openaiApiKey;
+      const apiKey = env.OPENAI_API_KEY;
       requireEnv(apiKey, "OPENAI_API_KEY");
       const openai = createOpenAI({ apiKey });
       return openai(modelId);
     }
     case "anthropic": {
-      const apiKey = credentials.anthropicApiKey;
+      const apiKey = env.ANTHROPIC_API_KEY;
       requireEnv(apiKey, "ANTHROPIC_API_KEY");
       const anthropic = createAnthropic({ apiKey });
       return anthropic(modelId);
     }
     case "google": {
-      const apiKey = credentials.googleApiKey;
+      const apiKey = env.GOOGLE_GENERATIVE_AI_API_KEY;
       requireEnv(apiKey, "GOOGLE_GENERATIVE_AI_API_KEY");
       const google = createGoogleGenerativeAI({ apiKey });
       return google(modelId);
@@ -200,24 +196,21 @@ export function createLanguageModelFromConfig(
 /**
  * Creates an embedding model instance from serializable config.
  * Use this in steps to instantiate embedding models from config passed through workflow.
+ * Fetches credentials internally from environment variables to avoid exposing them in step I/O.
  */
 export function createEmbeddingModelFromConfig(
   provider: SupportedEmbeddingProvider,
   modelId: string,
-  credentials: {
-    openaiApiKey?: string;
-    googleApiKey?: string;
-  },
 ): EmbeddingModel<string> {
   switch (provider) {
     case "openai": {
-      const apiKey = credentials.openaiApiKey;
+      const apiKey = env.OPENAI_API_KEY;
       requireEnv(apiKey, "OPENAI_API_KEY");
       const openai = createOpenAI({ apiKey });
       return openai.embedding(modelId);
     }
     case "google": {
-      const apiKey = credentials.googleApiKey;
+      const apiKey = env.GOOGLE_GENERATIVE_AI_API_KEY;
       requireEnv(apiKey, "GOOGLE_GENERATIVE_AI_API_KEY");
       const google = createGoogleGenerativeAI({ apiKey });
       return google.textEmbeddingModel(modelId);

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -3,7 +3,6 @@ import dedent from "dedent";
 import { z } from "zod";
 
 import { createWorkflowConfig } from "../lib/client-factory";
-import type { ValidatedCredentials } from "../lib/client-factory";
 import type { ImageDownloadOptions } from "../lib/image-download";
 import { downloadImageAsBase64 } from "../lib/image-download";
 import { getPlaybackIdForAsset } from "../lib/mux-assets";
@@ -200,24 +199,18 @@ async function analyzeStoryboard({
   imageDataUrl,
   provider,
   modelId,
-  credentials,
   userPrompt,
   systemPrompt,
 }: {
   imageDataUrl: string;
   provider: SupportedProvider;
   modelId: string;
-  credentials: ValidatedCredentials;
   userPrompt: string;
   systemPrompt: string;
 }): Promise<AnalysisResponse> {
   "use step";
 
-  const model = createLanguageModelFromConfig(
-    provider,
-    modelId,
-    credentials,
-  );
+  const model = createLanguageModelFromConfig(provider, modelId);
 
   const response = await generateObject({
     model,
@@ -271,7 +264,7 @@ export async function hasBurnedInCaptions(
     { ...config, model },
     provider as SupportedProvider,
   );
-  const { playbackId, policy } = await getPlaybackIdForAsset(workflowConfig.credentials, assetId);
+  const { playbackId, policy } = await getPlaybackIdForAsset(assetId);
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveSigningContext(options);
@@ -292,7 +285,6 @@ export async function hasBurnedInCaptions(
       imageDataUrl: base64Data,
       provider: workflowConfig.provider,
       modelId: workflowConfig.modelId,
-      credentials: workflowConfig.credentials,
       userPrompt,
       systemPrompt: SYSTEM_PROMPT,
     });
@@ -301,7 +293,6 @@ export async function hasBurnedInCaptions(
       imageDataUrl: imageUrl,
       provider: workflowConfig.provider,
       modelId: workflowConfig.modelId,
-      credentials: workflowConfig.credentials,
       userPrompt,
       systemPrompt: SYSTEM_PROMPT,
     });

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -2,7 +2,6 @@ import { generateObject } from "ai";
 import { z } from "zod";
 
 import { createWorkflowConfig } from "../lib/client-factory";
-import type { ValidatedCredentials } from "../lib/client-factory";
 import { getPlaybackIdForAsset } from "../lib/mux-assets";
 import { createLanguageModelFromConfig } from "../lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "../lib/providers";
@@ -54,23 +53,17 @@ export interface ChaptersOptions extends MuxAIOptions {
 async function generateChaptersWithAI({
   provider,
   modelId,
-  credentials,
   timestampedTranscript,
   systemPrompt,
 }: {
   provider: SupportedProvider;
   modelId: string;
-  credentials: ValidatedCredentials;
   timestampedTranscript: string;
   systemPrompt: string;
 }): Promise<ChaptersType> {
   "use step";
 
-  const model = createLanguageModelFromConfig(
-    provider,
-    modelId,
-    credentials,
-  );
+  const model = createLanguageModelFromConfig(provider, modelId);
 
   const response = await withRetry(() =>
     generateObject({
@@ -125,7 +118,7 @@ export async function generateChapters(
   const config = await createWorkflowConfig({ ...options, model }, provider as SupportedProvider);
 
   // Fetch asset and caption track/transcript
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(config.credentials, assetId);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId);
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveSigningContext(options);
@@ -164,7 +157,6 @@ export async function generateChapters(
     chaptersData = await generateChaptersWithAI({
       provider: config.provider,
       modelId: config.modelId,
-      credentials: config.credentials,
       timestampedTranscript,
       systemPrompt: SYSTEM_PROMPT,
     });

--- a/src/workflows/embeddings.ts
+++ b/src/workflows/embeddings.ts
@@ -1,7 +1,5 @@
 import { embed } from "ai";
 
-import { validateCredentials } from "../lib/client-factory";
-import type { ValidatedCredentials } from "../lib/client-factory";
 import { getPlaybackIdForAsset } from "../lib/mux-assets";
 import type { EmbeddingModelIdByProvider, SupportedEmbeddingProvider } from "../lib/providers";
 import { createEmbeddingModelFromConfig, resolveEmbeddingModel } from "../lib/providers";
@@ -73,23 +71,20 @@ function averageEmbeddings(embeddings: number[][]): number[] {
  * @param options.chunk - Text chunk to embed
  * @param options.provider - AI provider for embedding generation
  * @param options.modelId - Provider-specific model identifier
- * @param options.credentials - Validated API credentials
  * @returns Chunk embedding with metadata
  */
 async function generateSingleChunkEmbedding({
   chunk,
   provider,
   modelId,
-  credentials,
 }: {
   chunk: TextChunk;
   provider: SupportedEmbeddingProvider;
   modelId: string;
-  credentials: ValidatedCredentials;
 }): Promise<ChunkEmbedding> {
   "use step";
 
-  const model = createEmbeddingModelFromConfig(provider, modelId, credentials);
+  const model = createEmbeddingModelFromConfig(provider, modelId);
   const response = await withRetry(() =>
     embed({
       model,
@@ -152,15 +147,10 @@ export async function generateVideoEmbeddings(
     batchSize = 5,
   } = options;
 
-  // Validate credentials
-  const credentials = await validateCredentials(options, provider === "google" ? "google" : "openai");
   const embeddingModel = resolveEmbeddingModel({ ...options, provider, model });
 
   // Fetch asset and playback ID
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(
-    credentials,
-    assetId,
-  );
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId);
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveSigningContext(options);
@@ -218,7 +208,6 @@ export async function generateVideoEmbeddings(
             chunk,
             provider: embeddingModel.provider,
             modelId: embeddingModel.modelId as string,
-            credentials,
           }),
         ),
       );

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -1,5 +1,4 @@
-import env from "../env";
-import { validateCredentials } from "../lib/client-factory";
+import { getApiKeyFromEnv } from "../lib/client-factory";
 import type { ImageDownloadOptions } from "../lib/image-download";
 import { downloadImagesAsBase64 } from "../lib/image-download";
 import { getPlaybackIdForAsset } from "../lib/mux-assets";
@@ -142,7 +141,6 @@ async function processConcurrently<T>(
 
 async function requestOpenAIModeration(
   imageUrls: string[],
-  apiKey: string,
   model: string,
   maxConcurrent: number = 5,
   submissionMode: "url" | "base64" = "url",
@@ -152,18 +150,19 @@ async function requestOpenAIModeration(
   const targetUrls =
     submissionMode === "base64" ?
         (await downloadImagesAsBase64(imageUrls, downloadOptions, maxConcurrent)).map(
-          img => ({ url: img.url, image: img.base64Data, apiKey, model }),
+          img => ({ url: img.url, image: img.base64Data, model }),
         ) :
-        imageUrls.map(url => ({ url, image: url, apiKey, model }));
+        imageUrls.map(url => ({ url, image: url, model }));
 
-  const moderate = async (entry: { url: string; image: string; apiKey: string; model: string }): Promise<ThumbnailModerationScore> => {
+  const moderate = async (entry: { url: string; image: string; model: string }): Promise<ThumbnailModerationScore> => {
     "use step";
+    const apiKey = getApiKeyFromEnv("openai");
     try {
       const res = await fetch("https://api.openai.com/v1/moderations", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${entry.apiKey}`,
+          "Authorization": `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
           model: entry.model,
@@ -220,7 +219,6 @@ function getHiveCategoryScores(
 
 async function requestHiveModeration(
   imageUrls: string[],
-  apiKey: string,
   maxConcurrent: number = 5,
   submissionMode: "url" | "base64" = "url",
   downloadOptions?: ImageDownloadOptions,
@@ -243,6 +241,7 @@ async function requestHiveModeration(
 
   const moderate = async (entry: { url: string; source: HiveModerationSource }): Promise<ThumbnailModerationScore> => {
     "use step";
+    const apiKey = getApiKeyFromEnv("hive");
     try {
       const formData = new FormData();
 
@@ -316,10 +315,8 @@ export async function getModerationScores(
     imageDownloadOptions,
   } = options;
 
-  const credentials = await validateCredentials(options, provider === "openai" ? "openai" : undefined);
-
   // Fetch asset data and playback ID from Mux via helper
-  const { asset, playbackId, policy } = await getPlaybackIdForAsset(credentials, assetId);
+  const { asset, playbackId, policy } = await getPlaybackIdForAsset(assetId);
   const duration = asset.duration || 0;
 
   // Resolve signing context for signed playback IDs
@@ -341,28 +338,16 @@ export async function getModerationScores(
   let thumbnailScores: ThumbnailModerationScore[];
 
   if (provider === "openai") {
-    const apiKey = credentials.openaiApiKey;
-    if (!apiKey) {
-      throw new Error("OpenAI API key is required for moderation. Set OPENAI_API_KEY or pass openaiApiKey.");
-    }
-
     thumbnailScores = await requestOpenAIModeration(
       thumbnailUrls,
-      apiKey,
       model || "omni-moderation-latest",
       maxConcurrent,
       imageSubmissionMode,
       imageDownloadOptions,
     );
   } else if (provider === "hive") {
-    const hiveApiKey = options.hiveApiKey || env.HIVE_API_KEY;
-    if (!hiveApiKey) {
-      throw new Error("Hive API key is required for moderation. Set HIVE_API_KEY or pass hiveApiKey.");
-    }
-
     thumbnailScores = await requestHiveModeration(
       thumbnailUrls,
-      hiveApiKey,
       maxConcurrent,
       imageSubmissionMode,
       imageDownloadOptions,

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -3,8 +3,7 @@ import { generateObject } from "ai";
 import { z } from "zod";
 
 import env from "../env";
-import { createWorkflowConfig } from "../lib/client-factory";
-import type { ValidatedCredentials } from "../lib/client-factory";
+import { createWorkflowConfig, getMuxCredentialsFromEnv } from "../lib/client-factory";
 import { getLanguageCodePair, getLanguageName } from "../lib/language-codes";
 import type { LanguageCodePair, SupportedISO639_1 } from "../lib/language-codes";
 import { getPlaybackIdForAsset } from "../lib/mux-assets";
@@ -94,7 +93,6 @@ async function translateVttWithAI({
   toLanguageCode,
   provider,
   modelId,
-  credentials,
   abortSignal,
 }: {
   vttContent: string;
@@ -102,16 +100,11 @@ async function translateVttWithAI({
   toLanguageCode: string;
   provider: SupportedProvider;
   modelId: string;
-  credentials: ValidatedCredentials;
   abortSignal?: AbortSignal;
 }): Promise<{ translatedVtt: string; usage: TokenUsage }> {
   "use step";
 
-  const languageModel = createLanguageModelFromConfig(
-    provider,
-    modelId,
-    credentials,
-  );
+  const languageModel = createLanguageModelFromConfig(provider, modelId);
 
   const response = await generateObject({
     model: languageModel,
@@ -204,16 +197,16 @@ async function uploadVttToS3({
 }
 
 async function createTextTrackOnMux(
-  credentials: ValidatedCredentials,
   assetId: string,
   languageCode: string,
   trackName: string,
   presignedUrl: string,
 ): Promise<string> {
   "use step";
+  const { muxTokenId, muxTokenSecret } = getMuxCredentialsFromEnv();
   const mux = new Mux({
-    tokenId: credentials.muxTokenId,
-    tokenSecret: credentials.muxTokenSecret,
+    tokenId: muxTokenId,
+    tokenSecret: muxTokenSecret,
   });
   const trackResponse = await mux.video.assets.createTrack(assetId, {
     type: "text",
@@ -267,7 +260,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   }
 
   // Fetch asset data and playback ID from Mux
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(config.credentials, assetId);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId);
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveSigningContext(options);
@@ -317,7 +310,6 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
       toLanguageCode,
       provider: config.provider,
       modelId: config.modelId,
-      credentials: config.credentials,
       abortSignal: options.abortSignal,
     });
     translatedVtt = result.translatedVtt;
@@ -370,7 +362,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     const languageName = getLanguageName(toLanguageCode);
     const trackName = `${languageName} (auto-translated)`;
 
-    uploadedTrackId = await createTextTrackOnMux(config.credentials, assetId, toLanguageCode, trackName, presignedUrl);
+    uploadedTrackId = await createTextTrackOnMux(assetId, toLanguageCode, trackName, presignedUrl);
   } catch (error) {
     console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
   }


### PR DESCRIPTION
In this solution:

- ENV vars will not be leaked between steps
- You can still pass in credential overrides, but they WILL be leaded between steps. If you're using "regular" node, that's no problem
- But if you are using Workflow DevKit -- then as a best practice you should only use ENV vars and you should not be passing in credentials as function argss, if you do, it will work, but it will leak into the logs and observability tools