### PR TITLE
feat: add tone validation with helpful error message for getSummaryAndTags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.45",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -108,6 +108,8 @@ export interface SummarizationOptions extends MuxAIOptions {
 // Prompts
 // ─────────────────────────────────────────────────────────────────────────────
 
+const VALID_TONES = ["neutral", "playful", "professional"] as const;
+
 const TONE_INSTRUCTIONS: Record<ToneType, string> = {
   neutral: "Provide a clear, straightforward analysis.",
   playful: "Channel your inner diva! Answer with maximum sass, wit, and playful attitude. Don't hold back - be cheeky, clever, and delightfully snarky. Make it pop!",
@@ -339,6 +341,13 @@ export async function getSummaryAndTags(
     abortSignal: _abortSignal,
     promptOverrides,
   } = options ?? {};
+
+  // Validate tone parameter
+  if (!VALID_TONES.includes(tone)) {
+    throw new Error(
+      `Invalid tone "${tone}". Valid tones are: ${VALID_TONES.join(", ")}`,
+    );
+  }
 
   // Validate credentials and resolve language model
   const config = await createWorkflowConfig(

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { SupportedProvider } from "../../src/lib/providers";
+import type { ToneType } from "../../src/types";
 import { getSummaryAndTags } from "../../src/workflows";
 
 import "../../src/env";
@@ -17,5 +18,13 @@ describe("summarization Integration Tests", () => {
     expect(result).toHaveProperty("title");
     expect(result).toHaveProperty("description");
     expect(result).toHaveProperty("tags");
+  });
+
+  it("should throw a useful error if tone is not valid", async () => {
+    const provider = providers[0];
+
+    await expect(
+      getSummaryAndTags(testAssetId, { provider, tone: "blah" as ToneType }),
+    ).rejects.toThrow("Invalid tone \"blah\". Valid tones are: neutral, playful, professional");
   });
 });


### PR DESCRIPTION
This was difficult to debug:

 POST /.well-known/workflow/v1/flow 200 in 471ms (compile: 1825µs, render: 469ms)
[Workflows] "wrun_01KCJBAZS9D71SYJ5KAYW6ZT3Z" - Encountered `Error` while executing step "step//workflows/get-summary-and-tags.ts//generateSummaryAndTagsStep" (attempt 1):
  > Error: Workflow run "wrun_01KCJBB2X73CYYE40STECTHWH1" failed: TypeError: Cannot read properties of undefined (reading 'trim')
    >     at Run.pollReturnValue (/Users/djhaveri/code/@muxinc/nextjs-video-ai-workflows/.next/dev/server/chunks/43408_@workflow_core_dist_0b137053._.js:2988:27)
    >     at async generateSummaryAndTagsStep (/Users/djhaveri/code/@muxinc/nextjs-video-ai-workflows/.next/dev/server/chunks/[root-of-the-server]__6c24f007._.js:2362:20)
    >     at async /Users/djhaveri/code/@muxinc/nextjs-video-ai-workflows/.next/dev/server/chunks/43408_@workflow_core_dist_0b137053._.js:3393:26

  This step has failed but will be retried
