### PR TITLE
chore: support tsc-alias

### DIFF
--- a/evalite.config.ts
+++ b/evalite.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "evalite/config";
 
 // See: https://v1.evalite.dev/guides/configuration
@@ -5,4 +7,15 @@ export default defineConfig({
   testTimeout: 120000, // 120 seconds
   maxConcurrency: 6, // Run up to 6 tests in parallel
   hideTable: false, // Show the table of results
+  viteConfig: {
+    resolve: {
+      alias: [
+        { find: /^@mux\/ai\/workflows$/, replacement: fileURLToPath(new URL("./src/workflows/index.ts", import.meta.url)) },
+        { find: /^@mux\/ai\/primitives$/, replacement: fileURLToPath(new URL("./src/primitives/index.ts", import.meta.url)) },
+        { find: /^@mux\/ai\/types$/, replacement: fileURLToPath(new URL("./src/types.ts", import.meta.url)) },
+        { find: /^@mux\/ai\/(.+)$/, replacement: fileURLToPath(new URL("./src/$1", import.meta.url)) },
+        { find: "@mux/ai", replacement: fileURLToPath(new URL("./src/index.ts", import.meta.url)) },
+      ],
+    },
+  } as any,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.45",
@@ -34,6 +34,7 @@
         "husky": "^9.1.7",
         "nitro": "^3.0.1-alpha.1",
         "ts-node": "^10.9.2",
+        "tsc-alias": "^1.8.16",
         "tsconfig-paths": "^4.2.0",
         "tsup": "^8.5.0",
         "typescript": "^5.0.0",
@@ -8097,6 +8098,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -8234,6 +8262,19 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/boolbase": {
@@ -11566,6 +11607,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-builtin-module": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
@@ -13282,6 +13336,20 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mylas": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.14.tgz",
+      "integrity": "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -13635,6 +13703,16 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -14188,6 +14266,19 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -14386,6 +14477,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -15849,6 +15950,102 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsc-alias": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+      "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "husky": "^9.1.7",
     "nitro": "^3.0.1-alpha.1",
     "ts-node": "^10.9.2",
+    "tsc-alias": "^1.8.16",
     "tsconfig-paths": "^4.2.0",
     "tsup": "^8.5.0",
     "typescript": "^5.0.0",

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -1,12 +1,11 @@
-import env from "../env";
-
+import env from "@mux/ai/env";
 import type {
   ModelRequestOptions,
   SupportedProvider,
-} from "./providers";
+} from "@mux/ai/lib/providers";
 import {
   resolveLanguageModel,
-} from "./providers";
+} from "@mux/ai/lib/providers";
 
 /**
  * Gets Mux credentials from environment variables.

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -1,12 +1,12 @@
-import env from "../env.ts";
+import env from "../env";
 
 import type {
   ModelRequestOptions,
   SupportedProvider,
-} from "./providers.ts";
+} from "./providers";
 import {
   resolveLanguageModel,
-} from "./providers.ts";
+} from "./providers";
 
 /**
  * Gets Mux credentials from environment variables.

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -1,8 +1,7 @@
 import Mux from "@mux/mux-node";
 
-import type { MuxAsset, PlaybackAsset, PlaybackPolicy } from "../types";
-
-import { getMuxCredentialsFromEnv } from "./client-factory";
+import { getMuxCredentialsFromEnv } from "@mux/ai/lib/client-factory";
+import type { MuxAsset, PlaybackAsset, PlaybackPolicy } from "@mux/ai/types";
 
 /**
  * Finds a usable playback ID for the given asset.

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -2,8 +2,8 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 
-import env from "../env";
-import type { MuxAIOptions } from "../types";
+import env from "@mux/ai/env";
+import type { MuxAIOptions } from "@mux/ai/types";
 
 import type { EmbeddingModel, LanguageModel } from "ai";
 

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -2,7 +2,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 
-import env from "../env.ts";
+import env from "../env";
 import type { MuxAIOptions } from "../types";
 
 import type { EmbeddingModel, LanguageModel } from "ai";

--- a/src/lib/url-signing.ts
+++ b/src/lib/url-signing.ts
@@ -1,6 +1,6 @@
 import Mux from "@mux/mux-node";
 
-import env from "../env";
+import env from "@mux/ai/env";
 
 /**
  * Context required to sign URLs for signed playback IDs.

--- a/src/primitives/storyboards.ts
+++ b/src/primitives/storyboards.ts
@@ -1,4 +1,4 @@
-import { getMuxSigningContextFromEnv, signUrl } from "../lib/url-signing";
+import { getMuxSigningContextFromEnv, signUrl } from "@mux/ai/lib/url-signing";
 
 export const DEFAULT_STORYBOARD_WIDTH = 640;
 

--- a/src/primitives/text-chunking.ts
+++ b/src/primitives/text-chunking.ts
@@ -1,6 +1,5 @@
-import type { ChunkingStrategy, TextChunk } from "../types";
-
-import type { VTTCue } from "./transcripts";
+import type { VTTCue } from "@mux/ai/primitives/transcripts";
+import type { ChunkingStrategy, TextChunk } from "@mux/ai/types";
 
 /**
  * Simple token counter that approximates tokens by word count.

--- a/src/primitives/thumbnails.ts
+++ b/src/primitives/thumbnails.ts
@@ -1,4 +1,4 @@
-import { getMuxSigningContextFromEnv, signUrl } from "../lib/url-signing";
+import { getMuxSigningContextFromEnv, signUrl } from "@mux/ai/lib/url-signing";
 
 export interface ThumbnailOptions {
   /** Interval between thumbnails in seconds (default: 10) */

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -1,5 +1,5 @@
-import { getMuxSigningContextFromEnv, signUrl } from "../lib/url-signing";
-import type { AssetTextTrack, MuxAsset } from "../types";
+import { getMuxSigningContextFromEnv, signUrl } from "@mux/ai/lib/url-signing";
+import type { AssetTextTrack, MuxAsset } from "@mux/ai/types";
 
 /** A single cue from a VTT file with timing info. */
 export interface VTTCue {

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -2,17 +2,17 @@ import { generateObject } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
-import { createWorkflowConfig } from "../lib/client-factory";
-import type { ImageDownloadOptions } from "../lib/image-download";
-import { downloadImageAsBase64 } from "../lib/image-download";
-import { getPlaybackIdForAsset } from "../lib/mux-assets";
-import type { PromptOverrides } from "../lib/prompt-builder";
-import { createPromptBuilder } from "../lib/prompt-builder";
-import { createLanguageModelFromConfig } from "../lib/providers";
-import type { ModelIdByProvider, SupportedProvider } from "../lib/providers";
-import { getMuxSigningContextFromEnv } from "../lib/url-signing";
-import { getStoryboardUrl } from "../primitives/storyboards";
-import type { ImageSubmissionMode, MuxAIOptions, TokenUsage } from "../types";
+import { createWorkflowConfig } from "@mux/ai/lib/client-factory";
+import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
+import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
+import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import type { PromptOverrides } from "@mux/ai/lib/prompt-builder";
+import { createPromptBuilder } from "@mux/ai/lib/prompt-builder";
+import { createLanguageModelFromConfig } from "@mux/ai/lib/providers";
+import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
+import { getMuxSigningContextFromEnv } from "@mux/ai/lib/url-signing";
+import { getStoryboardUrl } from "@mux/ai/primitives/storyboards";
+import type { ImageSubmissionMode, MuxAIOptions, TokenUsage } from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -1,18 +1,18 @@
 import { generateObject } from "ai";
 import { z } from "zod";
 
-import { createWorkflowConfig } from "../lib/client-factory";
-import { getPlaybackIdForAsset } from "../lib/mux-assets";
-import { createLanguageModelFromConfig } from "../lib/providers";
-import type { ModelIdByProvider, SupportedProvider } from "../lib/providers";
-import { withRetry } from "../lib/retry";
-import { getMuxSigningContextFromEnv } from "../lib/url-signing";
+import { createWorkflowConfig } from "@mux/ai/lib/client-factory";
+import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import { createLanguageModelFromConfig } from "@mux/ai/lib/providers";
+import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
+import { withRetry } from "@mux/ai/lib/retry";
+import { getMuxSigningContextFromEnv } from "@mux/ai/lib/url-signing";
 import {
   extractTimestampedTranscript,
   fetchTranscriptForAsset,
   getReadyTextTracks,
-} from "../primitives/transcripts";
-import type { MuxAIOptions } from "../types";
+} from "@mux/ai/primitives/transcripts";
+import type { MuxAIOptions } from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types

--- a/src/workflows/embeddings.ts
+++ b/src/workflows/embeddings.ts
@@ -1,19 +1,19 @@
 import { embed } from "ai";
 
-import { getPlaybackIdForAsset } from "../lib/mux-assets";
-import type { EmbeddingModelIdByProvider, SupportedEmbeddingProvider } from "../lib/providers";
-import { createEmbeddingModelFromConfig, resolveEmbeddingModel } from "../lib/providers";
-import { withRetry } from "../lib/retry";
-import { getMuxSigningContextFromEnv } from "../lib/url-signing";
-import { chunkText, chunkVTTCues } from "../primitives/text-chunking";
-import { fetchTranscriptForAsset, getReadyTextTracks, parseVTTCues } from "../primitives/transcripts";
+import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import type { EmbeddingModelIdByProvider, SupportedEmbeddingProvider } from "@mux/ai/lib/providers";
+import { createEmbeddingModelFromConfig, resolveEmbeddingModel } from "@mux/ai/lib/providers";
+import { withRetry } from "@mux/ai/lib/retry";
+import { getMuxSigningContextFromEnv } from "@mux/ai/lib/url-signing";
+import { chunkText, chunkVTTCues } from "@mux/ai/primitives/text-chunking";
+import { fetchTranscriptForAsset, getReadyTextTracks, parseVTTCues } from "@mux/ai/primitives/transcripts";
 import type {
   ChunkEmbedding,
   ChunkingStrategy,
   MuxAIOptions,
   TextChunk,
   VideoEmbeddingsResult,
-} from "../types";
+} from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -1,10 +1,10 @@
-import { getApiKeyFromEnv } from "../lib/client-factory";
-import type { ImageDownloadOptions } from "../lib/image-download";
-import { downloadImagesAsBase64 } from "../lib/image-download";
-import { getPlaybackIdForAsset } from "../lib/mux-assets";
-import { getMuxSigningContextFromEnv } from "../lib/url-signing";
-import { getThumbnailUrls } from "../primitives/thumbnails";
-import type { ImageSubmissionMode, MuxAIOptions } from "../types";
+import { getApiKeyFromEnv } from "@mux/ai/lib/client-factory";
+import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
+import { downloadImagesAsBase64 } from "@mux/ai/lib/image-download";
+import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import { getMuxSigningContextFromEnv } from "@mux/ai/lib/url-signing";
+import { getThumbnailUrls } from "@mux/ai/primitives/thumbnails";
+import type { ImageSubmissionMode, MuxAIOptions } from "@mux/ai/types";
 
 import type { Buffer } from "node:buffer";
 

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -2,25 +2,25 @@ import { generateObject } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
-import { createWorkflowConfig } from "../lib/client-factory";
-import type { ImageDownloadOptions } from "../lib/image-download";
-import { downloadImageAsBase64 } from "../lib/image-download";
-import { getPlaybackIdForAsset } from "../lib/mux-assets";
+import { createWorkflowConfig } from "@mux/ai/lib/client-factory";
+import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
+import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
+import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
 import type {
   PromptOverrides,
-} from "../lib/prompt-builder";
+} from "@mux/ai/lib/prompt-builder";
 import {
   createPromptBuilder,
   createToneSection,
   createTranscriptSection,
-} from "../lib/prompt-builder";
-import { createLanguageModelFromConfig } from "../lib/providers";
-import type { ModelIdByProvider, SupportedProvider } from "../lib/providers";
-import { withRetry } from "../lib/retry";
-import { getMuxSigningContextFromEnv } from "../lib/url-signing";
-import { getStoryboardUrl } from "../primitives/storyboards";
-import { fetchTranscriptForAsset } from "../primitives/transcripts";
-import type { ImageSubmissionMode, MuxAIOptions, TokenUsage, ToneType } from "../types";
+} from "@mux/ai/lib/prompt-builder";
+import { createLanguageModelFromConfig } from "@mux/ai/lib/providers";
+import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
+import { withRetry } from "@mux/ai/lib/retry";
+import { getMuxSigningContextFromEnv } from "@mux/ai/lib/url-signing";
+import { getStoryboardUrl } from "@mux/ai/primitives/storyboards";
+import { fetchTranscriptForAsset } from "@mux/ai/primitives/transcripts";
+import type { ImageSubmissionMode, MuxAIOptions, TokenUsage, ToneType } from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -1,12 +1,12 @@
 import Mux from "@mux/mux-node";
 
-import env from "../env";
-import { getApiKeyFromEnv, getMuxCredentialsFromEnv } from "../lib/client-factory";
-import { getLanguageCodePair, toISO639_1, toISO639_3 } from "../lib/language-codes";
-import type { LanguageCodePair, SupportedISO639_1 } from "../lib/language-codes";
-import { getPlaybackIdForAsset } from "../lib/mux-assets";
-import { getMuxSigningContextFromEnv, signUrl } from "../lib/url-signing";
-import type { MuxAIOptions } from "../types";
+import env from "@mux/ai/env";
+import { getApiKeyFromEnv, getMuxCredentialsFromEnv } from "@mux/ai/lib/client-factory";
+import { getLanguageCodePair, toISO639_1, toISO639_3 } from "@mux/ai/lib/language-codes";
+import type { LanguageCodePair, SupportedISO639_1 } from "@mux/ai/lib/language-codes";
+import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import { getMuxSigningContextFromEnv, signUrl } from "@mux/ai/lib/url-signing";
+import type { MuxAIOptions } from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -2,15 +2,15 @@ import Mux from "@mux/mux-node";
 import { generateObject } from "ai";
 import { z } from "zod";
 
-import env from "../env";
-import { createWorkflowConfig, getMuxCredentialsFromEnv } from "../lib/client-factory";
-import { getLanguageCodePair, getLanguageName } from "../lib/language-codes";
-import type { LanguageCodePair, SupportedISO639_1 } from "../lib/language-codes";
-import { getPlaybackIdForAsset } from "../lib/mux-assets";
-import { createLanguageModelFromConfig } from "../lib/providers";
-import type { ModelIdByProvider, SupportedProvider } from "../lib/providers";
-import { getMuxSigningContextFromEnv, signUrl } from "../lib/url-signing";
-import type { MuxAIOptions, TokenUsage } from "../types";
+import env from "@mux/ai/env";
+import { createWorkflowConfig, getMuxCredentialsFromEnv } from "@mux/ai/lib/client-factory";
+import { getLanguageCodePair, getLanguageName } from "@mux/ai/lib/language-codes";
+import type { LanguageCodePair, SupportedISO639_1 } from "@mux/ai/lib/language-codes";
+import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import { createLanguageModelFromConfig } from "@mux/ai/lib/providers";
+import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
+import { getMuxSigningContextFromEnv, signUrl } from "@mux/ai/lib/url-signing";
+import type { MuxAIOptions, TokenUsage } from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types

--- a/test-server/nitro.config.ts
+++ b/test-server/nitro.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import { defineNitroConfig } from "nitro/config";
 
 /*
@@ -8,6 +10,12 @@ import { defineNitroConfig } from "nitro/config";
 export default defineNitroConfig({
   modules: ["workflow/nitro"],
   compatibilityDate: "2024-01-01",
-  rootDir: "./",
-  serverDir: "./",
+  alias: {
+    "@mux/ai/workflows": fileURLToPath(new URL("../src/workflows/index.ts", import.meta.url)),
+    "@mux/ai/primitives": fileURLToPath(new URL("../src/primitives/index.ts", import.meta.url)),
+    "@mux/ai/types": fileURLToPath(new URL("../src/types.ts", import.meta.url)),
+    "@mux/ai/env": fileURLToPath(new URL("../src/env.ts", import.meta.url)),
+    "@mux/ai/lib": fileURLToPath(new URL("../src/lib", import.meta.url)),
+    "@mux/ai": fileURLToPath(new URL("../src/index.ts", import.meta.url)),
+  },
 });

--- a/test-server/workflows.ts
+++ b/test-server/workflows.ts
@@ -1,2 +1,2 @@
-// Re-export workflows from parent directory for nitro to discover
-export * from "../src/workflows";
+// Re-export workflows from compiled dist for nitro to discover
+export * from "../dist/workflows";

--- a/test-server/workflows.ts
+++ b/test-server/workflows.ts
@@ -1,2 +1,2 @@
-// Re-export workflows from compiled dist for nitro to discover
-export * from "../dist/workflows";
+// Re-export workflows from source so workflow IDs match client-side transforms
+export * from "@mux/ai/workflows";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
       "@mux/ai": ["src/index.ts"],
       "@mux/ai/workflows": ["src/workflows/index.ts"],
       "@mux/ai/primitives": ["src/primitives/index.ts"],
-      "@mux/ai/types": ["src/types.ts"]
+      "@mux/ai/types": ["src/types.ts"],
+      "@mux/ai/*": ["src/*"]
     },
     "resolveJsonModule": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
       "@mux/ai/types": ["src/types.ts"]
     },
     "resolveJsonModule": true,
-    "allowImportingTsExtensions": true,
     "strict": true,
     "declaration": true,
     "declarationMap": true,
@@ -28,6 +27,9 @@
       "module": "CommonJS",
       "moduleResolution": "node"
     }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true
   },
   "include": [
     "src/**/*"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,17 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: [
+      { find: /^@mux\/ai\/workflows$/, replacement: fileURLToPath(new URL("./src/workflows/index.ts", import.meta.url)) },
+      { find: /^@mux\/ai\/primitives$/, replacement: fileURLToPath(new URL("./src/primitives/index.ts", import.meta.url)) },
+      { find: /^@mux\/ai\/types$/, replacement: fileURLToPath(new URL("./src/types.ts", import.meta.url)) },
+      { find: /^@mux\/ai\/(.+)$/, replacement: fileURLToPath(new URL("./src/$1", import.meta.url)) },
+      { find: "@mux/ai", replacement: fileURLToPath(new URL("./src/index.ts", import.meta.url)) },
+    ],
+  },
   test: {
     globals: true,
     environment: "node",

--- a/vitest.workflowdevkit.config.ts
+++ b/vitest.workflowdevkit.config.ts
@@ -1,8 +1,19 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 import { workflow } from "workflow/vite";
 
 export default defineConfig({
   plugins: [workflow()],
+  resolve: {
+    alias: [
+      { find: /^@mux\/ai\/workflows$/, replacement: fileURLToPath(new URL("./src/workflows/index.ts", import.meta.url)) },
+      { find: /^@mux\/ai\/primitives$/, replacement: fileURLToPath(new URL("./src/primitives/index.ts", import.meta.url)) },
+      { find: /^@mux\/ai\/types$/, replacement: fileURLToPath(new URL("./src/types.ts", import.meta.url)) },
+      { find: /^@mux\/ai\/(.+)$/, replacement: fileURLToPath(new URL("./src/$1", import.meta.url)) },
+      { find: "@mux/ai", replacement: fileURLToPath(new URL("./src/index.ts", import.meta.url)) },
+    ],
+  },
   test: {
     include: ["**/*.test.workflowdevkit.ts"],
     testTimeout: 300000,

--- a/vitest.workflowdevkit.setup.ts
+++ b/vitest.workflowdevkit.setup.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
 
 import type { ChildProcess } from "node:child_process";
@@ -10,11 +10,6 @@ let nitroServer: ChildProcess | null = null;
 const PORT = "4000";
 
 export async function setup() {
-  // Keep a fresh build handy before starting Nitro (helps catch build regressions)
-  // eslint-disable-next-line no-console
-  console.log("Building project before starting Nitro server...");
-  execSync("npm run build", { stdio: "inherit" });
-
   // eslint-disable-next-line no-console
   console.log("Starting Nitro server for workflow execution...");
 

--- a/vitest.workflowdevkit.setup.ts
+++ b/vitest.workflowdevkit.setup.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
 
 import type { ChildProcess } from "node:child_process";
@@ -10,6 +10,11 @@ let nitroServer: ChildProcess | null = null;
 const PORT = "4000";
 
 export async function setup() {
+  // Build the project first so nitro can use compiled dist/
+  // eslint-disable-next-line no-console
+  console.log("Building project before starting Nitro server...");
+  execSync("npm run build", { stdio: "inherit" });
+
   // eslint-disable-next-line no-console
   console.log("Starting Nitro server for workflow execution...");
 

--- a/vitest.workflowdevkit.setup.ts
+++ b/vitest.workflowdevkit.setup.ts
@@ -10,7 +10,7 @@ let nitroServer: ChildProcess | null = null;
 const PORT = "4000";
 
 export async function setup() {
-  // Build the project first so nitro can use compiled dist/
+  // Keep a fresh build handy before starting Nitro (helps catch build regressions)
   // eslint-disable-next-line no-console
   console.log("Building project before starting Nitro server...");
   execSync("npm run build", { stdio: "inherit" });


### PR DESCRIPTION
# Overview

This branch implements project-wide path aliases using the `@mux/ai` prefix. It migrates all relative imports to use these aliases, ensuring better consistency across the codebase, workflows, and test environments. It also adds tooling to resolve these aliases during the build process and within various test runners.

# What was changed

- **Path Aliases**: Replaced relative imports (e.g., `../lib/...`) with absolute-style aliases (e.g., `@mux/ai/lib/...`) across all source files and workflows.
- **Build Tooling**: Added `tsc-alias` as a dependency and configured it in `tsconfig.json` to resolve path aliases in the compiled output.
- **Test Infrastructure**:
    - **Vitest**: Updated `vitest.config.ts` and `vitest.workflowdevkit.config.ts` with regex-based alias definitions for robust path resolution.
    - **Evalite**: Updated `evalite.config.ts` to include the same alias configuration for AI evaluation tests.
    - **Nitro**: Enhanced `test-server/nitro.config.ts` with explicit aliases for all internal modules to ensure the dev server correctly resolves source files.
- **Build-on-Test**: Modified the workflow devkit setup to trigger a full build (`npm run build`) before starting the Nitro server, catching potential build regressions during integration testing.
- **Config Clean-up**: Removed `allowImportingTsExtensions` from `tsconfig.json` and standardized import paths.
- **Version Bump**: Bumped the package version to `0.4.1`.

# Suggested review order

1. `tsconfig.json` and `package.json`: To see the core alias configuration and the addition of `tsc-alias`.
2. `vitest.config.ts`, `evalite.config.ts`, and `test-server/nitro.config.ts`: To verify how aliases are resolved consistently across different test and server environments.
3. `src/workflows/` and `src/lib/`: A sample check of how the relative imports were converted to `@mux/ai/*` aliases.
4. `vitest.workflowdevkit.setup.ts`: To review the change in the test setup flow.
