### PR TITLE
chore: publish eval results

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,5 @@ EVALITE_INGEST_SECRET=your_evalite_ingest_secret
 # S3_ACCESS_KEY_ID=your-r2-access-key
 # S3_SECRET_ACCESS_KEY=your-r2-secret-key
 
-# Used for storing eval results in CI
-# DATABASE_URL=your_postgress-url
-
 # Evalite results API (Optional)
 # EVALITE_RESULTS_ENDPOINT=https://your-app.com/api/evalite-results

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # Get your credentials at: https://dashboard.mux.com/settings/access-tokens
 MUX_TOKEN_ID=your_mux_token_id
 MUX_TOKEN_SECRET=your_mux_token_secret
+EVALITE_INGEST_SECRET=your_evalite_ingest_secret
 
 # Mux Signing Keys (Conditional - only if using signed playback)
 # Get at: https://dashboard.mux.com/settings/signing-keys
@@ -44,3 +45,9 @@ MUX_TOKEN_SECRET=your_mux_token_secret
 # S3_BUCKET=your-bucket-name
 # S3_ACCESS_KEY_ID=your-r2-access-key
 # S3_SECRET_ACCESS_KEY=your-r2-secret-key
+
+# Used for storing eval results in CI
+# DATABASE_URL=your_postgress-url
+
+# Evalite results API (Optional)
+# EVALITE_RESULTS_ENDPOINT=https://your-app.com/api/evalite-results

--- a/.github/workflows/publish-evalite-results.yml
+++ b/.github/workflows/publish-evalite-results.yml
@@ -1,38 +1,28 @@
-name: Publish Evals UI
+name: Publish Evalite Results
 
 on:
   push:
     branches: [main]
   workflow_dispatch: # Allows manual triggering from any branch
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version-file: .nvmrc
+          cache: npm
 
       - run: npm install
 
-      - name: Run Evalite and Export UI
+      - name: Run Evalite and Export Results
         env:
           MUX_TOKEN_ID: ${{ secrets.MUX_TOKEN_ID }}
           MUX_TOKEN_SECRET: ${{ secrets.MUX_TOKEN_SECRET }}
+          EVALITE_INGEST_SECRET: ${{ secrets.EVALITE_INGEST_SECRET }}
           MUX_SIGNING_KEY: ${{ secrets.MUX_SIGNING_KEY }}
           MUX_PRIVATE_KEY: ${{ secrets.MUX_PRIVATE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -45,15 +35,10 @@ jobs:
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          EVALITE_RESULTS_ENDPOINT: ${{ secrets.EVALITE_RESULTS_ENDPOINT }}
         run: |
-          npx evalite run
-          npx evalite export --output=./ui-output
+          npm run evalite:post-results:production
 
-      - name: Upload static UI for Pages
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ui-output
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Cleanup Evalite Results File
+        if: always()
+        run: rm -f evalite-results.json

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ test-run.js
 # Temporary files
 tmp/
 temp/
+evalite-results.json
 
 .swc/
 test-server/.workflow-data

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -67,17 +67,22 @@ npx evalite serve summarization.eval.ts
 
 ### CI/CD
 
-Evals run automatically on pushes to `main` (or via manual workflow dispatch). The CI job executes the evals, exports the json output, and posts the raw results to the Evalite API used by `evaluating-mux-ai`:
+Evals run automatically on pushes to `main` (or via manual workflow dispatch). The CI job executes the evals, exports the JSON output, and posts the raw results to the Evalite API used by `evaluating-mux-ai`.
+
+**For local development/testing:**
 
 ```bash
-# Run evals and write evalite-results.json
-npx tsx scripts/export-evalite-results.ts
+# Run evals and export results as a dry run (inspect without publishing)
+npm run evalite:post-results:dev
+```
 
-# Export static UI output (optional)
-npx evalite export --output ./ui-output
+**For production (internal maintainers only):**
 
-# Post results to the API (deletes evalite-results.json on success)
-npx tsx scripts/post-evalite-results.ts
+> ⚠️ The production script posts results to the live Evalite dashboard and is not intended for OSS contributors. It requires internal credentials and should only be run by project maintainers.
+
+```bash
+# Run evals, export results, and post to production endpoint
+npm run evalite:post-results:production
 ```
 
 The post step requires `EVALITE_RESULTS_ENDPOINT` (full URL to `/api/evalite-results`) and uses `EVALITE_INGEST_SECRET` as the shared secret header.

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -67,17 +67,20 @@ npx evalite serve summarization.eval.ts
 
 ### CI/CD
 
-Evals run automatically on every push to `main` and on pull requests:
+Evals run automatically on pushes to `main` (or via manual workflow dispatch). The CI job executes the evals, exports the json output, and posts the raw results to the Evalite API used by `evaluating-mux-ai`:
 
 ```bash
-# Run evals once and exit (CI mode)
-npx evalite run
+# Run evals and write evalite-results.json
+npx tsx scripts/export-evalite-results.ts
 
-# Export static UI for artifacts
-npx evalite export --output ./ui-export
+# Export static UI output (optional)
+npx evalite export --output ./ui-output
+
+# Post results to the API (deletes evalite-results.json on success)
+npx tsx scripts/post-evalite-results.ts
 ```
 
-The [Evalite UI is published to GitHub Pages](https://muxinc.github.io/ai/evals/) on every push to `main`, providing a persistent dashboard of eval results.
+The post step requires `EVALITE_RESULTS_ENDPOINT` (full URL to `/api/evalite-results`) and uses `EVALITE_INGEST_SECRET` as the shared secret header.
 
 ## Eval Structure
 
@@ -221,4 +224,3 @@ Pricing sources (verify periodically):
 - [Evalite Documentation](https://v1.evalite.dev/)
 - [Evalite CLI Reference](https://v1.evalite.dev/api/cli/)
 - [CI/CD Integration Guide](https://v1.evalite.dev/tips/run-evals-on-ci-cd)
-

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "example:embeddings": "npx tsx examples/embeddings/basic-example.ts",
     "example:translate-captions": "npx tsx examples/translate-captions/basic-example.ts",
     "example:translate-audio": "npx tsx examples/translate-audio/basic-example.ts",
+    "evalite:post-results:dev": "npx tsx scripts/export-evalite-results.ts && npx tsx scripts/post-evalite-results.ts -d -k",
+    "evalite:post-results:production": "npx tsx scripts/export-evalite-results.ts && npx tsx scripts/post-evalite-results.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/export-evalite-results.ts
+++ b/scripts/export-evalite-results.ts
@@ -1,0 +1,17 @@
+import { runEvalite } from "evalite/runner";
+
+async function runEvals() {
+  try {
+    await runEvalite({
+      mode: "run-once-and-exit",
+      scoreThreshold: 75, // Fail if average score < 75
+      outputPath: "./evalite-results.json", // Export results
+    });
+    console.warn("All evals passed!");
+  } catch (error) {
+    console.error("Evals failed:", error);
+    process.exit(1);
+  }
+}
+
+runEvals();

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -1,0 +1,155 @@
+/* eslint-disable node/no-process-env */
+import { execSync } from "node:child_process";
+import { readFile, unlink } from "node:fs/promises";
+import path from "node:path";
+
+import { Command } from "commander";
+
+import env from "../src/env";
+
+interface EvaliteEnvelope {
+  repo: string;
+  sha: string;
+  ref: string;
+  githubRunId?: number;
+  githubRunAttempt?: number;
+  status: "completed";
+  evaliteVersion?: string;
+  results: unknown;
+}
+
+function execGit(command: string) {
+  return execSync(command, { encoding: "utf8" }).trim();
+}
+
+function parseRepoFromRemote(remoteUrl: string) {
+  const githubMatch = remoteUrl.match(/github\.com[:/](.+?)(?:\.git)?$/i);
+  return githubMatch ? githubMatch[1] : null;
+}
+
+function resolveRepo() {
+  if (process.env.GITHUB_REPOSITORY) {
+    return process.env.GITHUB_REPOSITORY;
+  }
+
+  try {
+    const remote = execGit("git config --get remote.origin.url");
+    const parsed = parseRepoFromRemote(remote);
+    if (parsed) {
+      return parsed;
+    }
+  } catch {
+    // Ignore git lookup failures.
+  }
+
+  return null;
+}
+
+function resolveSha() {
+  if (process.env.GITHUB_SHA) {
+    return process.env.GITHUB_SHA;
+  }
+
+  try {
+    return execGit("git rev-parse HEAD");
+  } catch {
+    return null;
+  }
+}
+
+function resolveRef() {
+  if (process.env.GITHUB_REF_NAME) {
+    return process.env.GITHUB_REF_NAME;
+  }
+
+  if (process.env.GITHUB_REF) {
+    return process.env.GITHUB_REF.replace("refs/heads/", "");
+  }
+
+  try {
+    return execGit("git rev-parse --abbrev-ref HEAD");
+  } catch {
+    return null;
+  }
+}
+
+interface Options {
+  dryRun: boolean;
+  keepFile: boolean;
+}
+
+const program = new Command();
+
+program
+  .name("post-evalite-results")
+  .description("Post evalite results to the configured endpoint")
+  .option("-d, --dry-run", "Print the payload without posting to the endpoint", false)
+  .option("-k, --keep-file", "Skip deleting evalite-results.json after posting", false)
+  .action(async (options: Options) => {
+    try {
+      const endpoint = env.EVALITE_RESULTS_ENDPOINT;
+      if (!endpoint && !options.dryRun) {
+        throw new Error("Missing EVALITE_RESULTS_ENDPOINT. Set it to the API URL (or use --dry-run).");
+      }
+
+      if (!env.EVALITE_INGEST_SECRET && !options.dryRun) {
+        throw new Error("Missing EVALITE_INGEST_SECRET. Set it to the ingest secret (or use --dry-run).");
+      }
+
+      const repo = resolveRepo();
+      const sha = resolveSha();
+      const ref = resolveRef();
+
+      if (!repo || !sha || !ref) {
+        throw new Error("Unable to resolve repo/sha/ref metadata for eval run.");
+      }
+
+      const resultsPath = path.resolve(process.cwd(), "evalite-results.json");
+      const raw = await readFile(resultsPath, "utf8");
+      const results = JSON.parse(raw) as unknown;
+
+      const payload: EvaliteEnvelope = {
+        repo,
+        sha,
+        ref,
+        githubRunId: process.env.GITHUB_RUN_ID ? Number(process.env.GITHUB_RUN_ID) : undefined,
+        githubRunAttempt: process.env.GITHUB_RUN_ATTEMPT ? Number(process.env.GITHUB_RUN_ATTEMPT) : undefined,
+        status: "completed",
+        evaliteVersion: process.env.EVALITE_VERSION,
+        results,
+      };
+
+      if (options.dryRun) {
+        console.warn("🔍 Dry run – payload that would be sent:\n");
+        console.warn(JSON.stringify(payload, null, 2));
+        console.warn(`\n📍 Would POST to: ${endpoint ?? "(no endpoint configured)"}`);
+        return;
+      }
+
+      const response = await fetch(endpoint!, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-evalite-secret": env.EVALITE_INGEST_SECRET ?? "",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Evalite results POST failed: ${response.status} ${errorText}`);
+      }
+
+      if (options.keepFile) {
+        console.warn(`✅ Posted evalite results to ${endpoint} (kept ${resultsPath})`);
+      } else {
+        await unlink(resultsPath);
+        console.warn(`✅ Posted evalite results to ${endpoint}`);
+      }
+    } catch (error) {
+      console.error("❌ Failed to post evalite results:", error);
+      process.exit(1);
+    }
+  });
+
+program.parse();

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -3,9 +3,95 @@ import { execSync } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
 import path from "node:path";
 
+import { openai } from "@ai-sdk/openai";
+import { generateObject } from "ai";
 import { Command } from "commander";
+import dedent from "dedent";
+import { z } from "zod";
 
 import env from "../src/env";
+
+interface EvaliteSuite {
+  name?: string;
+  filepath?: string;
+  status?: string;
+  averageScore?: number;
+  duration?: number;
+  createdAt?: string;
+  evals?: unknown[];
+}
+
+interface EvaliteScoreRecord {
+  name?: string;
+  score?: number;
+}
+
+interface EvaliteRecord {
+  input?: Record<string, unknown>;
+  output?: Record<string, unknown>;
+  expected?: Record<string, unknown>;
+  scores?: EvaliteScoreRecord[];
+  averageScore?: number;
+  duration?: number;
+  caseIndex?: number;
+  colOrder?: number;
+}
+
+interface ProviderStats {
+  provider: string;
+  model?: string;
+  models?: string[];
+  caseCount: number;
+  avgLatencyMs?: number;
+  avgCostUsd?: number;
+  avgScore?: number;
+  scorerAverages?: Record<string, number>;
+  confidence?: {
+    positiveAvg?: number;
+    negativeAvg?: number;
+    positiveRange?: [number, number];
+    negativeRange?: [number, number];
+  };
+}
+
+interface ProviderRecommendation {
+  provider: string;
+  model?: string;
+}
+
+interface WorkflowInsightStats {
+  workflowKey: string;
+  workflowName: string;
+  suiteStatus?: string;
+  suiteAverageScore?: number;
+  suiteDurationMs?: number;
+  suiteCreatedAt?: string;
+  caseCount: number;
+  assetCount?: number;
+  providerCount: number;
+  providers: ProviderStats[];
+  scorerAverages?: Record<string, number>;
+  recommendations?: {
+    quality?: ProviderRecommendation;
+    latency?: ProviderRecommendation;
+    expense?: ProviderRecommendation;
+  };
+  notes?: string[];
+}
+
+interface WorkflowInsightPayload {
+  workflowKey: string;
+  workflowName: string;
+  summaryMarkdown: string;
+  tldr?: string;
+  caveat?: string;
+  stats: WorkflowInsightStats;
+  recommendations?: {
+    quality?: ProviderRecommendation;
+    latency?: ProviderRecommendation;
+    expense?: ProviderRecommendation;
+  };
+}
 
 interface EvaliteEnvelope {
   repo: string;
@@ -16,6 +102,14 @@ interface EvaliteEnvelope {
   status: "completed";
   evaliteVersion?: string;
   results: unknown;
+  insights: {
+    generatedAt: string;
+    model?: {
+      provider?: string;
+      modelId?: string;
+    };
+    workflows: WorkflowInsightPayload[];
+  };
 }
 
 function execGit(command: string) {
@@ -78,6 +172,412 @@ interface Options {
   keepFile: boolean;
 }
 
+const WORKFLOW_MATCHERS = [
+  { key: "burned_in_captions", regex: /burned[- ]in[- ]captions/i },
+  { key: "translate_captions", regex: /translate[- ]captions/i },
+  { key: "summarization", regex: /summarization/i },
+] as const;
+
+const WorkflowInsightSchema = z.object({
+  summaryMarkdown: z.string().min(1),
+  tldr: z.string().min(1).optional(),
+  caveat: z.string().min(1).optional(),
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveWorkflowKey(suite: EvaliteSuite): string | null {
+  const haystack = `${suite.name ?? ""} ${suite.filepath ?? ""}`.toLowerCase();
+  for (const matcher of WORKFLOW_MATCHERS) {
+    if (matcher.regex.test(haystack)) {
+      return matcher.key;
+    }
+  }
+  return null;
+}
+
+function coerceNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function computeWorkflowStats(suite: EvaliteSuite, workflowKey: string): WorkflowInsightStats {
+  const evals = Array.isArray(suite.evals) ? suite.evals : [];
+  const providerStats = new Map<string, {
+    provider: string;
+    models: Set<string>;
+    caseCount: number;
+    latencySum: number;
+    latencyCount: number;
+    costSum: number;
+    costCount: number;
+    avgScoreSum: number;
+    avgScoreCount: number;
+    scorerSums: Map<string, { sum: number; count: number }>;
+    confidencePositiveSum: number;
+    confidencePositiveCount: number;
+    confidencePositiveMin?: number;
+    confidencePositiveMax?: number;
+    confidenceNegativeSum: number;
+    confidenceNegativeCount: number;
+    confidenceNegativeMin?: number;
+    confidenceNegativeMax?: number;
+  }>();
+  const overallScorers = new Map<string, { sum: number; count: number }>();
+  const providers = new Set<string>();
+  const assets = new Set<string>();
+  let suiteDurationMs = coerceNumber(suite.duration);
+  let suiteDurationFallbackSum = 0;
+  let suiteDurationFallbackCount = 0;
+
+  for (const item of evals) {
+    if (!isRecord(item)) {
+      continue;
+    }
+
+    const evalRecord = item as EvaliteRecord;
+    const input = isRecord(evalRecord.input) ? evalRecord.input : {};
+    const output = isRecord(evalRecord.output) ? evalRecord.output : {};
+    const expected = isRecord(evalRecord.expected) ? evalRecord.expected : {};
+
+    const assetId =
+      typeof input.assetId === "string" ?
+        input.assetId :
+        typeof output.assetId === "string" ?
+          output.assetId :
+          undefined;
+    if (assetId) {
+      assets.add(assetId);
+    }
+
+    const provider =
+      typeof output.provider === "string" ?
+        output.provider :
+        typeof input.provider === "string" ?
+          input.provider :
+          undefined;
+    const model =
+      typeof output.model === "string" ?
+        output.model :
+        typeof input.model === "string" ?
+          input.model :
+          undefined;
+
+    if (!provider) {
+      continue;
+    }
+
+    providers.add(provider);
+    const stats = providerStats.get(provider) ?? {
+      provider,
+      models: new Set<string>(),
+      caseCount: 0,
+      latencySum: 0,
+      latencyCount: 0,
+      costSum: 0,
+      costCount: 0,
+      avgScoreSum: 0,
+      avgScoreCount: 0,
+      scorerSums: new Map(),
+      confidencePositiveSum: 0,
+      confidencePositiveCount: 0,
+      confidencePositiveMin: undefined,
+      confidencePositiveMax: undefined,
+      confidenceNegativeSum: 0,
+      confidenceNegativeCount: 0,
+      confidenceNegativeMin: undefined,
+      confidenceNegativeMax: undefined,
+    };
+
+    stats.caseCount += 1;
+    if (model) {
+      stats.models.add(model);
+    }
+
+    const latency =
+      coerceNumber(output.latencyMs) ??
+      coerceNumber(evalRecord.duration);
+    if (typeof latency === "number") {
+      stats.latencySum += latency;
+      stats.latencyCount += 1;
+    }
+
+    const duration = coerceNumber(evalRecord.duration);
+    if (typeof duration === "number") {
+      suiteDurationFallbackSum += duration;
+      suiteDurationFallbackCount += 1;
+    }
+
+    const cost = coerceNumber(output.estimatedCostUsd);
+    if (typeof cost === "number") {
+      stats.costSum += cost;
+      stats.costCount += 1;
+    }
+
+    const avgScore = coerceNumber(evalRecord.averageScore);
+    if (typeof avgScore === "number") {
+      stats.avgScoreSum += avgScore;
+      stats.avgScoreCount += 1;
+    }
+
+    if (Array.isArray(evalRecord.scores)) {
+      for (const scoreItem of evalRecord.scores) {
+        if (!scoreItem) {
+          continue;
+        }
+        const scorerName = typeof scoreItem.name === "string" ? scoreItem.name : undefined;
+        const scoreValue = coerceNumber(scoreItem.score);
+        if (!scorerName || typeof scoreValue !== "number") {
+          continue;
+        }
+        const scorer = stats.scorerSums.get(scorerName) ?? { sum: 0, count: 0 };
+        scorer.sum += scoreValue;
+        scorer.count += 1;
+        stats.scorerSums.set(scorerName, scorer);
+
+        const overall = overallScorers.get(scorerName) ?? { sum: 0, count: 0 };
+        overall.sum += scoreValue;
+        overall.count += 1;
+        overallScorers.set(scorerName, overall);
+      }
+    }
+
+    if (workflowKey === "burned_in_captions") {
+      const expectedHasCaptions = typeof expected.hasBurnedInCaptions === "boolean" ?
+        expected.hasBurnedInCaptions :
+        undefined;
+      const confidence = coerceNumber(output.confidence);
+      if (typeof expectedHasCaptions === "boolean" && typeof confidence === "number") {
+        if (expectedHasCaptions) {
+          stats.confidencePositiveSum += confidence;
+          stats.confidencePositiveCount += 1;
+          stats.confidencePositiveMin =
+            typeof stats.confidencePositiveMin === "number" ?
+                Math.min(stats.confidencePositiveMin, confidence) :
+              confidence;
+          stats.confidencePositiveMax =
+            typeof stats.confidencePositiveMax === "number" ?
+                Math.max(stats.confidencePositiveMax, confidence) :
+              confidence;
+        } else {
+          stats.confidenceNegativeSum += confidence;
+          stats.confidenceNegativeCount += 1;
+          stats.confidenceNegativeMin =
+            typeof stats.confidenceNegativeMin === "number" ?
+                Math.min(stats.confidenceNegativeMin, confidence) :
+              confidence;
+          stats.confidenceNegativeMax =
+            typeof stats.confidenceNegativeMax === "number" ?
+                Math.max(stats.confidenceNegativeMax, confidence) :
+              confidence;
+        }
+      }
+    }
+
+    providerStats.set(provider, stats);
+  }
+
+  if (!suiteDurationMs && suiteDurationFallbackCount > 0) {
+    suiteDurationMs = suiteDurationFallbackSum;
+  }
+
+  const providerSummaries: ProviderStats[] = Array.from(providerStats.values()).map((stats) => {
+    const scorerAverages: Record<string, number> = {};
+    for (const [name, scorer] of stats.scorerSums.entries()) {
+      if (scorer.count > 0) {
+        scorerAverages[name] = scorer.sum / scorer.count;
+      }
+    }
+
+    const confidence =
+      stats.confidencePositiveCount || stats.confidenceNegativeCount ?
+          {
+            positiveAvg:
+          stats.confidencePositiveCount > 0 ?
+            stats.confidencePositiveSum / stats.confidencePositiveCount :
+            undefined,
+            negativeAvg:
+          stats.confidenceNegativeCount > 0 ?
+            stats.confidenceNegativeSum / stats.confidenceNegativeCount :
+            undefined,
+            positiveRange:
+          typeof stats.confidencePositiveMin === "number" &&
+          typeof stats.confidencePositiveMax === "number" ?
+              [stats.confidencePositiveMin, stats.confidencePositiveMax] as [number, number] :
+            undefined,
+            negativeRange:
+          typeof stats.confidenceNegativeMin === "number" &&
+          typeof stats.confidenceNegativeMax === "number" ?
+              [stats.confidenceNegativeMin, stats.confidenceNegativeMax] as [number, number] :
+            undefined,
+          } :
+        undefined;
+
+    const models = Array.from(stats.models);
+    return {
+      provider: stats.provider,
+      model: models.length === 1 ? models[0] : undefined,
+      models: models.length > 1 ? models : undefined,
+      caseCount: stats.caseCount,
+      avgLatencyMs:
+        stats.latencyCount > 0 ? stats.latencySum / stats.latencyCount : undefined,
+      avgCostUsd: stats.costCount > 0 ? stats.costSum / stats.costCount : undefined,
+      avgScore:
+        stats.avgScoreCount > 0 ? stats.avgScoreSum / stats.avgScoreCount : undefined,
+      scorerAverages: Object.keys(scorerAverages).length > 0 ? scorerAverages : undefined,
+      confidence,
+    };
+  });
+
+  const recommendationFromSummary = (summary: ProviderStats): ProviderRecommendation => ({
+    provider: summary.provider,
+    model: summary.model ?? summary.models?.[0],
+  });
+
+  const qualityCandidate = providerSummaries
+    .filter(summary => typeof summary.avgScore === "number")
+    .sort((a, b) => (b.avgScore ?? 0) - (a.avgScore ?? 0))[0];
+  const latencyCandidate = providerSummaries
+    .filter(summary => typeof summary.avgLatencyMs === "number")
+    .sort(
+      (a, b) =>
+        (a.avgLatencyMs ?? Number.POSITIVE_INFINITY) -
+        (b.avgLatencyMs ?? Number.POSITIVE_INFINITY),
+    )[0];
+  const expenseCandidate = providerSummaries
+    .filter(summary => typeof summary.avgCostUsd === "number")
+    .sort(
+      (a, b) =>
+        (a.avgCostUsd ?? Number.POSITIVE_INFINITY) -
+        (b.avgCostUsd ?? Number.POSITIVE_INFINITY),
+    )[0];
+
+  const recommendations = {
+    quality: qualityCandidate ? recommendationFromSummary(qualityCandidate) : undefined,
+    latency: latencyCandidate ? recommendationFromSummary(latencyCandidate) : undefined,
+    expense: expenseCandidate ? recommendationFromSummary(expenseCandidate) : undefined,
+  };
+
+  const overallScorerAverages: Record<string, number> = {};
+  for (const [name, scorer] of overallScorers.entries()) {
+    if (scorer.count > 0) {
+      overallScorerAverages[name] = scorer.sum / scorer.count;
+    }
+  }
+
+  const notes: string[] = [];
+  if (evals.length > 0 && evals.length < 10) {
+    notes.push("Small sample size (<10 cases).");
+  }
+
+  return {
+    workflowKey,
+    workflowName: suite.name ?? workflowKey,
+    suiteStatus: suite.status,
+    suiteAverageScore: coerceNumber(suite.averageScore),
+    suiteDurationMs,
+    suiteCreatedAt: suite.createdAt,
+    caseCount: evals.length,
+    assetCount: assets.size || undefined,
+    providerCount: providers.size,
+    providers: providerSummaries,
+    scorerAverages: Object.keys(overallScorerAverages).length > 0 ?
+      overallScorerAverages :
+      undefined,
+    recommendations:
+      recommendations.quality || recommendations.latency || recommendations.expense ?
+        recommendations :
+        undefined,
+    notes: notes.length > 0 ? notes : undefined,
+  };
+}
+
+async function generateWorkflowInsights(suites: EvaliteSuite[]) {
+  const model = openai("gpt-5.1");
+  const insights: WorkflowInsightPayload[] = [];
+  const systemPrompt = dedent`
+    <role>
+      You are an analyst summarizing AI evaluation results for engineering stakeholders.
+    </role>
+    <constraints>
+      Use ASCII-only Markdown.
+      Do not invent numbers or claims that are not in the provided metrics.
+      Omit sections that lack supporting data.
+    </constraints>
+    <style>
+      Concise, factual, and practical.
+      Prefer 1-3 bullets per section.
+    </style>`;
+
+  for (const suite of suites) {
+    const workflowKey = resolveWorkflowKey(suite);
+    if (!workflowKey) {
+      continue;
+    }
+
+    const stats = computeWorkflowStats(suite, workflowKey);
+    const userPrompt = dedent`
+      <task>
+        Write a concise evaluation summary for the workflow using the metrics JSON.
+      </task>
+      <output_format>
+        Return a JSON object with:
+        - summaryMarkdown: full Markdown summary
+        - tldr: a single-sentence takeaway (optional)
+        - caveat: a concise caveat (optional)
+      </output_format>
+      <markdown_template>
+        **{Workflow Name} Evals Summary ({caseCount} runs, {providerCount} providers)**
+
+        **Accuracy**
+        - ...
+
+        **Latency**
+        - ...
+
+        **Cost**
+        - ...
+
+        **Caveat**
+        - ...
+
+        **TLDR**
+        - ...
+      </markdown_template>
+      <rules>
+        If notes mention small sample size, include a caveat in summaryMarkdown and caveat.
+      </rules>
+      <metrics_json>
+        ${JSON.stringify(stats, null, 2)}
+      </metrics_json>`;
+
+    const result = await generateObject({
+      model,
+      schema: WorkflowInsightSchema,
+      messages: [
+        { role: "system", content: systemPrompt },
+        { role: "user", content: userPrompt },
+      ],
+    });
+
+    insights.push({
+      workflowKey,
+      workflowName: stats.workflowName,
+      summaryMarkdown: result.object.summaryMarkdown.trim(),
+      tldr: result.object.tldr?.trim(),
+      caveat: result.object.caveat?.trim(),
+      stats,
+      recommendations: stats.recommendations,
+    });
+  }
+
+  return {
+    model: { provider: "openai", modelId: "gpt-5.1" },
+    insights,
+  };
+}
+
 const program = new Command();
 
 program
@@ -107,6 +607,11 @@ program
       const resultsPath = path.resolve(process.cwd(), "evalite-results.json");
       const raw = await readFile(resultsPath, "utf8");
       const results = JSON.parse(raw) as unknown;
+      const suites = isRecord(results) && Array.isArray(results.suites) ?
+          (results.suites as EvaliteSuite[]) :
+          [];
+
+      const { model, insights } = await generateWorkflowInsights(suites);
 
       const payload: EvaliteEnvelope = {
         repo,
@@ -117,6 +622,11 @@ program
         status: "completed",
         evaliteVersion: process.env.EVALITE_VERSION,
         results,
+        insights: {
+          generatedAt: new Date().toISOString(),
+          model,
+          workflows: insights,
+        },
       };
 
       if (options.dryRun) {

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -176,6 +176,7 @@ function resolveRef() {
 
 const WORKFLOW_MATCHERS = [
   { key: "burned_in_captions", regex: /burned[- ]in[- ]captions/i },
+  { key: "chapters", regex: /chapters?/i },
   { key: "translate_captions", regex: /translate[- ]captions/i },
   { key: "summarization", regex: /summarization/i },
 ] as const;
@@ -728,6 +729,13 @@ program
         allSuites;
 
       if (options.workflows && options.workflows.length > 0) {
+        const presentKeys = new Set(
+          suites.map(suite => resolveWorkflowKey(suite)).filter(Boolean) as WorkflowKey[],
+        );
+        const missing = options.workflows.filter(key => !presentKeys.has(key));
+        if (missing.length > 0) {
+          throw new Error(`Requested workflow(s) not found in evalite-results.json: ${missing.join(", ")}`);
+        }
         console.warn(`📋 Filtering results to workflows: ${options.workflows.join(", ")}`);
       }
 

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -101,6 +101,7 @@ interface EvaliteEnvelope {
   githubRunAttempt?: number;
   status: "completed";
   evaliteVersion?: string;
+  packageVersion?: string;
   results: unknown;
   insights: {
     generatedAt: string;
@@ -607,6 +608,14 @@ program
       const resultsPath = path.resolve(process.cwd(), "evalite-results.json");
       const raw = await readFile(resultsPath, "utf8");
       const results = JSON.parse(raw) as unknown;
+      const packageJsonPath = path.resolve(process.cwd(), "package.json");
+      const packageJsonRaw = await readFile(packageJsonPath, "utf8");
+      const packageJson = JSON.parse(packageJsonRaw) as {
+        version?: string;
+        devDependencies?: Record<string, string>;
+      };
+      const packageVersion = packageJson.version;
+      const evaliteVersion = packageJson.devDependencies?.evalite;
       const suites = isRecord(results) && Array.isArray(results.suites) ?
           (results.suites as EvaliteSuite[]) :
           [];
@@ -620,7 +629,8 @@ program
         githubRunId: process.env.GITHUB_RUN_ID ? Number(process.env.GITHUB_RUN_ID) : undefined,
         githubRunAttempt: process.env.GITHUB_RUN_ATTEMPT ? Number(process.env.GITHUB_RUN_ATTEMPT) : undefined,
         status: "completed",
-        evaliteVersion: process.env.EVALITE_VERSION,
+        evaliteVersion,
+        packageVersion,
         results,
         insights: {
           generatedAt: new Date().toISOString(),

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -113,7 +113,7 @@ interface EvaliteEnvelope {
   };
 }
 
-function execGit(command: string) {
+function exec(command: string) {
   return execSync(command, { encoding: "utf8" }).trim();
 }
 
@@ -128,7 +128,7 @@ function resolveRepo() {
   }
 
   try {
-    const remote = execGit("git config --get remote.origin.url");
+    const remote = exec("git config --get remote.origin.url");
     const parsed = parseRepoFromRemote(remote);
     if (parsed) {
       return parsed;
@@ -146,7 +146,7 @@ function resolveSha() {
   }
 
   try {
-    return execGit("git rev-parse HEAD");
+    return exec("git rev-parse HEAD");
   } catch {
     return null;
   }
@@ -162,7 +162,7 @@ function resolveRef() {
   }
 
   try {
-    return execGit("git rev-parse --abbrev-ref HEAD");
+    return exec("git rev-parse --abbrev-ref HEAD");
   } catch {
     return null;
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -23,6 +23,10 @@ const EnvSchema = z.object({
 
   MUX_TOKEN_ID: requiredString("Mux access token ID.", "Required to access Mux APIs"),
   MUX_TOKEN_SECRET: requiredString("Mux access token secret.", "Required to access Mux APIs"),
+  EVALITE_INGEST_SECRET: optionalString(
+    "Shared secret for posting Evalite results.",
+    "Evalite ingest secret",
+  ),
 
   MUX_SIGNING_KEY: optionalString("Mux signing key ID for signed playback URLs.", "Used to sign playback URLs"),
   MUX_PRIVATE_KEY: optionalString("Mux signing private key for signed playback URLs.", "Used to sign playback URLs"),
@@ -51,6 +55,11 @@ const EnvSchema = z.object({
   S3_BUCKET: optionalString("Bucket used for caption and audio uploads.", "S3 bucket"),
   S3_ACCESS_KEY_ID: optionalString("Access key ID for S3-compatible uploads.", "S3 access key id"),
   S3_SECRET_ACCESS_KEY: optionalString("Secret access key for S3-compatible uploads.", "S3 secret access key"),
+
+  EVALITE_RESULTS_ENDPOINT: optionalString(
+    "Full URL for posting Evalite results (e.g., https://example.com/api/evalite-results).",
+    "Evalite results endpoint",
+  ),
 });
 
 export type Env = z.infer<typeof EnvSchema>;


### PR DESCRIPTION
# Overview

Migrates evalite results publishing from GitHub Pages to an API-based ingest system. Instead of exporting a static UI to Pages, evals now run and POST raw JSON results to a configured endpoint (used by `evaluating-mux-ai`).

# What was changed

| File | Change |
|------|--------|
| `scripts/export-evalite-results.ts` | New script to run evalite and output `evalite-results.json` |
| `scripts/post-evalite-results.ts` | New script to POST results to API with repo/sha/ref metadata |
| `.github/workflows/publish-evalite-results.yml` | Replaced GitHub Pages deploy with API POST workflow |
| `src/env.ts` | Added `EVALITE_RESULTS_ENDPOINT` and `EVALITE_INGEST_SECRET` env vars |
| `package.json` | Added `evalite:post-results:dev` and `evalite:post-results:production` scripts |
| `docs/EVALS.md` | Updated CI/CD docs to reflect new flow |
| `.env.example` | Added new env var examples |
| `.gitignore` | Ignore `evalite-results.json` |

# Suggested review order

1. `scripts/post-evalite-results.ts` — Core logic: builds envelope with git metadata, POSTs to endpoint
2. `scripts/export-evalite-results.ts` — Simple runner that outputs JSON
3. `.github/workflows/publish-evalite-results.yml` — CI integration
4. `src/env.ts` — Env schema additions
5. `docs/EVALS.md` — Documentation updates

# Key details

- **Auth**: Uses `x-evalite-secret` header with `EVALITE_INGEST_SECRET`
- **Metadata**: Payload includes `repo`, `sha`, `ref`, `githubRunId`, `githubRunAttempt`
- **CLI flags**: `--dry-run` (-d) prints payload without posting; `--keep-file` (-k) skips deleting the JSON
- **Cleanup**: Results file deleted after successful POST (unless `--keep-file`)
