### PR TITLE
chore: move test ids into env vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,14 +42,15 @@ npm install
 ### Environment Configuration
 
 ```bash
-# Copy the example environment file
-cp .env.example .env
+# Copy the example test environment file
+cp env.test.example .env.test
 
-# Edit .env with your credentials
+# Edit .env.test with your credentials
 # You'll need:
 # - Mux credentials (MUX_TOKEN_ID, MUX_TOKEN_SECRET)
 # - At least one AI provider API key (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
 # - S3 credentials if testing translation workflows
+# - Mux test asset IDs (MUX_TEST_ASSET_ID, etc.) if running integration tests with your own Mux env
 ```
 
 > **💡 Tip:** You don't need all credentials—only those for the workflows you're testing.
@@ -131,6 +132,21 @@ npm run test:integration
 # Run LLM evaluation tests
 npm run test:eval
 ```
+
+### Integration test assets (Mux)
+
+Integration tests call real Mux + AI provider APIs, so they require:
+
+- **Mux credentials**: `MUX_TOKEN_ID`, `MUX_TOKEN_SECRET`
+- **Assets that exist in the same Mux environment as those credentials**
+
+By default, the repo’s integration tests use Mux-owned demo assets (hard-coded defaults). If you’re using your own Mux credentials, override the asset IDs via env vars in `.env.test`:
+
+- **`MUX_TEST_ASSET_ID`**: General-purpose asset used by most workflow integration tests (recommended: has an English transcript/captions track).
+- **`MUX_TEST_ASSET_ID_VIOLENT`**: Asset likely to score above the violence threshold in moderation tests.
+- **`MUX_TEST_ASSET_ID_BURNED_IN_CAPTIONS`**: Asset with clearly visible burned-in (hardcoded) captions.
+
+For the canonical list of env vars + what each test asset is expected to represent, see `tests/helpers/mux-test-assets.ts`.
 
 ### Writing Tests
 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ Please see our **[Contributing Guide](./CONTRIBUTING.md)** for details on:
 - Submitting pull requests
 - Reporting issues
 
+> **Note on integration tests:** The integration suite runs against real Mux assets. If you want to run `npm run test:integration` with your own Mux credentials, you’ll also need to set Mux test asset IDs (see `env.test.example`, the “Integration test assets (Mux)” section in `CONTRIBUTING.md`, and `tests/helpers/mux-test-assets.ts` for the expected test asset IDs).
+
 For questions or discussions, feel free to [open an issue](https://github.com/muxinc/ai/issues).
 
 ## License

--- a/env.test.example
+++ b/env.test.example
@@ -1,0 +1,55 @@
+# Copy to `.env.test` for running tests in this repo.
+#
+# Test scripts are invoked with `DOTENV_CONFIG_PATH=.env.test`.
+#
+# NOTE: `.env.test` is gitignored.
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Mux (required for integration tests + most evals)
+# ──────────────────────────────────────────────────────────────────────────────
+MUX_TOKEN_ID=
+MUX_TOKEN_SECRET=
+
+# If your assets only have signed playback IDs (optional)
+MUX_SIGNING_KEY=
+MUX_PRIVATE_KEY=
+
+# ──────────────────────────────────────────────────────────────────────────────
+# AI Providers (set the ones you want to test)
+# ──────────────────────────────────────────────────────────────────────────────
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEY=
+
+# Moderation providers (optional)
+HIVE_API_KEY=
+
+# Audio dubbing provider (optional)
+ELEVENLABS_API_KEY=
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test Assets (integration tests)
+# ──────────────────────────────────────────────────────────────────────────────
+# These MUST exist in the same Mux environment as your MUX_TOKEN_* credentials.
+# If you omit them, tests default to Mux-owned demo assets (which only work with
+# Mux-internal creds).
+#
+# Recommended: a general-purpose asset with an English transcript/captions track.
+MUX_TEST_ASSET_ID=
+#
+# Recommended: an asset likely to score above violence threshold in moderation.
+MUX_TEST_ASSET_ID_VIOLENT=
+#
+# Recommended: an asset with clearly visible burned-in captions.
+MUX_TEST_ASSET_ID_BURNED_IN_CAPTIONS=
+
+# ──────────────────────────────────────────────────────────────────────────────
+# S3-Compatible Storage (required for translation workflows only if uploadToMux=true)
+# ──────────────────────────────────────────────────────────────────────────────
+S3_ENDPOINT=
+S3_REGION=
+S3_BUCKET=
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+
+

--- a/src/env.ts
+++ b/src/env.ts
@@ -35,6 +35,7 @@ const EnvSchema = z.object({
     "Mux burned-in captions test asset id",
   ),
   MUX_TEST_ASSET_ID_AUDIO_ONLY: optionalString("Mux test asset ID for audio-only assets.", "Mux test asset id for audio-only assets for testing"),
+  MUX_TEST_ASSET_ID_VIOLENT_AUDIO_ONLY: optionalString("Mux test asset ID for audio-only assets with violent content.", "Mux test asset id for audio-only assets with violent content for testing"),
 
   // AI Providers
   OPENAI_API_KEY: optionalString("OpenAI API key for OpenAI-backed workflows.", "OpenAI API key"),

--- a/src/env.ts
+++ b/src/env.ts
@@ -34,6 +34,7 @@ const EnvSchema = z.object({
     "Mux burned-in captions asset ID used by integration tests.",
     "Mux burned-in captions test asset id",
   ),
+  MUX_TEST_ASSET_ID_AUDIO_ONLY: optionalString("Mux test asset ID for audio-only assets.", "Mux test asset id for audio-only assets for testing"),
 
   // AI Providers
   OPENAI_API_KEY: optionalString("OpenAI API key for OpenAI-backed workflows.", "OpenAI API key"),

--- a/src/env.ts
+++ b/src/env.ts
@@ -27,6 +27,15 @@ const EnvSchema = z.object({
   MUX_SIGNING_KEY: optionalString("Mux signing key ID for signed playback URLs.", "Used to sign playback URLs"),
   MUX_PRIVATE_KEY: optionalString("Mux signing private key for signed playback URLs.", "Used to sign playback URLs"),
 
+  // Test-only helpers (used by this repo's integration tests)
+  MUX_TEST_ASSET_ID: optionalString("Mux asset ID used by integration tests.", "Mux test asset id"),
+  MUX_TEST_ASSET_ID_VIOLENT: optionalString("Mux violent asset ID used by integration tests.", "Mux violent test asset id"),
+  MUX_TEST_ASSET_ID_BURNED_IN_CAPTIONS: optionalString(
+    "Mux burned-in captions asset ID used by integration tests.",
+    "Mux burned-in captions test asset id",
+  ),
+
+  // AI Providers
   OPENAI_API_KEY: optionalString("OpenAI API key for OpenAI-backed workflows.", "OpenAI API key"),
   ANTHROPIC_API_KEY: optionalString("Anthropic API key for Claude-backed workflows.", "Anthropic API key"),
   GOOGLE_GENERATIVE_AI_API_KEY: optionalString("Google Generative AI API key for Gemini-backed workflows.", "Google Generative AI API key"),
@@ -34,6 +43,7 @@ const EnvSchema = z.object({
   ELEVENLABS_API_KEY: optionalString("ElevenLabs API key for audio translation.", "ElevenLabs API key"),
   HIVE_API_KEY: optionalString("Hive Visual Moderation API key.", "Hive API key"),
 
+  // S3-Compatible Storage (required for translation & audio dubbing)
   S3_ENDPOINT: optionalString("S3-compatible endpoint for uploads.", "S3 endpoint"),
   S3_REGION: optionalString("S3 region (defaults to 'auto' when omitted)."),
   S3_BUCKET: optionalString("Bucket used for caption and audio uploads.", "S3 bucket"),

--- a/tests/helpers/mux-test-assets.ts
+++ b/tests/helpers/mux-test-assets.ts
@@ -1,0 +1,25 @@
+import env from "../../src/env";
+
+/**
+ * Mux assets used by integration tests.
+ *
+ * Defaults point at Mux-owned demo assets, but you can override them to run tests
+ * against your own Mux environment by setting env vars in `.env.test`:
+ *
+ * - MUX_TEST_ASSET_ID
+ * - MUX_TEST_ASSET_ID_VIOLENT
+ * - MUX_TEST_ASSET_ID_BURNED_IN_CAPTIONS
+ */
+export const muxTestAssets = {
+  /**
+   * General purpose asset used by most workflows.
+   * Recommended: an asset with an English transcript/captions track.
+   */
+  assetId: env.MUX_TEST_ASSET_ID ?? "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk",
+
+  /** Recommended: an asset likely to score above violence threshold. */
+  violentAssetId: env.MUX_TEST_ASSET_ID_VIOLENT ?? "zYHICEOEbVJIdEfbZZ0048501iJjg9T4SgY00oPVWOaHNU",
+
+  /** Recommended: an asset with clearly visible burned-in captions. */
+  burnedInCaptionsAssetId: env.MUX_TEST_ASSET_ID_BURNED_IN_CAPTIONS ?? "atuutlT45YbyucKU15u0100p45fG2CoXfJOd02VWMg4m004",
+} as const;

--- a/tests/integration/burned-in-captions.test.ts
+++ b/tests/integration/burned-in-captions.test.ts
@@ -2,11 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { SupportedProvider } from "../../src/lib/providers";
 import { hasBurnedInCaptions } from "../../src/workflows";
-
-import "../../src/env";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("burned-in Captions Integration Tests", () => {
-  const testAssetId = "atuutlT45YbyucKU15u0100p45fG2CoXfJOd02VWMg4m004";
+  const testAssetId = muxTestAssets.burnedInCaptionsAssetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should return valid result for %s provider", async (provider) => {

--- a/tests/integration/burned-in-captions.test.workflowdevkit.ts
+++ b/tests/integration/burned-in-captions.test.workflowdevkit.ts
@@ -3,9 +3,10 @@ import { start } from "workflow/api";
 
 import type { SupportedProvider } from "../../src/lib/providers";
 import { hasBurnedInCaptions } from "../../src/workflows";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("Burned-in Captions Integration Tests for Workflow DevKit", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.burnedInCaptionsAssetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should detect burned-in captions with %s provider", async (provider) => {

--- a/tests/integration/chapters.test.ts
+++ b/tests/integration/chapters.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { generateChapters } from "../../src/workflows";
-
-import "../../src/env";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("chapters Integration Tests", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.assetId;
   const languageCode = "en";
 
   it("should generate chapters with OpenAI provider", async () => {

--- a/tests/integration/chapters.test.workflowdevkit.ts
+++ b/tests/integration/chapters.test.workflowdevkit.ts
@@ -3,9 +3,10 @@ import { start } from "workflow/api";
 
 import type { SupportedProvider } from "../../src/lib/providers";
 import { generateChapters } from "../../src/workflows";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("Chapters Integration Tests for Workflow DevKit", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.assetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should generate chapters with %s provider", async (provider) => {

--- a/tests/integration/embeddings.test.ts
+++ b/tests/integration/embeddings.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { generateVideoEmbeddings } from "../../src/workflows";
-
-import "../../src/env";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("embeddings Integration Tests", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.assetId;
 
   it("should generate embeddings with OpenAI provider", async () => {
     const result = await generateVideoEmbeddings(assetId, {

--- a/tests/integration/embeddings.test.workflowdevkit.ts
+++ b/tests/integration/embeddings.test.workflowdevkit.ts
@@ -3,9 +3,10 @@ import { start } from "workflow/api";
 
 import type { SupportedEmbeddingProvider } from "../../src/lib/providers";
 import { generateVideoEmbeddings } from "../../src/workflows";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("Embeddings Integration Tests for Workflow DevKit", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.assetId;
   const providers: SupportedEmbeddingProvider[] = ["openai", "google"];
 
   it.each(providers)("should generate embeddings with %s provider", async (provider) => {

--- a/tests/integration/moderation.test.ts
+++ b/tests/integration/moderation.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { getModerationScores } from "../../src/workflows";
-
-import "../../src/env";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("moderation Integration Tests", () => {
-  const safeAsset = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
-  const violentAsset = "zYHICEOEbVJIdEfbZZ0048501iJjg9T4SgY00oPVWOaHNU";
+  const safeAsset = muxTestAssets.assetId;
+  const violentAsset = muxTestAssets.violentAssetId;
 
   // Define reasonable thresholds for classification
   const VIOLENCE_THRESHOLD = 0.5;

--- a/tests/integration/moderation.test.workflowdevkit.ts
+++ b/tests/integration/moderation.test.workflowdevkit.ts
@@ -3,9 +3,10 @@ import { start } from "workflow/api";
 
 import type { ModerationProvider } from "../../src/workflows";
 import { getModerationScores } from "../../src/workflows";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("Moderation Integration Tests for Workflow DevKit", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.assetId;
   const providers: ModerationProvider[] = ["openai"];
 
   it.each(providers)("should get moderation scores with %s provider", async (provider) => {

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -3,11 +3,10 @@ import { describe, expect, it } from "vitest";
 import type { SupportedProvider } from "../../src/lib/providers";
 import type { ToneType } from "../../src/types";
 import { getSummaryAndTags } from "../../src/workflows";
-
-import "../../src/env";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("summarization Integration Tests", () => {
-  const testAssetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const testAssetId = muxTestAssets.assetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should return valid result for %s provider", async (provider) => {

--- a/tests/integration/summarization.test.workflowdevkit.ts
+++ b/tests/integration/summarization.test.workflowdevkit.ts
@@ -3,9 +3,10 @@ import { start } from "workflow/api";
 
 import type { SupportedProvider } from "../../src/lib/providers";
 import { getSummaryAndTags } from "../../src/workflows";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("summarization Integration Tests", () => {
-  const testAssetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const testAssetId = muxTestAssets.assetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should return a run with a runId for each provider", async (provider) => {

--- a/tests/integration/translate-audio.test.ts
+++ b/tests/integration/translate-audio.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { translateAudio } from "../../src/workflows";
-
-import "../../src/env";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("audio Translation Integration Tests", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.assetId;
 
   it("should translate audio to French without uploading to Mux", async () => {
     const result = await translateAudio(assetId, "fr", {

--- a/tests/integration/translate-audio.test.workflowdevkit.ts
+++ b/tests/integration/translate-audio.test.workflowdevkit.ts
@@ -2,9 +2,10 @@ import { describe, expect, it } from "vitest";
 import { start } from "workflow/api";
 
 import { translateAudio } from "../../src/workflows";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("audio Translation Integration Tests for Workflow DevKit", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.assetId;
 
   it("should translate audio to French without uploading to Mux", async () => {
     const run = await start(translateAudio, [assetId, "fr", {

--- a/tests/integration/translate-captions.test.ts
+++ b/tests/integration/translate-captions.test.ts
@@ -2,11 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { SupportedProvider } from "../../src/lib/providers";
 import { translateCaptions } from "../../src/workflows";
-
-import "../../src/env";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("translateCaptions Integration Tests", () => {
-  const testAssetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const testAssetId = muxTestAssets.assetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should return valid result for %s provider", async (provider) => {

--- a/tests/integration/translate-captions.test.workflowdevkit.ts
+++ b/tests/integration/translate-captions.test.workflowdevkit.ts
@@ -3,9 +3,10 @@ import { start } from "workflow/api";
 
 import type { SupportedProvider } from "../../src/lib/providers";
 import { translateCaptions } from "../../src/workflows";
+import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("Caption Translation Integration Tests for Workflow DevKit", () => {
-  const assetId = "88Lb01qNUqFJrOFMITk00Ck201F00Qmcbpc5qgopNV4fCOk";
+  const assetId = muxTestAssets.assetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should translate captions to French with %s provider without uploading to Mux", async (provider) => {


### PR DESCRIPTION
# Overview

This branch makes the integration test suite **configurable for external contributors** by centralizing Mux test asset IDs behind env vars (with sane defaults) and documenting the expected `.env.test` setup.

addresses #51 

# What was changed

- **Integration tests now use a shared test-asset helper** instead of hard-coded asset IDs:
  - Added `tests/helpers/mux-test-assets.ts` exporting `muxTestAssets` (`assetId`, `violentAssetId`, `burnedInCaptionsAssetId`).
  - Updated integration tests to import `muxTestAssets` and reference its IDs.
  - Removed per-test `import "../../src/env";` side-effect imports in favor of importing the helper (which loads env via `src/env.ts`).

- **Env schema extended with test-only variables** (optional):
  - `src/env.ts` adds `MUX_TEST_ASSET_ID`, `MUX_TEST_ASSET_ID_VIOLENT`, `MUX_TEST_ASSET_ID_BURNED_IN_CAPTIONS`.

- **Docs + developer experience updates**:
  - Added `env.test.example` as the canonical template for `.env.test` (gitignored).
  - `CONTRIBUTING.md` updated to recommend `cp env.test.example .env.test` and explains required integration-test assets and env vars.
  - `README.md` adds a short note pointing to the above docs for integration tests.

# Suggested review order

1. `tests/helpers/mux-test-assets.ts` (new) — single source of truth for integration-test asset IDs + env var overrides.
2. `src/env.ts` — new optional schema entries used by the helper.
3. `tests/integration/*.test.ts` and `tests/integration/*.test.workflowdevkit.ts` — mechanical swaps from hard-coded IDs to `muxTestAssets.*`.
4. `env.test.example` — new example env file aligned with test scripts using `DOTENV_CONFIG_PATH=.env.test`.
5. `CONTRIBUTING.md` + `README.md` — documentation updates guiding contributors through the new flow.
