### PR TITLE
feat: multi-tenant support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -67,7 +67,7 @@ Analyzes video thumbnails for inappropriate content using OpenAI's Moderation AP
   - `maxRetryDelay?: number` - Maximum delay between retries in milliseconds (default: 10000)
   - `exponentialBackoff?: boolean` - Whether to use exponential backoff (default: true)
 
-All credentials (`MUX_TOKEN_ID`, `MUX_TOKEN_SECRET`, `OPENAI_API_KEY`, `HIVE_API_KEY`) are automatically read from environment variables.
+Credentials (`MUX_TOKEN_ID`, `MUX_TOKEN_SECRET`, `OPENAI_API_KEY`, `HIVE_API_KEY`) are read from environment variables by default. For Workflow Dev Kit multi-tenant usage, pass encrypted `credentials` in options (see README).
 
 **Returns:**
 

--- a/docs/ENCRYPTED-SECRETS.md
+++ b/docs/ENCRYPTED-SECRETS.md
@@ -13,6 +13,124 @@ There are two phases, both running in Vercel serverless functions:
 When running inside a workflow runtime (or when `MUX_AI_WORKFLOW_SECRET_KEY` is set),
 passing plaintext `credentials` will throw an error to prevent accidental exposure.
 
+## Creating a Workflow Secret Key
+
+The `MUX_AI_WORKFLOW_SECRET_KEY` must be a 256-bit (32-byte) key encoded as
+base64. This key is used for AES-256-GCM encryption of your credentials.
+
+### Using OpenSSL
+
+Generate a cryptographically secure key with OpenSSL:
+
+```bash
+openssl rand -base64 32
+```
+
+This outputs a 44-character base64 string (32 bytes + padding) you can use
+directly as your secret key.
+
+### Using Node.js
+
+Generate a key programmatically with Node.js:
+
+```javascript
+const crypto = require("crypto");
+const key = crypto.randomBytes(32).toString("base64");
+console.log(key);
+```
+
+Or as a one-liner:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+
+### Storing the Key
+
+Store the generated key as an environment variable:
+
+```bash
+# .env or environment configuration
+MUX_AI_WORKFLOW_SECRET_KEY=your_base64_encoded_key_here
+```
+
+Keep this key secure and never commit it to version control.
+
+## Rotating the Workflow Secret Key
+
+Key rotation is the process of replacing an existing encryption key with a new
+one. You should rotate keys periodically or immediately if you suspect a key
+may have been compromised.
+
+### Key ID (`kid`) Support
+
+The `encryptForWorkflow` function accepts an optional third parameter—a key ID
+(`kid`)—that is stored in plaintext alongside the encrypted payload. This
+enables zero-downtime key rotation by allowing the execution host to identify
+which key was used for encryption.
+
+```typescript
+// Encrypt with a key ID
+const encrypted = await encryptForWorkflow(
+  credentials,
+  env.MUX_AI_WORKFLOW_SECRET_KEY!,
+  "key-2026-01", // key ID stored in payload.kid
+);
+```
+
+Security notes:
+- The `kid` is stored unencrypted—don't put sensitive data in it
+- If an attacker modifies `kid`, decryption simply fails—the wrong key can't
+  decrypt the payload
+
+### Rotation Strategy
+
+The built-in credential resolution always reads from `MUX_AI_WORKFLOW_SECRET_KEY`.
+For most use cases, a simple key swap works well:
+
+1. **Generate a new key** using the methods above.
+2. **Update `MUX_AI_WORKFLOW_SECRET_KEY`** on the execution host.
+3. **Deploy the change**.
+
+Any workflows triggered after the deployment will use the new key. Workflows
+already in progress will complete because credentials are decrypted at step
+execution time—if a step already started with the old key, it continues with
+those decrypted credentials.
+
+### Advanced: Zero-Downtime Rotation with Key IDs
+
+For zero-downtime rotation, you can use the `kid` field to tag encrypted payloads
+with a key identifier, then implement custom decryption logic that looks up the
+correct key. This requires bypassing the built-in credential resolution.
+
+```typescript
+import { decryptFromWorkflow, encryptForWorkflow } from "@mux/ai/workflows";
+
+// Trigger phase: tag payload with the key ID
+const encrypted = await encryptForWorkflow(
+  credentials,
+  process.env.MUX_AI_WORKFLOW_KEY_V2!,
+  "v2", // stored in payload.kid
+);
+
+// Execution phase: look up key by ID before decrypting
+function getKeyById(kid: string | undefined): string {
+  const keys: Record<string, string | undefined> = {
+    v1: process.env.MUX_AI_WORKFLOW_KEY_V1,
+    v2: process.env.MUX_AI_WORKFLOW_KEY_V2,
+  };
+  const key = keys[kid ?? "v1"];
+  if (!key) throw new Error(`Unknown key ID: ${kid}`);
+  return key;
+}
+
+const key = getKeyById(encrypted.kid);
+const decrypted = await decryptFromWorkflow(encrypted, key);
+```
+
+This approach lets you keep both keys active during the transition, then remove
+the old key once all in-flight workflows have completed.
+
 ## Example: Summarization (default providers only)
 
 `getSummaryAndTags` accepts the default language-model providers (`openai`,

--- a/docs/ENCRYPTED-SECRETS.md
+++ b/docs/ENCRYPTED-SECRETS.md
@@ -10,6 +10,9 @@ There are two phases, both running in Vercel serverless functions:
 - Trigger phase — your API route calls `start()` and passes encrypted credentials.
 - Execution phase — the workflow steps run in a separate serverless invocation; this is the execution host where decryption happens.
 
+When running inside a workflow runtime (or when `MUX_AI_WORKFLOW_SECRET_KEY` is set),
+passing plaintext `credentials` will throw an error to prevent accidental exposure.
+
 ## Example: Summarization (default providers only)
 
 `getSummaryAndTags` accepts the default language-model providers (`openai`,

--- a/docs/ENCRYPTED-SECRETS.md
+++ b/docs/ENCRYPTED-SECRETS.md
@@ -1,0 +1,90 @@
+# Encrypted Secrets
+
+This guide shows how encrypted credentials work with workflows and how provider
+type coverage narrows to each workflow's supported providers.
+
+## How this works on Vercel (serverless-only setup)
+
+There are two phases, both running in Vercel serverless functions:
+
+- Trigger phase — your API route calls `start()` and passes encrypted credentials.
+- Execution phase — the workflow steps run in a separate serverless invocation; this is the execution host where decryption happens.
+
+## Example: Summarization (default providers only)
+
+`getSummaryAndTags` accepts the default language-model providers (`openai`,
+`anthropic`, `google`). The type of `provider` is restricted to those values.
+
+```typescript
+import { start } from "workflow/api";
+import { encryptForWorkflow, getSummaryAndTags } from "@mux/ai/workflows";
+
+// Trigger phase (API route): encrypt before calling start()
+const workflowKey = process.env.MUX_AI_WORKFLOW_SECRET_KEY!;
+const encryptedCredentials = await encryptForWorkflow(
+  {
+    muxTokenId: "mux-token-id",
+    muxTokenSecret: "mux-token-secret",
+    openaiApiKey: "openai-api-key",
+  },
+  workflowKey,
+);
+
+// Execution phase happens later in a separate invocation.
+// The workflow runtime decrypts inside steps using MUX_AI_WORKFLOW_SECRET_KEY.
+const run = await start(getSummaryAndTags, [
+  "your-asset-id",
+  { provider: "openai", credentials: encryptedCredentials },
+]);
+```
+
+## Example: Moderation (workflow-specific providers)
+
+`getModerationScores` supports `openai` and `hive`. The `provider` type is
+limited to those values, even though `hive` is not a default language provider.
+
+```typescript
+import { start } from "workflow/api";
+import { encryptForWorkflow, getModerationScores } from "@mux/ai/workflows";
+
+const workflowKey = process.env.MUX_AI_WORKFLOW_SECRET_KEY!;
+const encryptedCredentials = await encryptForWorkflow(
+  {
+    muxTokenId: "mux-token-id",
+    muxTokenSecret: "mux-token-secret",
+    hiveApiKey: "hive-api-key",
+  },
+  workflowKey,
+);
+
+const run = await start(getModerationScores, [
+  "your-asset-id",
+  { provider: "hive", credentials: encryptedCredentials },
+]);
+```
+
+## Example: Audio Translation (workflow-specific provider)
+
+`translateAudio` only supports `elevenlabs`. The `provider` type is restricted
+to that value, and the helper resolves the API key from encrypted credentials.
+
+```typescript
+import { start } from "workflow/api";
+import { encryptForWorkflow, translateAudio } from "@mux/ai/workflows";
+
+const workflowKey = process.env.MUX_AI_WORKFLOW_SECRET_KEY!;
+const encryptedCredentials = await encryptForWorkflow(
+  {
+    muxTokenId: "mux-token-id",
+    muxTokenSecret: "mux-token-secret",
+    elevenLabsApiKey: "elevenlabs-api-key",
+  },
+  workflowKey,
+);
+
+const run = await start(translateAudio, [
+  "your-asset-id",
+  "es",
+  { provider: "elevenlabs", credentials: encryptedCredentials },
+]);
+```

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -268,7 +268,9 @@ const result = await translateCaptions(assetId, "en", "es", {
 });
 ```
 
-> **⚠️ Important:** Currently, the only way to set secrets is as ENV vars. The reason for this is to avoid leaking secrets into Workflow DevKit observability tooling. `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` are considered secrets. The other values for S3: `S3_ENDPOINT`, `S3_REGION` and `S3_BUCKET` are not considered secrets. They can be passed in explicitly at runtime.
+> **⚠️ Important:** Workflow Dev Kit serializes workflow inputs/outputs. Do not pass plaintext secrets as workflow args.
+> Use the `encryptForWorkflow` helper and pass `credentials` to workflows when running multi-tenant.
+> `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` must still be set as ENV vars on the execution host.
 
 
 **Why S3 Storage?**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
+import { version } from "../package.json";
+
+// Workflow credential utilities
+export { setWorkflowCredentialsProvider } from "./lib/workflow-credentials";
+export type { WorkflowCredentialsProvider } from "./lib/workflow-credentials";
+export { decryptFromWorkflow, encryptForWorkflow } from "./lib/workflow-crypto";
+export type { Encrypted, EncryptedPayload } from "./lib/workflow-crypto";
+
 // Entry points are intentionally shallow; import explicitly from primitives or workflows
 export * as primitives from "./primitives";
 export * from "./types";
 export * as workflows from "./workflows";
 
-export const version = "0.1.0";
+export { version };

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -1,11 +1,13 @@
 import env from "@mux/ai/env";
 import type {
+  ModelIdByProvider,
   ModelRequestOptions,
   SupportedProvider,
 } from "@mux/ai/lib/providers";
 import {
   resolveLanguageModel,
 } from "@mux/ai/lib/providers";
+import type { ApiKeyProvider } from "@mux/ai/lib/workflow-credentials";
 import { resolveMuxCredentials, resolveProviderApiKey } from "@mux/ai/lib/workflow-credentials";
 import type { WorkflowCredentialsInput } from "@mux/ai/types";
 
@@ -26,7 +28,7 @@ export async function getMuxCredentialsFromEnv(
  * Throws if the API key is not available.
  */
 export async function getApiKeyFromEnv(
-  provider: "openai" | "anthropic" | "google" | "hive" | "elevenlabs",
+  provider: ApiKeyProvider,
   credentials?: WorkflowCredentialsInput,
 ): Promise<string> {
   return resolveProviderApiKey(provider, credentials);
@@ -38,20 +40,24 @@ export interface ValidatedCredentials {
   openaiApiKey?: string;
   anthropicApiKey?: string;
   googleApiKey?: string;
+  hiveApiKey?: string;
+  elevenLabsApiKey?: string;
 }
 
 /**
  * Validates and retrieves credentials from options or environment variables.
  * This function is NOT a workflow step to avoid exposing credentials in step I/O.
  */
-export async function validateCredentials(
-  requiredProvider?: SupportedProvider,
+export async function validateCredentials<P extends ApiKeyProvider = SupportedProvider>(
+  requiredProvider?: P,
 ): Promise<ValidatedCredentials> {
   const muxTokenId = env.MUX_TOKEN_ID;
   const muxTokenSecret = env.MUX_TOKEN_SECRET;
   const openaiApiKey = env.OPENAI_API_KEY;
   const anthropicApiKey = env.ANTHROPIC_API_KEY;
   const googleApiKey = env.GOOGLE_GENERATIVE_AI_API_KEY;
+  const hiveApiKey = env.HIVE_API_KEY;
+  const elevenLabsApiKey = env.ELEVENLABS_API_KEY;
 
   if (!muxTokenId || !muxTokenSecret) {
     throw new Error(
@@ -77,30 +83,44 @@ export async function validateCredentials(
     );
   }
 
+  if (requiredProvider === "hive" && !hiveApiKey) {
+    throw new Error(
+      "Hive API key is required. Provide hiveApiKey in options or set HIVE_API_KEY environment variable.",
+    );
+  }
+
+  if (requiredProvider === "elevenlabs" && !elevenLabsApiKey) {
+    throw new Error(
+      "ElevenLabs API key is required. Provide elevenLabsApiKey in options or set ELEVENLABS_API_KEY environment variable.",
+    );
+  }
+
   return {
     muxTokenId,
     muxTokenSecret,
     openaiApiKey,
     anthropicApiKey,
     googleApiKey,
+    hiveApiKey,
+    elevenLabsApiKey,
   };
 }
 
-export interface WorkflowConfig {
+export interface WorkflowConfig<P extends SupportedProvider = SupportedProvider> {
   credentials: ValidatedCredentials;
-  provider: SupportedProvider;
-  modelId: string;
+  provider: P;
+  modelId: ModelIdByProvider[P];
 }
 
 /**
  * Validates credentials and resolves model configuration for a workflow.
  * This function is NOT a workflow step to avoid exposing credentials in step I/O.
  */
-export async function createWorkflowConfig(
-  options: ModelRequestOptions,
-  provider?: SupportedProvider,
-): Promise<WorkflowConfig> {
-  const providerToUse = provider || options.provider || "openai";
+export async function createWorkflowConfig<P extends SupportedProvider = SupportedProvider>(
+  options: ModelRequestOptions<P>,
+  provider?: P,
+): Promise<WorkflowConfig<P>> {
+  const providerToUse = provider || options.provider || ("openai" as P);
   const credentials = await validateCredentials(providerToUse);
   const resolved = resolveLanguageModel({
     ...options,
@@ -110,6 +130,6 @@ export async function createWorkflowConfig(
   return {
     credentials,
     provider: resolved.provider,
-    modelId: resolved.modelId as string,
+    modelId: resolved.modelId,
   };
 }

--- a/src/lib/client-factory.ts
+++ b/src/lib/client-factory.ts
@@ -6,54 +6,30 @@ import type {
 import {
   resolveLanguageModel,
 } from "@mux/ai/lib/providers";
+import { resolveMuxCredentials, resolveProviderApiKey } from "@mux/ai/lib/workflow-credentials";
+import type { WorkflowCredentialsInput } from "@mux/ai/types";
 
 /**
- * Gets Mux credentials from environment variables.
+ * Gets Mux credentials from workflow credentials or environment variables.
  * Used internally by workflow steps to avoid passing credentials through step I/O.
  * Throws if credentials are not available.
  */
-export function getMuxCredentialsFromEnv(): { muxTokenId: string; muxTokenSecret: string } {
-  const muxTokenId = env.MUX_TOKEN_ID;
-  const muxTokenSecret = env.MUX_TOKEN_SECRET;
-
-  if (!muxTokenId || !muxTokenSecret) {
-    throw new Error(
-      "Mux credentials are required. Set MUX_TOKEN_ID and MUX_TOKEN_SECRET environment variables.",
-    );
-  }
-
-  return { muxTokenId, muxTokenSecret };
+export async function getMuxCredentialsFromEnv(
+  credentials?: WorkflowCredentialsInput,
+): Promise<{ muxTokenId: string; muxTokenSecret: string }> {
+  return resolveMuxCredentials(credentials);
 }
 
 /**
- * Gets an API key from environment variables for the specified provider.
+ * Gets an API key from workflow credentials or environment variables for the specified provider.
  * Used internally by workflow steps to avoid passing credentials through step I/O.
  * Throws if the API key is not available.
  */
-export function getApiKeyFromEnv(provider: "openai" | "anthropic" | "google" | "hive" | "elevenlabs"): string {
-  const envVarMap: Record<string, string | undefined> = {
-    openai: env.OPENAI_API_KEY,
-    anthropic: env.ANTHROPIC_API_KEY,
-    google: env.GOOGLE_GENERATIVE_AI_API_KEY,
-    hive: env.HIVE_API_KEY,
-    elevenlabs: env.ELEVENLABS_API_KEY,
-  };
-
-  const apiKey = envVarMap[provider];
-  if (!apiKey) {
-    const envVarNames: Record<string, string> = {
-      openai: "OPENAI_API_KEY",
-      anthropic: "ANTHROPIC_API_KEY",
-      google: "GOOGLE_GENERATIVE_AI_API_KEY",
-      hive: "HIVE_API_KEY",
-      elevenlabs: "ELEVENLABS_API_KEY",
-    };
-    throw new Error(
-      `${provider} API key is required. Set ${envVarNames[provider]} environment variable.`,
-    );
-  }
-
-  return apiKey;
+export async function getApiKeyFromEnv(
+  provider: "openai" | "anthropic" | "google" | "hive" | "elevenlabs",
+  credentials?: WorkflowCredentialsInput,
+): Promise<string> {
+  return resolveProviderApiKey(provider, credentials);
 }
 
 export interface ValidatedCredentials {

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -1,7 +1,7 @@
 import Mux from "@mux/mux-node";
 
 import { getMuxCredentialsFromEnv } from "@mux/ai/lib/client-factory";
-import type { MuxAsset, PlaybackAsset, PlaybackPolicy } from "@mux/ai/types";
+import type { MuxAsset, PlaybackAsset, PlaybackPolicy, WorkflowCredentialsInput } from "@mux/ai/types";
 
 /**
  * Finds a usable playback ID for the given asset.
@@ -31,9 +31,10 @@ function getPlaybackId(asset: MuxAsset): { id: string; policy: PlaybackPolicy } 
 
 export async function getPlaybackIdForAsset(
   assetId: string,
+  credentials?: WorkflowCredentialsInput,
 ): Promise<PlaybackAsset> {
   "use step";
-  const { muxTokenId, muxTokenSecret } = getMuxCredentialsFromEnv();
+  const { muxTokenId, muxTokenSecret } = await getMuxCredentialsFromEnv(credentials);
   const mux = new Mux({
     tokenId: muxTokenId,
     tokenSecret: muxTokenSecret,

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -182,9 +182,9 @@ function requireEnv(value: string | undefined, name: string): string {
  * Use this in steps to instantiate models from config passed through workflow.
  * Fetches credentials internally from environment variables to avoid exposing them in step I/O.
  */
-export async function createLanguageModelFromConfig(
-  provider: SupportedProvider,
-  modelId: string,
+export async function createLanguageModelFromConfig<P extends SupportedProvider = SupportedProvider>(
+  provider: P,
+  modelId: ModelIdByProvider[P],
   credentials?: WorkflowCredentialsInput,
 ): Promise<LanguageModel> {
   switch (provider) {
@@ -215,9 +215,11 @@ export async function createLanguageModelFromConfig(
  * Use this in steps to instantiate embedding models from config passed through workflow.
  * Fetches credentials internally from environment variables to avoid exposing them in step I/O.
  */
-export async function createEmbeddingModelFromConfig(
-  provider: SupportedEmbeddingProvider,
-  modelId: string,
+export async function createEmbeddingModelFromConfig<
+  P extends SupportedEmbeddingProvider = SupportedEmbeddingProvider,
+>(
+  provider: P,
+  modelId: EmbeddingModelIdByProvider[P],
   credentials?: WorkflowCredentialsInput,
 ): Promise<EmbeddingModel<string>> {
   switch (provider) {

--- a/src/lib/workflow-credentials.ts
+++ b/src/lib/workflow-credentials.ts
@@ -131,8 +131,8 @@ export async function resolveMuxCredentials(
   return { muxTokenId, muxTokenSecret };
 }
 
-/** Supported AI/ML provider identifiers for API key resolution */
-type ProviderApiKey = "openai" | "anthropic" | "google" | "hive" | "elevenlabs";
+/** Supported AI/ML provider identifiers for API key resolution. */
+export type ApiKeyProvider = "openai" | "anthropic" | "google" | "hive" | "elevenlabs";
 
 /**
  * Resolves an API key for a specific AI/ML provider.
@@ -146,13 +146,13 @@ type ProviderApiKey = "openai" | "anthropic" | "google" | "hive" | "elevenlabs";
  * @throws Error if no API key is available for the specified provider
  */
 export async function resolveProviderApiKey(
-  provider: ProviderApiKey,
+  provider: ApiKeyProvider,
   credentials?: WorkflowCredentialsInput,
 ): Promise<string> {
   const resolved = await resolveWorkflowCredentials(credentials);
 
   // Map each provider to its credential field and env var fallback
-  const apiKeyMap: Record<ProviderApiKey, string | undefined> = {
+  const apiKeyMap: Record<ApiKeyProvider, string | undefined> = {
     openai: resolved.openaiApiKey ?? env.OPENAI_API_KEY,
     anthropic: resolved.anthropicApiKey ?? env.ANTHROPIC_API_KEY,
     google: resolved.googleApiKey ?? env.GOOGLE_GENERATIVE_AI_API_KEY,
@@ -170,7 +170,7 @@ export async function resolveProviderApiKey(
       google: "GOOGLE_GENERATIVE_AI_API_KEY",
       hive: "HIVE_API_KEY",
       elevenlabs: "ELEVENLABS_API_KEY",
-    } as const satisfies Record<ProviderApiKey, keyof Env>;
+    } as const satisfies Record<ApiKeyProvider, keyof Env>;
 
     throw new Error(
       `${provider} API key is required. Provide encrypted workflow credentials or set ${envVarNames[provider]} environment variable.`,

--- a/src/lib/workflow-credentials.ts
+++ b/src/lib/workflow-credentials.ts
@@ -119,8 +119,9 @@ export async function resolveWorkflowCredentials(
         getWorkflowSecretKeyFromEnv(),
       );
       return { ...resolved, ...decrypted };
-    } catch {
-      throw new Error("Failed to decrypt workflow credentials.");
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "Unknown error.";
+      throw new Error(`Failed to decrypt workflow credentials. ${detail}`);
     }
   }
 

--- a/src/lib/workflow-credentials.ts
+++ b/src/lib/workflow-credentials.ts
@@ -1,0 +1,203 @@
+/**
+ * Workflow Credentials Management
+ *
+ * This module provides a unified way to resolve credentials from multiple sources:
+ * 1. A custom credentials provider (set via `setWorkflowCredentialsProvider`)
+ * 2. Encrypted credentials passed directly to workflow functions
+ * 3. Environment variables as fallback
+ *
+ * Credentials are merged in order of precedence: direct input > provider > environment.
+ */
+import env from "@mux/ai/env";
+import type { Env } from "@mux/ai/env";
+import type { SigningContext } from "@mux/ai/lib/url-signing";
+import { decryptFromWorkflow, isEncryptedPayload } from "@mux/ai/lib/workflow-crypto";
+import type { WorkflowCredentials, WorkflowCredentialsInput } from "@mux/ai/types";
+
+/**
+ * A function that returns workflow credentials, either synchronously or asynchronously.
+ * Used to inject credentials from external sources (e.g., a secrets manager).
+ */
+export type WorkflowCredentialsProvider =
+  () => Promise<WorkflowCredentials | undefined> | WorkflowCredentials | undefined;
+
+/** Module-level credentials provider, set via `setWorkflowCredentialsProvider` */
+let workflowCredentialsProvider: WorkflowCredentialsProvider | undefined;
+
+/**
+ * Registers a custom credentials provider for the module.
+ * The provider will be called whenever credentials need to be resolved.
+ */
+export function setWorkflowCredentialsProvider(provider?: WorkflowCredentialsProvider): void {
+  workflowCredentialsProvider = provider;
+}
+
+/**
+ * Retrieves the workflow secret key from environment variables.
+ * This key is used to decrypt encrypted credential payloads.
+ */
+function getWorkflowSecretKeyFromEnv(): string {
+  const key = env.MUX_AI_WORKFLOW_SECRET_KEY;
+  if (!key) {
+    throw new Error("Workflow secret key is required. Set MUX_AI_WORKFLOW_SECRET_KEY environment variable.");
+  }
+  return key;
+}
+
+/**
+ * Invokes the registered credentials provider (if any) and validates the result.
+ */
+async function resolveProviderCredentials(): Promise<WorkflowCredentials | undefined> {
+  if (!workflowCredentialsProvider) {
+    return undefined;
+  }
+
+  const provided = await workflowCredentialsProvider();
+  if (!provided) {
+    return undefined;
+  }
+
+  if (typeof provided !== "object") {
+    throw new TypeError("Workflow credentials provider must return an object.");
+  }
+
+  return provided;
+}
+
+/**
+ * Resolves workflow credentials by merging from multiple sources.
+ *
+ * Resolution order (later sources override earlier):
+ * 1. Credentials from the registered provider
+ * 2. Decrypted credentials (if input is an encrypted payload)
+ *    OR plain credentials object (if input is already decrypted)
+ *
+ * @param credentials - Optional credentials input (encrypted or plain object)
+ * @returns Merged credentials object
+ */
+export async function resolveWorkflowCredentials(
+  credentials?: WorkflowCredentialsInput,
+): Promise<WorkflowCredentials> {
+  // Start with provider credentials as the base
+  const providerCredentials = await resolveProviderCredentials();
+  const resolved: WorkflowCredentials = providerCredentials ? { ...providerCredentials } : {};
+
+  if (!credentials) {
+    return resolved;
+  }
+
+  // Handle encrypted payloads by decrypting them first
+  if (isEncryptedPayload(credentials)) {
+    try {
+      const decrypted = decryptFromWorkflow<WorkflowCredentials>(credentials, getWorkflowSecretKeyFromEnv());
+      return { ...resolved, ...decrypted };
+    } catch {
+      throw new Error("Failed to decrypt workflow credentials.");
+    }
+  }
+
+  // Plain credentials object - merge directly
+  return { ...resolved, ...credentials };
+}
+
+/**
+ * Resolves Mux API credentials (token ID and secret).
+ *
+ * Checks resolved workflow credentials first, then falls back to environment variables.
+ * Throws if neither source provides valid credentials.
+ *
+ * @param credentials - Optional workflow credentials input
+ * @returns Object containing muxTokenId and muxTokenSecret
+ * @throws Error if Mux credentials are not available
+ */
+export async function resolveMuxCredentials(
+  credentials?: WorkflowCredentialsInput,
+): Promise<{ muxTokenId: string; muxTokenSecret: string }> {
+  const resolved = await resolveWorkflowCredentials(credentials);
+
+  // Try resolved credentials first, fall back to environment variables
+  const muxTokenId = resolved.muxTokenId ?? env.MUX_TOKEN_ID;
+  const muxTokenSecret = resolved.muxTokenSecret ?? env.MUX_TOKEN_SECRET;
+
+  if (!muxTokenId || !muxTokenSecret) {
+    throw new Error(
+      "Mux credentials are required. Provide encrypted workflow credentials or set MUX_TOKEN_ID and MUX_TOKEN_SECRET environment variables.",
+    );
+  }
+
+  return { muxTokenId, muxTokenSecret };
+}
+
+/** Supported AI/ML provider identifiers for API key resolution */
+type ProviderApiKey = "openai" | "anthropic" | "google" | "hive" | "elevenlabs";
+
+/**
+ * Resolves an API key for a specific AI/ML provider.
+ *
+ * Checks resolved workflow credentials first, then falls back to the
+ * provider-specific environment variable.
+ *
+ * @param provider - The provider identifier (e.g., "openai", "anthropic")
+ * @param credentials - Optional workflow credentials input
+ * @returns The resolved API key string
+ * @throws Error if no API key is available for the specified provider
+ */
+export async function resolveProviderApiKey(
+  provider: ProviderApiKey,
+  credentials?: WorkflowCredentialsInput,
+): Promise<string> {
+  const resolved = await resolveWorkflowCredentials(credentials);
+
+  // Map each provider to its credential field and env var fallback
+  const apiKeyMap: Record<ProviderApiKey, string | undefined> = {
+    openai: resolved.openaiApiKey ?? env.OPENAI_API_KEY,
+    anthropic: resolved.anthropicApiKey ?? env.ANTHROPIC_API_KEY,
+    google: resolved.googleApiKey ?? env.GOOGLE_GENERATIVE_AI_API_KEY,
+    hive: resolved.hiveApiKey ?? env.HIVE_API_KEY,
+    elevenlabs: resolved.elevenLabsApiKey ?? env.ELEVENLABS_API_KEY,
+  };
+
+  const apiKey = apiKeyMap[provider];
+  if (!apiKey) {
+    // Provide helpful error message with the correct env var name.
+    // Using `satisfies` ensures these stay in sync with the Env schema.
+    const envVarNames = {
+      openai: "OPENAI_API_KEY",
+      anthropic: "ANTHROPIC_API_KEY",
+      google: "GOOGLE_GENERATIVE_AI_API_KEY",
+      hive: "HIVE_API_KEY",
+      elevenlabs: "ELEVENLABS_API_KEY",
+    } as const satisfies Record<ProviderApiKey, keyof Env>;
+
+    throw new Error(
+      `${provider} API key is required. Provide encrypted workflow credentials or set ${envVarNames[provider]} environment variable.`,
+    );
+  }
+
+  return apiKey;
+}
+
+/**
+ * Resolves Mux URL signing context for generating signed playback URLs.
+ *
+ * Unlike other resolve functions, this returns undefined if signing keys
+ * are not configured (signing is optional for public assets).
+ *
+ * @param credentials - Optional workflow credentials input
+ * @returns SigningContext if keys are available, undefined otherwise
+ */
+export async function resolveMuxSigningContext(
+  credentials?: WorkflowCredentialsInput,
+): Promise<SigningContext | undefined> {
+  const resolved = await resolveWorkflowCredentials(credentials);
+
+  // Check both key components - both are required for signing
+  const keyId = resolved.muxSigningKey ?? env.MUX_SIGNING_KEY;
+  const keySecret = resolved.muxPrivateKey ?? env.MUX_PRIVATE_KEY;
+
+  if (!keyId || !keySecret) {
+    return undefined;
+  }
+
+  return { keyId, keySecret };
+}

--- a/src/lib/workflow-credentials.ts
+++ b/src/lib/workflow-credentials.ts
@@ -89,7 +89,10 @@ export async function resolveWorkflowCredentials(
   // Handle encrypted payloads by decrypting them first
   if (isEncryptedPayload(credentials)) {
     try {
-      const decrypted = decryptFromWorkflow<WorkflowCredentials>(credentials, getWorkflowSecretKeyFromEnv());
+      const decrypted = await decryptFromWorkflow<WorkflowCredentials>(
+        credentials,
+        getWorkflowSecretKeyFromEnv(),
+      );
       return { ...resolved, ...decrypted };
     } catch {
       throw new Error("Failed to decrypt workflow credentials.");

--- a/src/lib/workflow-crypto.ts
+++ b/src/lib/workflow-crypto.ts
@@ -55,10 +55,7 @@ function bytesToBase64(bytes: Uint8Array): string {
     const chunk = bytes.subarray(i, i + BASE64_CHUNK_SIZE);
     binary += String.fromCharCode(...chunk);
   }
-  if (typeof globalThis.btoa !== "function") {
-    throw new TypeError("Base64 encoder is not available in this environment.");
-  }
-  return globalThis.btoa(binary);
+  return btoa(binary);
 }
 
 function base64ToBytes(value: string, label: string): Uint8Array {
@@ -66,12 +63,9 @@ function base64ToBytes(value: string, label: string): Uint8Array {
     throw new Error(`${label} is missing`);
   }
   const normalized = value.length % 4 === 0 ? value : value + "=".repeat(4 - (value.length % 4));
-  if (typeof globalThis.atob !== "function") {
-    throw new TypeError("Base64 decoder is not available in this environment.");
-  }
   let binary: string;
   try {
-    binary = globalThis.atob(normalized);
+    binary = atob(normalized);
   } catch {
     throw new Error(`${label} is not valid base64`);
   }

--- a/src/lib/workflow-crypto.ts
+++ b/src/lib/workflow-crypto.ts
@@ -1,0 +1,200 @@
+/**
+ * Workflow Crypto
+ *
+ * Provides AES-256-GCM encryption for securely passing credentials to workflows.
+ * Encrypted payloads are JSON-serializable and include version/algorithm metadata
+ * for forward compatibility.
+ */
+
+import { Buffer } from "node:buffer";
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+// Encryption parameters (AES-256-GCM with standard IV/tag sizes)
+const WORKFLOW_ENCRYPTION_VERSION = 1;
+const WORKFLOW_ENCRYPTION_ALGORITHM = "aes-256-gcm" as const;
+const IV_LENGTH_BYTES = 12; // 96-bit IV per NIST recommendation for GCM
+const AUTH_TAG_LENGTH_BYTES = 16; // 128-bit authentication tag
+
+/**
+ * Structure of an encrypted payload (all fields are base64-encoded where applicable).
+ *
+ * The optional `kid` (key ID) field supports key rotation scenarios:
+ * - Include a `kid` when encrypting to identify which key was used
+ * - On decryption, read `payload.kid` to look up the correct key
+ * - Keys should be invalidated/deleted after rotation, not kept indefinitely
+ *
+ * Security notes:
+ * - `kid` is stored in plaintext (not encrypted) — don't put sensitive data in it
+ * - Tampering with `kid` doesn't weaken security — wrong key = decryption fails
+ */
+export interface EncryptedPayload {
+  v: typeof WORKFLOW_ENCRYPTION_VERSION;
+  alg: typeof WORKFLOW_ENCRYPTION_ALGORITHM;
+  kid?: string;
+  iv: string;
+  tag: string;
+  ciphertext: string;
+}
+
+/** Branded type that preserves the original type information for decryption */
+export type Encrypted<T> = EncryptedPayload & { __type?: T };
+
+/** Converts key to Buffer and validates it's exactly 32 bytes (256 bits) */
+function normalizeKey(key: Buffer | string): Buffer {
+  const keyBuffer = typeof key === "string" ? Buffer.from(key, "base64") : Buffer.from(key);
+
+  if (keyBuffer.length !== 32) {
+    throw new Error("Invalid workflow secret key. Expected 32-byte base64 value.");
+  }
+
+  return keyBuffer;
+}
+
+/** Decodes a base64 field from the payload with descriptive error messages */
+function decodeBase64(value: string, label: string): Buffer {
+  if (!value) {
+    throw new Error(`Invalid encrypted payload: missing ${label}.`);
+  }
+
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(value, "base64");
+  } catch {
+    throw new Error(`Invalid encrypted payload: ${label} is not base64.`);
+  }
+
+  if (buffer.length === 0) {
+    throw new Error(`Invalid encrypted payload: ${label} is empty.`);
+  }
+
+  return buffer;
+}
+
+/** Type guard to check if a value is a valid encrypted payload structure */
+export function isEncryptedPayload(value: unknown): value is EncryptedPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const payload = value as EncryptedPayload;
+  return (
+    payload.v === WORKFLOW_ENCRYPTION_VERSION &&
+    payload.alg === WORKFLOW_ENCRYPTION_ALGORITHM &&
+    typeof payload.iv === "string" &&
+    typeof payload.tag === "string" &&
+    typeof payload.ciphertext === "string"
+  );
+}
+
+/** Validates payload structure and cryptographic parameters before decryption */
+function assertEncryptedPayload(payload: EncryptedPayload): void {
+  if (payload.v !== WORKFLOW_ENCRYPTION_VERSION) {
+    throw new Error("Invalid encrypted payload: unsupported version.");
+  }
+
+  if (payload.alg !== WORKFLOW_ENCRYPTION_ALGORITHM) {
+    throw new Error("Invalid encrypted payload: unsupported algorithm.");
+  }
+
+  const iv = decodeBase64(payload.iv, "iv");
+  const tag = decodeBase64(payload.tag, "tag");
+
+  if (iv.length !== IV_LENGTH_BYTES) {
+    throw new Error("Invalid encrypted payload: iv length mismatch.");
+  }
+
+  if (tag.length !== AUTH_TAG_LENGTH_BYTES) {
+    throw new Error("Invalid encrypted payload: tag length mismatch.");
+  }
+
+  decodeBase64(payload.ciphertext, "ciphertext");
+}
+
+/**
+ * Encrypts a value for secure transport to a workflow.
+ *
+ * @param value - Any JSON-serializable value (typically WorkflowCredentials)
+ * @param key - 32-byte secret key (base64 string or Buffer)
+ * @param keyId - Optional key identifier for rotation support (stored in plaintext)
+ * @returns Encrypted payload with metadata, safe to pass through untrusted channels
+ *
+ * @example
+ * // Without key ID
+ * const encrypted = encryptForWorkflow(credentials, secretKey);
+ *
+ * // With key ID for rotation support
+ * const encrypted = encryptForWorkflow(credentials, secretKey, "key-2024-01");
+ */
+export function encryptForWorkflow<T>(
+  value: T,
+  key: Buffer | string,
+  keyId?: string,
+): Encrypted<T> {
+  const keyBuffer = normalizeKey(key);
+  const iv = randomBytes(IV_LENGTH_BYTES); // Fresh IV for each encryption
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new Error("Failed to serialize value for encryption.");
+  }
+
+  const cipher = createCipheriv(WORKFLOW_ENCRYPTION_ALGORITHM, keyBuffer, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(serialized, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag(); // GCM auth tag for tamper detection
+
+  return {
+    v: WORKFLOW_ENCRYPTION_VERSION,
+    alg: WORKFLOW_ENCRYPTION_ALGORITHM,
+    ...(keyId !== undefined && { kid: keyId }),
+    iv: iv.toString("base64"),
+    tag: tag.toString("base64"),
+    ciphertext: ciphertext.toString("base64"),
+  };
+}
+
+/**
+ * Decrypts and deserializes a workflow payload.
+ *
+ * @param payload - Encrypted payload from `encryptForWorkflow`
+ * @param key - Same 32-byte secret key used for encryption
+ * @returns The original decrypted value
+ * @throws If payload is invalid, tampered with, or key is wrong
+ *
+ * @example
+ * // With key rotation: read kid to look up the correct key
+ * const keyId = payload.kid ?? "default";
+ * const key = keyStore.get(keyId);
+ * const credentials = decryptFromWorkflow(payload, key);
+ */
+export function decryptFromWorkflow<T>(payload: EncryptedPayload, key: Buffer | string): T {
+  if (!isEncryptedPayload(payload)) {
+    throw new Error("Invalid encrypted payload.");
+  }
+
+  assertEncryptedPayload(payload);
+
+  const keyBuffer = normalizeKey(key);
+  const iv = decodeBase64(payload.iv, "iv");
+  const tag = decodeBase64(payload.tag, "tag");
+  const ciphertext = decodeBase64(payload.ciphertext, "ciphertext");
+
+  let plaintext: Buffer;
+  try {
+    const decipher = createDecipheriv(WORKFLOW_ENCRYPTION_ALGORITHM, keyBuffer, iv);
+    decipher.setAuthTag(tag); // Verifies integrity before returning plaintext
+    plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  } catch {
+    throw new Error("Failed to decrypt workflow payload.");
+  }
+
+  try {
+    return JSON.parse(plaintext.toString("utf8")) as T;
+  } catch {
+    throw new Error("Failed to parse decrypted payload.");
+  }
+}

--- a/src/lib/workflow-crypto.ts
+++ b/src/lib/workflow-crypto.ts
@@ -7,7 +7,6 @@
  */
 
 const BASE64_CHUNK_SIZE = 0x8000;
-const BASE64_ALPHABET_RE = /^[A-Z0-9+/]+={0,2}$/i;
 
 // Encryption parameters (AES-256-GCM with standard IV/tag sizes)
 const WORKFLOW_ENCRYPTION_VERSION = 1;
@@ -67,9 +66,6 @@ function base64ToBytes(value: string, label: string): Uint8Array {
     throw new Error(`${label} is missing`);
   }
   const normalized = value.length % 4 === 0 ? value : value + "=".repeat(4 - (value.length % 4));
-  if (!BASE64_ALPHABET_RE.test(normalized)) {
-    throw new Error(`${label} is not valid base64`);
-  }
   if (typeof globalThis.atob !== "function") {
     throw new TypeError("Base64 decoder is not available in this environment.");
   }

--- a/src/primitives/storyboards.ts
+++ b/src/primitives/storyboards.ts
@@ -1,4 +1,5 @@
-import { getMuxSigningContextFromEnv, signUrl } from "@mux/ai/lib/url-signing";
+import { signUrl } from "@mux/ai/lib/url-signing";
+import type { WorkflowCredentialsInput } from "@mux/ai/types";
 
 export const DEFAULT_STORYBOARD_WIDTH = 640;
 
@@ -15,14 +16,13 @@ export async function getStoryboardUrl(
   playbackId: string,
   width: number = DEFAULT_STORYBOARD_WIDTH,
   shouldSign: boolean = false,
+  credentials?: WorkflowCredentialsInput,
 ): Promise<string> {
   "use step";
   const baseUrl = `https://image.mux.com/${playbackId}/storyboard.png`;
 
   if (shouldSign) {
-    // NOTE: this assumes you have already validated the signing context elsewhere
-    const signingContext = getMuxSigningContextFromEnv();
-    return signUrl(baseUrl, playbackId, signingContext!, "storyboard", { width });
+    return signUrl(baseUrl, playbackId, undefined, "storyboard", { width }, credentials);
   }
 
   return `${baseUrl}?width=${width}`;

--- a/src/primitives/thumbnails.ts
+++ b/src/primitives/thumbnails.ts
@@ -1,4 +1,5 @@
-import { getMuxSigningContextFromEnv, signUrl } from "@mux/ai/lib/url-signing";
+import { signUrl } from "@mux/ai/lib/url-signing";
+import type { WorkflowCredentialsInput } from "@mux/ai/types";
 
 export interface ThumbnailOptions {
   /** Interval between thumbnails in seconds (default: 10) */
@@ -7,6 +8,8 @@ export interface ThumbnailOptions {
   width?: number;
   /** Flag for whether or not to use signed playback IDs (default: false) */
   shouldSign?: boolean;
+  /** Workflow credentials for signing (optional). */
+  credentials?: WorkflowCredentialsInput;
 }
 
 /**
@@ -24,7 +27,7 @@ export async function getThumbnailUrls(
   options: ThumbnailOptions = {},
 ): Promise<string[]> {
   "use step";
-  const { interval = 10, width = 640, shouldSign = false } = options;
+  const { interval = 10, width = 640, shouldSign = false, credentials } = options;
   const timestamps: number[] = [];
 
   if (duration <= 50) {
@@ -42,9 +45,7 @@ export async function getThumbnailUrls(
 
   const urlPromises = timestamps.map(async (time) => {
     if (shouldSign) {
-      // NOTE: this assumes you have already validated the signing context elsewhere
-      const signingContext = getMuxSigningContextFromEnv();
-      return signUrl(baseUrl, playbackId, signingContext!, "thumbnail", { time, width });
+      return signUrl(baseUrl, playbackId, undefined, "thumbnail", { time, width }, credentials);
     }
 
     return `${baseUrl}?time=${time}&width=${width}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Encrypted } from "@mux/ai/lib/workflow-crypto";
+
 import type Mux from "@mux/mux-node";
 
 /**
@@ -12,7 +14,31 @@ export interface MuxAIOptions {
    * cancelled where supported.
    */
   abortSignal?: AbortSignal;
+  /**
+   * Optional credentials for workflow execution.
+   * Use encryptForWorkflow when running in Workflow Dev Kit environments.
+   */
+  credentials?: WorkflowCredentialsInput;
 }
+
+/**
+ * Plaintext workflow credentials. Avoid passing these to Workflow Dev Kit start()
+ * unless you are not using workflow serialization.
+ */
+export interface WorkflowCredentials {
+  muxTokenId?: string;
+  muxTokenSecret?: string;
+  muxSigningKey?: string;
+  muxPrivateKey?: string;
+  openaiApiKey?: string;
+  anthropicApiKey?: string;
+  googleApiKey?: string;
+  hiveApiKey?: string;
+  elevenLabsApiKey?: string;
+}
+
+/** Credentials that are safe to serialize across workflow boundaries. */
+export type WorkflowCredentialsInput = WorkflowCredentials | Encrypted<WorkflowCredentials>;
 
 /** Tone controls for the summarization helper. */
 export type ToneType = "neutral" | "playful" | "professional";

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -5,8 +5,6 @@ import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
 import { getThumbnailUrls } from "@mux/ai/primitives/thumbnails";
 import type { ImageSubmissionMode, MuxAIOptions, WorkflowCredentialsInput } from "@mux/ai/types";
 
-import type { Buffer } from "node:buffer";
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -39,7 +37,7 @@ export type ModerationProvider = "openai" | "hive";
 
 export type HiveModerationSource =
   | { kind: "url"; value: string } |
-  { kind: "file"; buffer: Buffer; contentType: string };
+  { kind: "file"; buffer: Uint8Array; contentType: string };
 
 export interface HiveModerationOutput {
   classes?: Array<{

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -393,13 +393,6 @@ export async function translateAudio(
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
 
-  if (!isEncryptedPayload(credentials)) {
-    const elevenLabsKey = credentials?.elevenLabsApiKey ?? env.ELEVENLABS_API_KEY;
-    if (!elevenLabsKey) {
-      throw new Error("ElevenLabs API key is required. Provide elevenLabsApiKey in options or set ELEVENLABS_API_KEY environment variable.");
-    }
-  }
-
   if (uploadToMux && (!s3Endpoint || !s3Bucket || !s3AccessKeyId || !s3SecretAccessKey)) {
     throw new Error("S3 configuration is required for uploading to Mux. Provide s3Endpoint, s3Bucket, s3AccessKeyId, and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
   }

--- a/tests/unit/workflow-crypto.test.ts
+++ b/tests/unit/workflow-crypto.test.ts
@@ -5,26 +5,26 @@ import { describe, expect, it } from "vitest";
 import { decryptFromWorkflow, encryptForWorkflow } from "../../src/lib/workflow-crypto";
 
 describe("workflow crypto helpers", () => {
-  it("round-trips encrypt/decrypt payloads", () => {
+  it("round-trips encrypt/decrypt payloads", async () => {
     const key = Buffer.alloc(32, 7);
     const payload = { muxTokenId: "id", muxTokenSecret: "secret", provider: "openai" };
 
-    const encrypted = encryptForWorkflow(payload, key);
-    const decrypted = decryptFromWorkflow<typeof payload>(encrypted, key);
+    const encrypted = await encryptForWorkflow(payload, key);
+    const decrypted = await decryptFromWorkflow<typeof payload>(encrypted, key);
 
     expect(decrypted).toEqual(payload);
   });
 
-  it("fails to decrypt with the wrong key", () => {
+  it("fails to decrypt with the wrong key", async () => {
     const key = Buffer.alloc(32, 1);
     const wrongKey = Buffer.alloc(32, 2);
 
-    const encrypted = encryptForWorkflow({ value: "secret" }, key);
+    const encrypted = await encryptForWorkflow({ value: "secret" }, key);
 
-    expect(() => decryptFromWorkflow(encrypted, wrongKey)).toThrow();
+    await expect(decryptFromWorkflow(encrypted, wrongKey)).rejects.toThrow();
   });
 
-  it("rejects malformed payloads", () => {
+  it("rejects malformed payloads", async () => {
     const key = Buffer.alloc(32, 3);
     const malformed = {
       v: 1,
@@ -34,58 +34,58 @@ describe("workflow crypto helpers", () => {
       ciphertext: "bad",
     } as const;
 
-    expect(() => decryptFromWorkflow(malformed, key)).toThrow();
+    await expect(decryptFromWorkflow(malformed, key)).rejects.toThrow();
   });
 
   describe("key ID (kid) support", () => {
-    it("includes kid in payload when provided", () => {
+    it("includes kid in payload when provided", async () => {
       const key = Buffer.alloc(32, 4);
       const payload = { secret: "value" };
 
-      const encrypted = encryptForWorkflow(payload, key, "key-2026-01");
+      const encrypted = await encryptForWorkflow(payload, key, "key-2026-01");
 
       expect(encrypted.kid).toBe("key-2026-01");
     });
 
-    it("omits kid from payload when not provided", () => {
+    it("omits kid from payload when not provided", async () => {
       const key = Buffer.alloc(32, 5);
       const payload = { secret: "value" };
 
-      const encrypted = encryptForWorkflow(payload, key);
+      const encrypted = await encryptForWorkflow(payload, key);
 
       expect(encrypted.kid).toBeUndefined();
       expect("kid" in encrypted).toBe(false);
     });
 
-    it("round-trips with kid intact", () => {
+    it("round-trips with kid intact", async () => {
       const key = Buffer.alloc(32, 6);
       const payload = { muxTokenId: "id", muxTokenSecret: "secret" };
 
-      const encrypted = encryptForWorkflow(payload, key, "rotation-key-v2");
-      const decrypted = decryptFromWorkflow<typeof payload>(encrypted, key);
+      const encrypted = await encryptForWorkflow(payload, key, "rotation-key-v2");
+      const decrypted = await decryptFromWorkflow<typeof payload>(encrypted, key);
 
       expect(encrypted.kid).toBe("rotation-key-v2");
       expect(decrypted).toEqual(payload);
     });
 
-    it("allows empty string as kid", () => {
+    it("allows empty string as kid", async () => {
       const key = Buffer.alloc(32, 8);
       const payload = { value: "test" };
 
-      const encrypted = encryptForWorkflow(payload, key, "");
+      const encrypted = await encryptForWorkflow(payload, key, "");
 
       expect(encrypted.kid).toBe("");
     });
 
-    it("decrypts payloads without kid (backwards compatibility)", () => {
+    it("decrypts payloads without kid (backwards compatibility)", async () => {
       const key = Buffer.alloc(32, 9);
       const payload = { legacy: "data" };
 
       // Simulate a legacy payload without kid
-      const encrypted = encryptForWorkflow(payload, key);
+      const encrypted = await encryptForWorkflow(payload, key);
       expect(encrypted.kid).toBeUndefined();
 
-      const decrypted = decryptFromWorkflow<typeof payload>(encrypted, key);
+      const decrypted = await decryptFromWorkflow<typeof payload>(encrypted, key);
       expect(decrypted).toEqual(payload);
     });
   });

--- a/tests/unit/workflow-crypto.test.ts
+++ b/tests/unit/workflow-crypto.test.ts
@@ -1,0 +1,92 @@
+import { Buffer } from "node:buffer";
+
+import { describe, expect, it } from "vitest";
+
+import { decryptFromWorkflow, encryptForWorkflow } from "../../src/lib/workflow-crypto";
+
+describe("workflow crypto helpers", () => {
+  it("round-trips encrypt/decrypt payloads", () => {
+    const key = Buffer.alloc(32, 7);
+    const payload = { muxTokenId: "id", muxTokenSecret: "secret", provider: "openai" };
+
+    const encrypted = encryptForWorkflow(payload, key);
+    const decrypted = decryptFromWorkflow<typeof payload>(encrypted, key);
+
+    expect(decrypted).toEqual(payload);
+  });
+
+  it("fails to decrypt with the wrong key", () => {
+    const key = Buffer.alloc(32, 1);
+    const wrongKey = Buffer.alloc(32, 2);
+
+    const encrypted = encryptForWorkflow({ value: "secret" }, key);
+
+    expect(() => decryptFromWorkflow(encrypted, wrongKey)).toThrow();
+  });
+
+  it("rejects malformed payloads", () => {
+    const key = Buffer.alloc(32, 3);
+    const malformed = {
+      v: 1,
+      alg: "aes-256-gcm",
+      iv: "bad",
+      tag: "bad",
+      ciphertext: "bad",
+    } as const;
+
+    expect(() => decryptFromWorkflow(malformed, key)).toThrow();
+  });
+
+  describe("key ID (kid) support", () => {
+    it("includes kid in payload when provided", () => {
+      const key = Buffer.alloc(32, 4);
+      const payload = { secret: "value" };
+
+      const encrypted = encryptForWorkflow(payload, key, "key-2026-01");
+
+      expect(encrypted.kid).toBe("key-2026-01");
+    });
+
+    it("omits kid from payload when not provided", () => {
+      const key = Buffer.alloc(32, 5);
+      const payload = { secret: "value" };
+
+      const encrypted = encryptForWorkflow(payload, key);
+
+      expect(encrypted.kid).toBeUndefined();
+      expect("kid" in encrypted).toBe(false);
+    });
+
+    it("round-trips with kid intact", () => {
+      const key = Buffer.alloc(32, 6);
+      const payload = { muxTokenId: "id", muxTokenSecret: "secret" };
+
+      const encrypted = encryptForWorkflow(payload, key, "rotation-key-v2");
+      const decrypted = decryptFromWorkflow<typeof payload>(encrypted, key);
+
+      expect(encrypted.kid).toBe("rotation-key-v2");
+      expect(decrypted).toEqual(payload);
+    });
+
+    it("allows empty string as kid", () => {
+      const key = Buffer.alloc(32, 8);
+      const payload = { value: "test" };
+
+      const encrypted = encryptForWorkflow(payload, key, "");
+
+      expect(encrypted.kid).toBe("");
+    });
+
+    it("decrypts payloads without kid (backwards compatibility)", () => {
+      const key = Buffer.alloc(32, 9);
+      const payload = { legacy: "data" };
+
+      // Simulate a legacy payload without kid
+      const encrypted = encryptForWorkflow(payload, key);
+      expect(encrypted.kid).toBeUndefined();
+
+      const decrypted = decryptFromWorkflow<typeof payload>(encrypted, key);
+      expect(decrypted).toEqual(payload);
+    });
+  });
+});


### PR DESCRIPTION
  # Overview

Adds multi-tenant credential support for Workflow Dev Kit. Credentials can now be encrypted client-side and passed safely through workflow serialization boundaries, then decrypted inside steps on the execution host.

  **Problem:** Workflow Dev Kit serializes workflow inputs/outputs for observability. Passing plaintext API keys through `start()` would expose secrets in logs/traces.

  **Solution:** AES-256-GCM encryption wrapper that encrypts credentials before workflow invocation and decrypts them inside steps using a shared secret key (`MUX_AI_WORKFLOW_SECRET_KEY`). 

Implementation also uses Web Crypto APIs to avoid Node.js modules in workflow functions.

---

# How this works on Vercel (serverless-only setup)

There are two phases, both running in Vercel serverless functions:

  1. **Trigger phase** — your API route calls `start()` and passes **encrypted** credentials.
  2. **Execution phase** — the workflow steps run in a separate serverless invocation; this is the **execution host** where decryption happens.

Set `MUX_AI_WORKFLOW_SECRET_KEY` in your Vercel project so every serverless function can decrypt during step execution.

  ```ts
  import { start } from "workflow/api";
  import { encryptForWorkflow, getSummaryAndTags } from "@mux/ai/workflows";

// Trigger phase (API route): encrypt before calling start()
  const workflowKey = process.env.MUX_AI_WORKFLOW_SECRET_KEY!;
  const encryptedCredentials = await encryptForWorkflow(
    {
      muxTokenId: "mux-token-id",
      muxTokenSecret: "mux-token-secret",
      openaiApiKey: "openai-api-key",
    },
    workflowKey,
  );

  // Execution phase happens later in a separate invocation.
  // The workflow runtime decrypts inside steps using MUX_AI_WORKFLOW_SECRET_KEY.
  const run = await start(getSummaryAndTags, [
    "your-asset-id",
    { provider: "openai", credentials: encryptedCredentials },
  ]);
```
  Key point: ciphertext crosses workflow boundaries; plaintext only exists inside the step runtime.

---

  # What was changed

  ### New files
  | File | Purpose |
  |------|---------|
  | `src/lib/workflow-crypto.ts` | `encryptForWorkflow` / `decryptFromWorkflow` helpers (AES-256-GCM) with optional key ID (`kid`) for rotation |
  | `src/lib/workflow-credentials.ts` | Resolution chain: encrypted creds → provider hook → env fallback |
  | `tests/unit/workflow-crypto.test.ts` | Round-trip, wrong-key, malformed payload, and key ID tests |

  ### Modified files

  **Core:**
  - `src/index.ts` — Exports crypto helpers, `setWorkflowCredentialsProvider`, and version from `package.json`
  - `src/types.ts` — `WorkflowCredentials`, `WorkflowCredentialsInput`, `Encrypted<T>` types
  - `src/env.ts` — Mux creds now optional; added `MUX_AI_WORKFLOW_SECRET_KEY`; requires either Mux creds OR workflow key
  - `src/lib/client-factory.ts` — `getMuxCredentialsFromEnv` / `getApiKeyFromEnv` now async with credentials param
  - `src/lib/providers.ts` — Added `resolveLanguageModelConfig` / `resolveEmbeddingModelConfig`; model factories now async
  - `src/lib/url-signing.ts` — `signUrl` now resolves signing context from credentials
  - `src/lib/workflow-crypto.ts` — Uses Web Crypto + `TextEncoder/TextDecoder`; crypto helpers are async
  - `src/lib/image-download.ts` — Uses `Uint8Array` and Web base64 helpers (no `node:buffer`)
  - `src/workflows/moderation.ts` — Hive file source now uses `Uint8Array` buffers
  - `src/lib/workflow-credentials.ts` — Awaits async decrypt

  **Primitives:**
  - `src/primitives/storyboards.ts`, `thumbnails.ts`, `transcripts.ts` — Accept `credentials` for signed URL generation

  **Workflows (all 7):**
  - `summarization.ts`, `chapters.ts`, `burned-in-captions.ts`, `moderation.ts`, `embeddings.ts`, `translate-captions.ts`, `translate-audio.ts`
  - Each threads `options.credentials` to Mux API calls, AI provider instantiation, and URL signing

  **Docs:**
  - `README.md` — Multi-tenant encryption examples + provider hook usage
  - `docs/API.md`, `docs/WORKFLOWS.md` — Updated credential guidance

  # Suggested review order

  1. **`src/lib/workflow-crypto.ts`** — AES-256-GCM implementation, IV/tag handling, `kid` support (WebCrypto)
  2. **`src/lib/workflow-credentials.ts`** — Resolution chain logic (decrypt → provider → env)
  3. **`tests/unit/workflow-crypto.test.ts`** — Crypto edge cases and key rotation tests
  4. **`src/types.ts`** — Type definitions that flow through entire codebase
  5. **`src/lib/client-factory.ts` + `src/lib/providers.ts`** — Async conversion pattern
  6. **One workflow (e.g., `summarization.ts`)** — Credential threading pattern
  7. **`README.md`** — User-facing docs for encryption + provider hook

  # Key design decisions

  | Decision | Rationale |
  |----------|-----------|
  | Encryption at rest, decryption in steps | Secrets never appear in workflow I/O serialization |
  | Web Crypto (no Node modules) | Workflow functions disallow Node.js core modules |
  | Async crypto helpers | SubtleCrypto APIs are async |
  | Fallback chain (encrypted → provider → env) | Flexible for multi-tenant or single-tenant deployments |
  | Versioned payload `{ v: 1, alg, kid?, iv, tag, ciphertext }` | Supports future algorithm upgrades and key rotation |
  | Optional `kid` field | Enables key rotation without breaking existing payloads |
  | Async credential resolution | Providers can fetch from external secrets managers |
  | Backwards compatible | Existing env-var-only usage continues unchanged |

# Testing notes

  ```bash
  # Run crypto unit tests
  npm test -- workflow-crypto

  # Run all unit tests
  npm test
```

Crypto tests cover: round-trip encryption, wrong key rejection, malformed payloads, key ID presence/absence, and backwards compatibility.