### PR TITLE
feat: Max Samples for thumbnails for moderation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -72,6 +72,8 @@ export interface ModerationOptions extends MuxAIOptions {
   thumbnailInterval?: number;
   /** Width of storyboard thumbnails in pixels (defaults to 640). */
   thumbnailWidth?: number;
+  /** Maximum number of thumbnails to sample (defaults to unlimited). When set, samples are evenly distributed with first and last frames pinned. */
+  maxSamples?: number;
   /** Max concurrent moderation requests (defaults to 5). */
   maxConcurrent?: number;
   /** Transport used for thumbnails (defaults to 'url'). */
@@ -428,6 +430,7 @@ export async function getModerationScores(
     thresholds = DEFAULT_THRESHOLDS,
     thumbnailInterval = 10,
     thumbnailWidth = 640,
+    maxSamples,
     maxConcurrent = 5,
     imageSubmissionMode = "url",
     imageDownloadOptions,
@@ -491,6 +494,7 @@ export async function getModerationScores(
       interval: thumbnailInterval,
       width: thumbnailWidth,
       shouldSign: policy === "signed",
+      maxSamples,
       credentials,
     });
 

--- a/tests/integration/signed-playback.test.ts
+++ b/tests/integration/signed-playback.test.ts
@@ -175,6 +175,28 @@ describe("signed Playback Integration Tests", () => {
           expect(url).not.toContain("token=");
         });
       });
+
+      it.skipIf(!canRunSignedTests)("should work with maxSamples on signed URLs", async () => {
+        const urls = await getThumbnailUrls(playbackId, 100, {
+          interval: 10,
+          width: 640,
+          shouldSign: true,
+          maxSamples: 5,
+        });
+
+        // Should be capped at 5 thumbnails
+        expect(urls.length).toBe(5);
+
+        // All URLs should be signed
+        urls.forEach((url) => {
+          expect(url).toContain(`https://image.mux.com/${playbackId}/thumbnail.png`);
+          expect(url).toContain("token=");
+        });
+
+        // Verify the first URL is accessible
+        const response = await fetch(urls[0], { method: "HEAD" });
+        expect(response.ok).toBe(true);
+      });
     });
 
     describe("buildTranscriptUrl", () => {

--- a/tests/unit/thumbnails.test.ts
+++ b/tests/unit/thumbnails.test.ts
@@ -172,7 +172,7 @@ describe("getThumbnailUrls", () => {
     });
   });
 
-  describe("uRL formatting", () => {
+  describe("formatting of URLs", () => {
     it("should include width parameter", async () => {
       const duration = 30;
       const urls = await getThumbnailUrls(testPlaybackId, duration, {

--- a/tests/unit/thumbnails.test.ts
+++ b/tests/unit/thumbnails.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+
+import { getThumbnailUrls } from "../../src/primitives/thumbnails";
+
+describe("getThumbnailUrls", () => {
+  const testPlaybackId = "test-playback-id";
+
+  describe("basic thumbnail generation", () => {
+    it("should generate thumbnails at default 10 second intervals", async () => {
+      const duration = 100;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        shouldSign: false,
+      });
+
+      // 100 seconds / 10 second interval = 10 thumbnails (0, 10, 20, ..., 90)
+      expect(urls.length).toBe(10);
+      expect(urls[0]).toContain("time=0");
+      expect(urls[9]).toContain("time=90");
+    });
+
+    it("should generate thumbnails at custom intervals", async () => {
+      const duration = 60;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        interval: 20,
+        shouldSign: false,
+      });
+
+      // 60 seconds / 20 second interval = 3 thumbnails (0, 20, 40)
+      expect(urls.length).toBe(3);
+      expect(urls[0]).toContain("time=0");
+      expect(urls[1]).toContain("time=20");
+      expect(urls[2]).toContain("time=40");
+    });
+
+    it("should generate 5 thumbnails for short videos (≤50 seconds)", async () => {
+      const duration = 30;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        shouldSign: false,
+      });
+
+      // Short videos use special logic: 5 evenly spaced thumbnails
+      expect(urls.length).toBe(5);
+    });
+  });
+
+  describe("maxSamples parameter", () => {
+    it("should cap thumbnails to maxSamples when limit is lower than default", async () => {
+      const duration = 100;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 5,
+        shouldSign: false,
+      });
+
+      // Should be capped at 5 thumbnails
+      expect(urls.length).toBe(5);
+    });
+
+    it("should not affect count when maxSamples is greater than default", async () => {
+      const duration = 50;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        interval: 10,
+        maxSamples: 100,
+        shouldSign: false,
+      });
+
+      // 50 / 10 = 5 thumbnails, maxSamples of 100 should not change this
+      expect(urls.length).toBe(5);
+    });
+
+    it("should always include first frame (time=0) when maxSamples is set", async () => {
+      const duration = 100;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 3,
+        shouldSign: false,
+      });
+
+      expect(urls[0]).toContain("time=0");
+    });
+
+    it("should always include last frame when maxSamples >= 2", async () => {
+      const duration = 100;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 4,
+        shouldSign: false,
+      });
+
+      expect(urls.length).toBe(4);
+      expect(urls[0]).toContain("time=0");
+      expect(urls[3]).toContain("time=100");
+    });
+
+    it("should evenly distribute timestamps when maxSamples is applied", async () => {
+      const duration = 100;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 5,
+        shouldSign: false,
+      });
+
+      // 5 samples: 0, 25, 50, 75, 100 (evenly distributed)
+      expect(urls.length).toBe(5);
+      expect(urls[0]).toContain("time=0");
+      expect(urls[1]).toContain("time=25");
+      expect(urls[2]).toContain("time=50");
+      expect(urls[3]).toContain("time=75");
+      expect(urls[4]).toContain("time=100");
+    });
+
+    it("should handle maxSamples = 1 (only first frame)", async () => {
+      const duration = 100;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 1,
+        shouldSign: false,
+      });
+
+      expect(urls.length).toBe(1);
+      expect(urls[0]).toContain("time=0");
+    });
+
+    it("should handle maxSamples = 2 (first and last frames)", async () => {
+      const duration = 100;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 2,
+        shouldSign: false,
+      });
+
+      expect(urls.length).toBe(2);
+      expect(urls[0]).toContain("time=0");
+      expect(urls[1]).toContain("time=100");
+    });
+
+    it("should work with maxSamples on short videos", async () => {
+      const duration = 30;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 3,
+        shouldSign: false,
+      });
+
+      // Short video generates 5 frames, but maxSamples caps it to 3
+      expect(urls.length).toBe(3);
+      expect(urls[0]).toContain("time=0");
+      expect(urls[2]).toContain("time=30");
+    });
+
+    it("should distribute evenly with maxSamples = 10 on 200 second video", async () => {
+      const duration = 200;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        interval: 10,
+        maxSamples: 10,
+        shouldSign: false,
+      });
+
+      // Without maxSamples: 200/10 = 20 thumbnails
+      // With maxSamples: capped to 10, evenly distributed
+      expect(urls.length).toBe(10);
+
+      // Extract timestamps from URLs
+      const timestamps = urls.map((url) => {
+        const match = url.match(/time=(\d+\.?\d*)/);
+        return match ? Number.parseFloat(match[1]) : 0;
+      });
+
+      // First and last should be pinned
+      expect(timestamps[0]).toBe(0);
+      expect(timestamps[9]).toBeCloseTo(200, 1);
+
+      // Middle timestamps should be evenly spaced
+      // Expected spacing: 200 / (10-1) = ~22.22
+      for (let i = 1; i < timestamps.length - 1; i++) {
+        const expected = (200 / (10 - 1)) * i;
+        expect(timestamps[i]).toBeCloseTo(expected, 1);
+      }
+    });
+  });
+
+  describe("uRL formatting", () => {
+    it("should include width parameter", async () => {
+      const duration = 30;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        width: 1280,
+        shouldSign: false,
+      });
+
+      urls.forEach((url) => {
+        expect(url).toContain("width=1280");
+      });
+    });
+
+    it("should generate correct base URL structure", async () => {
+      const duration = 30;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        shouldSign: false,
+      });
+
+      urls.forEach((url) => {
+        expect(url).toContain(`https://image.mux.com/${testPlaybackId}/thumbnail.png`);
+        expect(url).toContain("time=");
+        expect(url).toContain("width=");
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle very short duration", async () => {
+      const duration = 5;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        shouldSign: false,
+      });
+
+      // Short video logic applies
+      expect(urls.length).toBeGreaterThan(0);
+    });
+
+    it("should handle maxSamples = 0", async () => {
+      const duration = 100;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 0,
+        shouldSign: false,
+      });
+
+      // maxSamples of 0 should result in empty newTimestamps array, but code pushes at least first frame
+      expect(urls.length).toBe(1);
+      expect(urls[0]).toContain("time=0");
+    });
+
+    it("should handle very long video with small maxSamples", async () => {
+      const duration = 3600; // 1 hour
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        maxSamples: 4,
+        shouldSign: false,
+      });
+
+      expect(urls.length).toBe(4);
+
+      const timestamps = urls.map((url) => {
+        const match = url.match(/time=(\d+\.?\d*)/);
+        return match ? Number.parseFloat(match[1]) : 0;
+      });
+
+      expect(timestamps[0]).toBe(0);
+      expect(timestamps[3]).toBeCloseTo(3600, 1);
+    });
+  });
+});


### PR DESCRIPTION
Adds a maxSamples option to control the number of thumbnails sampled during moderation workflows. This allows users to balance moderation thoroughness against API costs.

This PR supersedes #90 

Changes

  - src/primitives/thumbnails.ts: Added maxSamples parameter to ThumbnailOptions interface
    - When set, caps the number of generated thumbnails to the specified limit
    - Samples are evenly distributed across the video duration
    - First frame (t=0) and last frame (t=duration) are always included when maxSamples >= 2
  - src/workflows/moderation.ts: Added maxSamples parameter to ModerationOptions interface
    - Passes through to getThumbnailUrls for thumbnail-based moderation
    - Does not affect transcript-based moderation (audio-only assets)

Usage

```
  // Default: samples every 10 seconds (100s video = 10 thumbnails)
  await getModerationScores(assetId, { thumbnailInterval: 10 });

  // With maxSamples: caps at 5 evenly-distributed samples
  await getModerationScores(assetId, {
    thumbnailInterval: 10,
    maxSamples: 5  // Samples at t=0, 25, 50, 75, 100
  });
```

Testing

  - Unit tests (tests/unit/thumbnails.test.ts): 17 tests covering thumbnail generation logic, maxSamples behavior, edge cases, and timestamp distribution
  - Integration tests (tests/integration/moderation.test.ts): 6 tests verifying moderation works correctly with limited samples across OpenAI and Hive providers
  - Signed playback tests (tests/integration/signed-playback.test.ts): 1 test confirming maxSamples works with signed URLs