### PR TITLE
chore: bump vercels ai sdk

### DIFF
--- a/docs/PRIMITIVES.md
+++ b/docs/PRIMITIVES.md
@@ -308,7 +308,7 @@ async function customVideoAnalysis(assetId: string) {
 
   // Build custom prompt
   const result = await generateText({
-    model: openai("gpt-4o-mini"),
+    model: openai("gpt-5.1"),
     messages: [
       {
         role: "user",
@@ -379,7 +379,7 @@ export async function customTranscriptAnalysis(assetId: string) {
 
   // Build your custom AI prompt
   const result = await generateText({
-    model: openai("gpt-4o-mini"),
+    model: openai("gpt-5.1"),
     messages: [
       {
         role: "user",
@@ -468,7 +468,7 @@ export async function analyzeSentiment(
   );
 
   const result = await generateText({
-    model: openai("gpt-4o-mini", {
+    model: openai("gpt-5.1", {
       apiKey: process.env.OPENAI_API_KEY
     }),
     messages: [

--- a/evalite.config.ts
+++ b/evalite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "evalite/config";
 
 // See: https://v1.evalite.dev/guides/configuration
 export default defineConfig({
-  testTimeout: 120000, // 120 seconds
+  testTimeout: 300000, // 300 seconds
   maxConcurrency: 6, // Run up to 6 tests in parallel
   hideTable: false, // Show the table of results
   viteConfig: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "@mux/ai",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^2.0.45",
-        "@ai-sdk/google": "^2.0.48",
-        "@ai-sdk/openai": "^2.0.71",
+        "@ai-sdk/anthropic": "^3.0.16",
+        "@ai-sdk/google": "^3.0.10",
+        "@ai-sdk/openai": "^3.0.12",
         "@aws-sdk/client-s3": "^3.0.0",
         "@aws-sdk/lib-storage": "^3.0.0",
         "@aws-sdk/s3-request-presigner": "^3.0.0",
         "@mux/mux-node": "^12.5.0",
-        "ai": "^5.0.98",
+        "ai": "^6.0.42",
         "dedent": "^1.7.0",
         "dotenv": "^17.2.2",
         "dotenv-expand": "^12.0.3",
@@ -46,13 +46,13 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.55",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.55.tgz",
-      "integrity": "sha512-jKOfnEntcR39Wd9b2MUEP2r6ucMyuzY2EYRH1lQzTcZutmEmHxXlIZD17OseFuhuYCKKBlQUBi8GyEl8/qB4qg==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.16.tgz",
+      "integrity": "sha512-vGqY/qwQvQR32YsNDZLJ3/hr3w7AduW+j8TBDZad5xTWsNfz9MTJ4V7pItkpravAgwKIX8hYas4Cc4LpHz7YsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.19"
+        "@ai-sdk/provider": "3.0.4",
+        "@ai-sdk/provider-utils": "4.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -62,14 +62,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.20.tgz",
-      "integrity": "sha512-0DKAZP9SiphUHuT/HmCYrv0uNyHfqn4gT3e5LsL+y1n3mMhWrrKNS2QYn+ysVd7yOmrLyv30gzrCCdbjnN+vtw==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.17.tgz",
+      "integrity": "sha512-mCz50GlBPyBV96Wcll1Mpaz56MVFuHL+bwRWGkIsCJwKAKIfdgUZecFzS3gckpHGaqP5+BYnmyJocIMzUhTQ2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.19",
-        "@vercel/oidc": "3.0.5"
+        "@ai-sdk/provider": "3.0.4",
+        "@ai-sdk/provider-utils": "4.0.8",
+        "@vercel/oidc": "3.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -78,14 +78,23 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@ai-sdk/gateway/node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@ai-sdk/google": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.48.tgz",
-      "integrity": "sha512-LMzyYEG+RshL13EzQZPvpSuS56Vhm5raC3LGcTwCOQDu4XQycphKT2xrYmzt0odMR+fMka8Sbk/kHA1DcJnu6A==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.10.tgz",
+      "integrity": "sha512-qd2EM9SlD7wWFrq036hwKsuAgkCVxQbwJzctszdmzPs9yUZg795/gHtZRpKItZhbyHSNWhAHmJwEgKjD+HOzuQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.19"
+        "@ai-sdk/provider": "3.0.4",
+        "@ai-sdk/provider-utils": "4.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -95,13 +104,13 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "2.0.81",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.81.tgz",
-      "integrity": "sha512-fgy5vUMF0WwrPZhxkvMYVFD9dIdIoQBQ6b/XMkwcnUcSE0bUaxKHwgl9UC6da6fb1SpNxzcXu/Y3/7CnyX3TFg==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.12.tgz",
+      "integrity": "sha512-zqLWEKuaKnjXhu7xCw1jgz/+yTbd3F7EtgU4T2Q8BAo8OJC5wZv14l+kwM7Jai7M1/2Y2T/zBkrfiIu+7NsvfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.19"
+        "@ai-sdk/provider": "3.0.4",
+        "@ai-sdk/provider-utils": "4.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -111,9 +120,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.4.tgz",
+      "integrity": "sha512-5KXyBOSEX+l67elrEa+wqo/LSsSTtrPj9Uoh3zMbe/ceQX4ucHI3b9nUEfNkGF3Ry1svv90widAt+aiKdIJasQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -123,13 +132,13 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.19",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.19.tgz",
-      "integrity": "sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.8.tgz",
+      "integrity": "sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
+        "@ai-sdk/provider": "3.0.4",
+        "@standard-schema/spec": "^1.1.0",
         "eventsource-parser": "^3.0.6"
       },
       "engines": {
@@ -138,6 +147,12 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@antfu/eslint-config": {
       "version": "6.6.1",
@@ -5073,6 +5088,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@stricli/auto-complete": {
@@ -5788,6 +5804,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
       "integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -7905,14 +7922,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.111",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.111.tgz",
-      "integrity": "sha512-kD1eBl3ZbSYIz9lZe0HvQpO23HruBFfqxUl0S/MtoDF4DCmfCtKhsGGGIvoIcMpjiLlJjtF//ZWcYu+v/3YRzg==",
+      "version": "6.0.42",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.42.tgz",
+      "integrity": "sha512-o+MVN7HBE4HEnhtN7nBt9WO1iISI6svyWNoOuY6WiXCdHuZfSGN4MUQ3QwjWz1Ue5gtBEcvwX5XFhgAwlPAxxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.20",
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.19",
+        "@ai-sdk/gateway": "3.0.17",
+        "@ai-sdk/provider": "3.0.4",
+        "@ai-sdk/provider-utils": "4.0.8",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -98,14 +98,14 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^2.0.45",
-    "@ai-sdk/google": "^2.0.48",
-    "@ai-sdk/openai": "^2.0.71",
+    "@ai-sdk/anthropic": "^3.0.16",
+    "@ai-sdk/google": "^3.0.10",
+    "@ai-sdk/openai": "^3.0.12",
     "@aws-sdk/client-s3": "^3.0.0",
     "@aws-sdk/lib-storage": "^3.0.0",
     "@aws-sdk/s3-request-presigner": "^3.0.0",
     "@mux/mux-node": "^12.5.0",
-    "ai": "^5.0.98",
+    "ai": "^6.0.42",
     "dedent": "^1.7.0",
     "dotenv": "^17.2.2",
     "dotenv-expand": "^12.0.3",

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { anthropic } from "@ai-sdk/anthropic";
 import { google } from "@ai-sdk/google";
 import { openai } from "@ai-sdk/openai";
-import { generateObject } from "ai";
+import { generateText, Output } from "ai";
 import { Command } from "commander";
 import dedent from "dedent";
 import { z } from "zod";
@@ -193,9 +193,9 @@ interface Options {
 }
 
 const WorkflowInsightSchema = z.object({
-  summaryMarkdown: z.string().min(1),
-  tldr: z.string().min(1).optional(),
-  caveat: z.string().min(1).optional(),
+  summaryMarkdown: z.string(),
+  tldr: z.string(),
+  caveat: z.string(),
 });
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -637,9 +637,9 @@ async function generateWorkflowInsights(suites: EvaliteSuite[], options: Generat
         ${JSON.stringify(stats, null, 2)}
       </metrics_json>`;
 
-    const result = await generateObject({
+    const result = await generateText({
       model,
-      schema: WorkflowInsightSchema,
+      output: Output.object({ schema: WorkflowInsightSchema }),
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userPrompt },
@@ -649,9 +649,9 @@ async function generateWorkflowInsights(suites: EvaliteSuite[], options: Generat
     insights.push({
       workflowKey,
       workflowName: stats.workflowName,
-      summaryMarkdown: result.object.summaryMarkdown.trim(),
-      tldr: result.object.tldr?.trim(),
-      caveat: result.object.caveat?.trim(),
+      summaryMarkdown: result.output.summaryMarkdown.trim(),
+      tldr: result.output.tldr?.trim(),
+      caveat: result.output.caveat?.trim(),
       stats,
       recommendations: stats.recommendations,
     });

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -221,7 +221,7 @@ export async function createEmbeddingModelFromConfig<
   provider: P,
   modelId: EmbeddingModelIdByProvider[P],
   credentials?: WorkflowCredentialsInput,
-): Promise<EmbeddingModel<string>> {
+): Promise<EmbeddingModel> {
   switch (provider) {
     case "openai": {
       const apiKey = await resolveProviderApiKey("openai", credentials);
@@ -301,7 +301,7 @@ export function resolveLanguageModel<P extends SupportedProvider = SupportedProv
  */
 export function resolveEmbeddingModel<P extends SupportedEmbeddingProvider = "openai">(
   options: MuxAIOptions & { provider?: P; model?: EmbeddingModelIdByProvider[P] } = {},
-): { provider: P; modelId: EmbeddingModelIdByProvider[P]; model: EmbeddingModel<string> } {
+): { provider: P; modelId: EmbeddingModelIdByProvider[P]; model: EmbeddingModel } {
   const provider = options.provider || ("openai" as P);
   const modelId = (options.model || DEFAULT_EMBEDDING_MODELS[provider]) as EmbeddingModelIdByProvider[P];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,6 @@ export interface MuxAIOptions {
   /** Optional timeout (ms) for helper utilities that support request limits. */
   timeout?: number;
   /**
-   * Optional cancellation signal passed through to underlying AI SDK calls.
-   * When aborted, in-flight model requests will be
-   * cancelled where supported.
-   */
-  abortSignal?: AbortSignal;
-  /**
    * Optional credentials for workflow execution.
    * Use encryptForWorkflow when running in Workflow Dev Kit environments.
    */

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -1,4 +1,4 @@
-import { generateObject } from "ai";
+import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
@@ -112,9 +112,9 @@ async function generateChaptersWithAI({
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
   const response = await withRetry(() =>
-    generateObject({
+    generateText({
       model,
-      schema: chaptersSchema,
+      output: Output.object({ schema: chaptersSchema }),
       messages: [
         {
           role: "system",
@@ -129,13 +129,13 @@ async function generateChaptersWithAI({
   );
 
   return {
-    chapters: response.object,
+    chapters: response.output,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,
       totalTokens: response.usage.totalTokens,
-      reasoningTokens: response.usage.reasoningTokens,
-      cachedInputTokens: response.usage.cachedInputTokens,
+      reasoningTokens: response.usage.outputTokenDetails.reasoningTokens,
+      cachedInputTokens: response.usage.inputTokenDetails.cacheReadTokens,
     },
   };
 }

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -1,4 +1,4 @@
-import { generateObject } from "ai";
+import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
@@ -378,9 +378,9 @@ async function analyzeStoryboard(
   "use step";
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
-  const response = await generateObject({
+  const response = await generateText({
     model,
-    schema: summarySchema,
+    output: Output.object({ schema: summarySchema }),
     messages: [
       {
         role: "system",
@@ -397,13 +397,13 @@ async function analyzeStoryboard(
   });
 
   return {
-    result: response.object,
+    result: response.output,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,
       totalTokens: response.usage.totalTokens,
-      reasoningTokens: response.usage.reasoningTokens,
-      cachedInputTokens: response.usage.cachedInputTokens,
+      reasoningTokens: response.usage.outputTokenDetails.reasoningTokens,
+      cachedInputTokens: response.usage.inputTokenDetails.cacheReadTokens,
     },
   };
 }
@@ -418,9 +418,9 @@ async function analyzeAudioOnly(
   "use step";
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
-  const response = await generateObject({
+  const response = await generateText({
     model,
-    schema: summarySchema,
+    output: Output.object({ schema: summarySchema }),
     messages: [
       {
         role: "system",
@@ -434,13 +434,13 @@ async function analyzeAudioOnly(
   });
 
   return {
-    result: response.object,
+    result: response.output,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,
       totalTokens: response.usage.totalTokens,
-      reasoningTokens: response.usage.reasoningTokens,
-      cachedInputTokens: response.usage.cachedInputTokens,
+      reasoningTokens: response.usage.outputTokenDetails.reasoningTokens,
+      cachedInputTokens: response.usage.inputTokenDetails.cacheReadTokens,
     },
   };
 }

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -488,7 +488,6 @@ export async function getSummaryAndTags(
     cleanTranscript = true,
     imageSubmissionMode = "url",
     imageDownloadOptions,
-    abortSignal: _abortSignal,
     promptOverrides,
     credentials,
   } = options ?? {};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    testTimeout: 120000, // 120 seconds for integration tests
+    testTimeout: 300000, // 300 seconds for integration tests
     fileParallelism: false, // Run test files sequentially to avoid rate limits and reduce API costs
   },
 });


### PR DESCRIPTION
# Overview
This branch updates AI SDK dependencies to v3/v6 and migrates usage from `generateObject` to `generateText` + `Output.object`, along with minor schema/usage adjustments and doc updates.

# What was changed
- Upgraded `ai` and `@ai-sdk/*` dependency versions in `package.json` and `package-lock.json`.
- Updated workflow implementations (`burned-in-captions`, `chapters`, `summarization`, `translate-captions`) to use `generateText` outputs and new token usage fields.
- Adjusted schema validation and response handling in `scripts/post-evalite-results.ts`.
- Updated documentation examples in `docs/PRIMITIVES.md` to use `gpt-5.1`.
- Reworked translation eval faithfulness scoring to a custom `generateText`-based grader.

# Suggested review order
1. `package.json` and `package-lock.json` for dependency/version upgrades.
2. `src/lib/providers.ts` and `src/types.ts` for type/signature changes.
3. Workflow updates in `src/workflows/*` for `generateText` + usage adjustments.
4. `scripts/post-evalite-results.ts` for schema/output changes.
5. `tests/eval/translate-captions.eval.ts` for new faithfulness scoring logic.
6. `docs/PRIMITIVES.md` for doc-only model updates.
