### PR TITLE
chore: add asset durations for posted eval runs

### DIFF
--- a/examples/ask-questions/basic-example.ts
+++ b/examples/ask-questions/basic-example.ts
@@ -45,9 +45,7 @@ program
 
       if (result.usage) {
         console.log("\n📈 Token Usage:");
-        console.log(`  Input: ${result.usage.inputTokens}`);
-        console.log(`  Output: ${result.usage.outputTokens}`);
-        console.log(`  Total: ${result.usage.totalTokens}`);
+        console.log(JSON.stringify(result.usage, null, 2));
       }
     } catch (error) {
       console.error("❌ Error:", error instanceof Error ? error.message : error);

--- a/examples/moderation/basic-example.ts
+++ b/examples/moderation/basic-example.ts
@@ -60,6 +60,9 @@ async function main() {
     });
 
     console.log("\n📦 Asset ID:", result.assetId);
+
+    console.log("\n📈 Usage:");
+    console.log(JSON.stringify(result.usage, null, 2));
   } catch (error) {
     console.error("❌ Error:", error instanceof Error ? error.message : error);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -12,6 +12,7 @@ import dedent from "dedent";
 import { z } from "zod";
 
 import env from "../src/env";
+import { getAssetDurationSeconds } from "../src/lib/mux-assets";
 import { DEFAULT_LANGUAGE_MODELS } from "../src/lib/providers";
 import type { SupportedProvider } from "../src/lib/providers";
 
@@ -74,6 +75,9 @@ interface WorkflowInsightStats {
   suiteCreatedAt?: string;
   caseCount: number;
   assetCount?: number;
+  assetDurationSecondsTotal?: number;
+  assetDurationMinutesTotal?: number;
+  assetDurationMissingCount?: number;
   providerCount: number;
   providers: ProviderStats[];
   scorerAverages?: Record<string, number>;
@@ -177,6 +181,7 @@ function resolveRef() {
 const WORKFLOW_MATCHERS = [
   { key: "burned_in_captions", regex: /burned[- ]in[- ]captions/i },
   { key: "chapters", regex: /chapters?/i },
+  { key: "ask_questions", regex: /ask[- ]questions/i },
   { key: "translate_captions", regex: /translate[- ]captions/i },
   { key: "summarization", regex: /summarization/i },
 ] as const;
@@ -216,7 +221,46 @@ function coerceNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function computeWorkflowStats(suite: EvaliteSuite, workflowKey: string): WorkflowInsightStats {
+let hasWarnedMissingMuxCredentials = false;
+
+async function resolveAssetDurationSeconds(
+  assetId: string,
+  cache: Map<string, number | null>,
+): Promise<number | undefined> {
+  if (cache.has(assetId)) {
+    const cached = cache.get(assetId);
+    return typeof cached === "number" ? cached : undefined;
+  }
+
+  if (!env.MUX_TOKEN_ID || !env.MUX_TOKEN_SECRET) {
+    if (!hasWarnedMissingMuxCredentials) {
+      console.warn("⚠️ Skipping asset duration lookup: MUX_TOKEN_ID and MUX_TOKEN_SECRET are required.");
+      hasWarnedMissingMuxCredentials = true;
+    }
+    cache.set(assetId, null);
+    return undefined;
+  }
+
+  try {
+    const duration = await getAssetDurationSeconds(assetId);
+    cache.set(assetId, typeof duration === "number" ? duration : null);
+    return duration;
+  } catch (error) {
+    console.warn(
+      `⚠️ Failed to fetch Mux asset duration for ${assetId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    cache.set(assetId, null);
+    return undefined;
+  }
+}
+
+async function computeWorkflowStats(
+  suite: EvaliteSuite,
+  workflowKey: string,
+  assetDurationCache: Map<string, number | null>,
+): Promise<WorkflowInsightStats> {
   const evals = Array.isArray(suite.evals) ? suite.evals : [];
   const providerStats = new Map<string, {
     provider: string;
@@ -396,6 +440,19 @@ function computeWorkflowStats(suite: EvaliteSuite, workflowKey: string): Workflo
     suiteDurationMs = suiteDurationFallbackSum;
   }
 
+  let assetDurationSecondsTotal = 0;
+  let assetDurationMissingCount = 0;
+  if (assets.size > 0) {
+    for (const assetId of assets) {
+      const durationSeconds = await resolveAssetDurationSeconds(assetId, assetDurationCache);
+      if (typeof durationSeconds === "number") {
+        assetDurationSecondsTotal += durationSeconds;
+      } else {
+        assetDurationMissingCount += 1;
+      }
+    }
+  }
+
   const providerSummaries: ProviderStats[] = Array.from(providerStats.values()).map((stats) => {
     const scorerAverages: Record<string, number> = {};
     for (const [name, scorer] of stats.scorerSums.entries()) {
@@ -494,6 +551,10 @@ function computeWorkflowStats(suite: EvaliteSuite, workflowKey: string): Workflo
     suiteCreatedAt: suite.createdAt,
     caseCount: evals.length,
     assetCount: assets.size || undefined,
+    assetDurationSecondsTotal: assetDurationSecondsTotal > 0 ? assetDurationSecondsTotal : undefined,
+    assetDurationMinutesTotal:
+      assetDurationSecondsTotal > 0 ? assetDurationSecondsTotal / 60 : undefined,
+    assetDurationMissingCount: assetDurationMissingCount > 0 ? assetDurationMissingCount : undefined,
     providerCount: providers.size,
     providers: providerSummaries,
     scorerAverages: Object.keys(overallScorerAverages).length > 0 ?
@@ -569,6 +630,7 @@ async function generateWorkflowInsights(suites: EvaliteSuite[], options: Generat
   const { model, provider, modelId } = resolveInsightsModel(options);
   const { workflows: workflowFilter } = options;
   const insights: WorkflowInsightPayload[] = [];
+  const assetDurationCache = new Map<string, number | null>();
 
   console.warn(`🤖 Generating insights using ${provider}/${modelId}`);
   if (workflowFilter && workflowFilter.length > 0) {
@@ -600,7 +662,7 @@ async function generateWorkflowInsights(suites: EvaliteSuite[], options: Generat
       continue;
     }
 
-    const stats = computeWorkflowStats(suite, workflowKey);
+    const stats = await computeWorkflowStats(suite, workflowKey, assetDurationCache);
 
     const userPrompt = dedent`
       <task>

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -68,6 +68,10 @@ export async function getAssetDurationSeconds(
   });
 
   const asset = await mux.video.assets.retrieve(assetId);
+  return getAssetDurationSecondsFromAsset(asset);
+}
+
+export function getAssetDurationSecondsFromAsset(asset: MuxAsset): number | undefined {
   const duration = asset.duration;
   return typeof duration === "number" && Number.isFinite(duration) ? duration : undefined;
 }

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -55,3 +55,19 @@ export async function getPlaybackIdForAsset(
 
   return { asset, playbackId, policy };
 }
+
+export async function getAssetDurationSeconds(
+  assetId: string,
+  credentials?: WorkflowCredentialsInput,
+): Promise<number | undefined> {
+  "use step";
+  const { muxTokenId, muxTokenSecret } = await getMuxCredentialsFromEnv(credentials);
+  const mux = new Mux({
+    tokenId: muxTokenId,
+    tokenSecret: muxTokenSecret,
+  });
+
+  const asset = await mux.video.assets.retrieve(assetId);
+  const duration = asset.duration;
+  return typeof duration === "number" && Number.isFinite(duration) ? duration : undefined;
+}

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -8,6 +8,7 @@ import type { MuxAsset, PlaybackAsset, PlaybackPolicy, WorkflowCredentialsInput 
  * Prefers public playback IDs, falls back to signed if no public is available.
  * Throws an error if no public or signed playback ID is found.
  */
+// Use the asset payload we already fetched to avoid extra Mux Video API calls.
 function getPlaybackId(asset: MuxAsset): { id: string; policy: PlaybackPolicy } {
   const playbackIds = asset.playback_ids || [];
 
@@ -44,16 +45,33 @@ export async function getPlaybackIdForAsset(
   credentials?: WorkflowCredentialsInput,
 ): Promise<PlaybackAsset> {
   "use step";
+  // Centralize the Mux Video API fetch so callers can reuse the same asset payload
+  // for playback IDs, duration, and other derived fields without double-hitting.
+  // Note: getMuxAsset still resolves Mux token ID/secret from env or provided
+  // credentials to preserve multi-tenant behavior.
+  const asset = await getMuxAsset(assetId, credentials);
+  const { id: playbackId, policy } = getPlaybackId(asset);
+
+  return { asset, playbackId, policy };
+}
+
+/**
+ * Fetches the Mux asset once so callers can derive playback IDs, duration, tracks,
+ * and other metadata from a single Video API call.
+ */
+export async function getMuxAsset(
+  assetId: string,
+  credentials?: WorkflowCredentialsInput,
+): Promise<MuxAsset> {
+  "use step";
+  // Always resolve Mux credentials from env or provided overrides (multi-tenant safe).
   const { muxTokenId, muxTokenSecret } = await getMuxCredentialsFromEnv(credentials);
   const mux = new Mux({
     tokenId: muxTokenId,
     tokenSecret: muxTokenSecret,
   });
 
-  const asset = await mux.video.assets.retrieve(assetId);
-  const { id: playbackId, policy } = getPlaybackId(asset);
-
-  return { asset, playbackId, policy };
+  return mux.video.assets.retrieve(assetId);
 }
 
 export async function getAssetDurationSeconds(
@@ -61,16 +79,13 @@ export async function getAssetDurationSeconds(
   credentials?: WorkflowCredentialsInput,
 ): Promise<number | undefined> {
   "use step";
-  const { muxTokenId, muxTokenSecret } = await getMuxCredentialsFromEnv(credentials);
-  const mux = new Mux({
-    tokenId: muxTokenId,
-    tokenSecret: muxTokenSecret,
-  });
-
-  const asset = await mux.video.assets.retrieve(assetId);
+  // Keep this helper, but route through getMuxAsset so a caller that already
+  // fetched the asset can prefer getAssetDurationSecondsFromAsset instead.
+  const asset = await getMuxAsset(assetId, credentials);
   return getAssetDurationSecondsFromAsset(asset);
 }
 
+// Use this when you already have the asset to avoid another Video API round trip.
 export function getAssetDurationSecondsFromAsset(asset: MuxAsset): number | undefined {
   const duration = asset.duration;
   return typeof duration === "number" && Number.isFinite(duration) ? duration : undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,10 +125,22 @@ export interface VideoEmbeddingsResult {
     embeddingDimensions: number;
     generatedAt: string;
   };
+  /** Workflow usage metadata (asset duration, thumbnails, etc.). */
+  usage?: TokenUsage;
 }
 // ─────────────────────────────────────────────────────────────────────────────
 // AI SDK Usage Metrics
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Metadata attached to usage objects for workflow context.
+ */
+export interface UsageMetadata {
+  /** Total asset duration in seconds. */
+  assetDurationSeconds?: number;
+  /** Number of thumbnails sampled for workflows that use thumbnails. */
+  thumbnailCount?: number;
+}
 
 /**
  * Token usage breakdown returned by AI SDK providers.
@@ -145,4 +157,6 @@ export interface TokenUsage {
   reasoningTokens?: number;
   /** Input tokens served from cache (reduces cost). */
   cachedInputTokens?: number;
+  /** Workflow metadata (asset duration, thumbnails, etc.). */
+  metadata?: UsageMetadata;
 }

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
-import { getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
 import { createPromptBuilder, createTranscriptSection } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
@@ -369,6 +369,8 @@ export async function askQuestions(
   // Fetch asset data and playback ID from Mux
   const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
 
+  const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
+
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
   if (policy === "signed" && !signingContext) {
@@ -449,7 +451,12 @@ export async function askQuestions(
     assetId,
     answers: analysisResponse.result.answers,
     storyboardUrl: imageUrl,
-    usage: analysisResponse.usage,
+    usage: {
+      ...analysisResponse.usage,
+      metadata: {
+        assetDurationSeconds,
+      },
+    },
     transcriptText: transcriptText || undefined,
   };
 }

--- a/src/workflows/embeddings.ts
+++ b/src/workflows/embeddings.ts
@@ -1,6 +1,10 @@
 import { embed } from "ai";
 
-import { getPlaybackIdForAsset, isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
+import {
+  getAssetDurationSecondsFromAsset,
+  getPlaybackIdForAsset,
+  isAudioOnlyAsset,
+} from "@mux/ai/lib/mux-assets";
 import type { EmbeddingModelIdByProvider, SupportedEmbeddingProvider } from "@mux/ai/lib/providers";
 import { createEmbeddingModelFromConfig, resolveEmbeddingModelConfig } from "@mux/ai/lib/providers";
 import { withRetry } from "@mux/ai/lib/retry";
@@ -158,6 +162,7 @@ async function generateEmbeddingsInternal(
 
   // Fetch asset and playback ID
   const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
   const isAudioOnly = isAudioOnlyAsset(assetData);
 
   // Resolve signing context for signed playback IDs
@@ -267,6 +272,11 @@ async function generateEmbeddingsInternal(
       chunkingStrategy: JSON.stringify(chunkingStrategy),
       embeddingDimensions: chunkEmbeddings[0].embedding.length,
       generatedAt: new Date().toISOString(),
+    },
+    usage: {
+      metadata: {
+        assetDurationSeconds,
+      },
     },
   };
 }

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -4,7 +4,11 @@ import { z } from "zod";
 
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
-import { getPlaybackIdForAsset, isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
+import {
+  getAssetDurationSecondsFromAsset,
+  getPlaybackIdForAsset,
+  isAudioOnlyAsset,
+} from "@mux/ai/lib/mux-assets";
 import type {
   PromptOverrides,
 } from "@mux/ai/lib/prompt-builder";
@@ -528,6 +532,8 @@ export async function getSummaryAndTags(
   // Fetch asset data from Mux and grab playback/transcript details
   const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
 
+  const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
+
   // Detect if asset is audio-only
   const isAudioOnly = isAudioOnlyAsset(assetData);
 
@@ -637,7 +643,12 @@ export async function getSummaryAndTags(
     description: analysisResponse.result.description,
     tags: normalizeKeywords(analysisResponse.result.keywords),
     storyboardUrl: imageUrl, // undefined for audio-only assets
-    usage: analysisResponse.usage,
+    usage: {
+      ...analysisResponse.usage,
+      metadata: {
+        assetDurationSeconds,
+      },
+    },
     transcriptText: transcriptText || undefined,
   };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    testTimeout: 300000, // 300 seconds for integration tests
+    testTimeout: 600000, // 600 seconds for integration tests
     fileParallelism: false, // Run test files sequentially to avoid rate limits and reduce API costs
   },
 });


### PR DESCRIPTION
# Overview

This branch expands evalite insights generation to include Ask Questions and adds asset duration metrics so we can track estimated cost per workflow we're shipping.

# What was changed

- Added Ask Questions to the workflow matcher so its eval results get summarized in insights.
- Added Mux asset duration lookups, caching, and new duration totals/missing counts in workflow stats.
- Threaded the duration cache through insight generation and surfaced new fields in the stats payload.
- Threaded asset duration and thumbnail count through usage stats returned for each workflow
- Documented how `usage.metadata` is populated by workflows and consumed in eval insights

# Notes on usage metadata

`usage.metadata` is populated by each workflow when it builds its response. Workflows compute
context like asset duration (and thumbnail count for thumbnail-based workflows), then attach
those values on the `usage` object returned by the workflow. The eval output captures that
workflow response, so `post-evalite-results.ts` can read `output.usage.metadata` to aggregate
per-case duration and thumbnail metrics without extra Mux API calls.

# Suggested review order

1. `scripts/post-evalite-results.ts`
2. `src/lib/mux-assets.ts`
3. `src/types.ts`
4. `src/workflows/ask-questions.ts`
5. `src/workflows/burned-in-captions.ts`
6. `src/workflows/chapters.ts`
7. `src/workflows/embeddings.ts`
8. `src/workflows/moderation.ts`
9. `src/workflows/summarization.ts`
10. `src/workflows/translate-audio.ts`
11. `src/workflows/translate-captions.ts`
12. `examples/ask-questions/basic-example.ts`
13. `examples/moderation/basic-example.ts`
