### PR TITLE
feat: add hotspot primitive

### DIFF
--- a/src/primitives/hotspots.ts
+++ b/src/primitives/hotspots.ts
@@ -1,0 +1,152 @@
+import { getMuxClientFromEnv } from "@mux/ai/lib/client-factory";
+import type { WorkflowCredentialsInput } from "@mux/ai/types";
+
+export interface Hotspot {
+  /** Inclusive start time in milliseconds */
+  startMs: number;
+  /** Exclusive end time in milliseconds */
+  endMs: number;
+  /** Hotspot score using distribution-based normalization (0-1) */
+  score: number;
+}
+
+export interface HotspotOptions {
+  /** Maximum number of hotspots to return (default: 5) */
+  limit?: number;
+  /** Sort order: 'asc' or 'desc' (default: 'desc') */
+  orderDirection?: "asc" | "desc";
+  /** Order by field (default: 'score') */
+  orderBy?: "score";
+  /** Time window for results, e.g., ['7:days'] (default: ['7:days']) */
+  timeframe?: string;
+  /** Optional workflow credentials */
+  credentials?: WorkflowCredentialsInput;
+}
+
+/** Raw API response structure from Mux Data API */
+// To be removed when the Mux Node SDK is updated
+interface HotspotApiResponse {
+  total_row_count: number | null;
+  timeframe: [number, number];
+  data: {
+    asset_id?: string;
+    video_id?: string;
+    playback_id?: string;
+    hotspots: Array<{
+      start_ms: number;
+      end_ms: number;
+      score: number;
+    }>;
+  };
+}
+
+export interface HotspotResponse {
+  assetId?: string;
+  videoId?: string;
+  playbackId?: string;
+  hotspots: Hotspot[];
+}
+
+/**
+ * Fetches engagement hotspots for a Mux asset.
+ * Returns the top N "hot" time ranges based on engagement data.
+ *
+ * @param assetId - The Mux asset ID
+ * @param options - Hotspot query options
+ * @returns Array of hotspots with time ranges and scores
+ */
+export async function getHotspotsForAsset(
+  assetId: string,
+  options: HotspotOptions = {},
+): Promise<Hotspot[]> {
+  "use step";
+  const response = await fetchHotspots("assets", assetId, options);
+  return response.hotspots;
+}
+
+/**
+ * Fetches engagement hotspots for a Mux video ID.
+ * Returns the top N "hot" time ranges based on engagement data.
+ *
+ * @param videoId - The Mux video ID
+ * @param options - Hotspot query options
+ * @returns Array of hotspots with time ranges and scores
+ */
+export async function getHotspotsForVideo(
+  videoId: string,
+  options: HotspotOptions = {},
+): Promise<Hotspot[]> {
+  "use step";
+  const response = await fetchHotspots("videos", videoId, options);
+  return response.hotspots;
+}
+
+/**
+ * Fetches engagement hotspots for a Mux playback ID.
+ * Returns the top N "hot" time ranges based on engagement data.
+ *
+ * @param playbackId - The Mux playback ID
+ * @param options - Hotspot query options
+ * @returns Array of hotspots with time ranges and scores
+ */
+export async function getHotspotsForPlaybackId(
+  playbackId: string,
+  options: HotspotOptions = {},
+): Promise<Hotspot[]> {
+  "use step";
+  const response = await fetchHotspots("playback-ids", playbackId, options);
+  return response.hotspots;
+}
+
+/**
+ * Transforms the snake_case API response to camelCase for the public interface.
+ * TODO: Remove when the Mux Node SDK is updated
+ */
+function transformHotspotResponse(response: HotspotApiResponse): HotspotResponse {
+  return {
+    assetId: response.data.asset_id,
+    videoId: response.data.video_id,
+    playbackId: response.data.playback_id,
+    hotspots: response.data.hotspots.map(h => ({
+      startMs: h.start_ms,
+      endMs: h.end_ms,
+      score: h.score,
+    })),
+  };
+}
+
+/**
+ * Internal helper to fetch hotspots from the Mux Data API.
+ * Uses the raw HTTP methods on the Mux client since the SDK doesn't have
+ * typed methods for the engagement endpoints yet.
+ */
+async function fetchHotspots(
+  identifierType: "assets" | "videos" | "playback-ids",
+  id: string,
+  options: HotspotOptions,
+): Promise<HotspotResponse> {
+  "use step";
+  const {
+    limit = 5,
+    orderDirection = "desc",
+    orderBy = "score",
+    timeframe = "[24:hours]",
+    credentials,
+  } = options;
+
+  const muxClient = await getMuxClientFromEnv(credentials);
+  const mux = await muxClient.createClient();
+
+  // Build query parameters
+  const queryParams = new URLSearchParams();
+  queryParams.append("limit", String(limit));
+  queryParams.append("order_direction", orderDirection);
+  queryParams.append("order_by", orderBy);
+  queryParams.append("timeframe[]", timeframe);
+
+  // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
+  const path = `/data/v1/engagement/${identifierType}/${id}/hotspots?${queryParams.toString()}`;
+  const response = await mux.get<unknown, HotspotApiResponse>(path);
+
+  return transformHotspotResponse(response);
+}

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -1,4 +1,5 @@
 // primitives public surface intentionally minimal; provider plumbing lives in lib/providers
+export * from "./hotspots";
 export * from "./storyboards";
 export * from "./text-chunking";
 export * from "./thumbnails";

--- a/tests/unit/hotspots.test.ts
+++ b/tests/unit/hotspots.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getHotspotsForAsset,
+  getHotspotsForPlaybackId,
+  getHotspotsForVideo,
+} from "../../src/primitives/hotspots";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MOCK_API_RESPONSE = {
+  total_row_count: null,
+  timeframe: [1770831101, 1770917501] as [number, number],
+  data: {
+    asset_id: "test-asset-123",
+    hotspots: [
+      {
+        start_ms: 86922,
+        score: 0.875,
+        end_ms: 90331,
+      },
+      {
+        start_ms: 131235,
+        score: 0.76,
+        end_ms: 141461,
+      },
+      {
+        start_ms: 109079,
+        score: 0.691,
+        end_ms: 110783,
+      },
+      {
+        start_ms: 28974,
+        score: 0.603,
+        end_ms: 30678,
+      },
+      {
+        start_ms: 161914,
+        score: 0.603,
+        end_ms: 163618,
+      },
+    ],
+  },
+};
+
+const MOCK_EMPTY_RESPONSE = {
+  total_row_count: null,
+  timeframe: [1770831101, 1770917501] as [number, number],
+  data: {
+    video_id: "test-video-123",
+    hotspots: [],
+  },
+};
+
+const MOCK_SINGLE_HOTSPOT_RESPONSE = {
+  total_row_count: null,
+  timeframe: [1770831101, 1770917501] as [number, number],
+  data: {
+    playback_id: "test-playback-123",
+    hotspots: [
+      {
+        start_ms: 5000,
+        score: 0.95,
+        end_ms: 10000,
+      },
+    ],
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock Setup
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Mock the getMuxClientFromEnv function
+vi.mock("../../src/lib/client-factory", () => ({
+  getMuxClientFromEnv: vi.fn(),
+}));
+
+const mockMuxGet = vi.fn();
+const mockCreateClient = vi.fn(() => ({
+  get: mockMuxGet,
+}));
+
+// Import after mocking
+const { getMuxClientFromEnv } = await import("../../src/lib/client-factory");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getMuxClientFromEnv).mockResolvedValue({
+    createClient: mockCreateClient,
+  } as any);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getHotspotsForAsset
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getHotspotsForAsset", () => {
+  it("returns transformed hotspots array", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    const result = await getHotspotsForAsset("test-asset-123");
+
+    expect(result).toHaveLength(5);
+    expect(result[0]).toEqual({
+      startMs: 86922,
+      endMs: 90331,
+      score: 0.875,
+    });
+  });
+
+  it("transforms snake_case to camelCase", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    const result = await getHotspotsForAsset("test-asset-123");
+
+    // Verify all properties are camelCase
+    result.forEach((hotspot) => {
+      expect(hotspot).toHaveProperty("startMs");
+      expect(hotspot).toHaveProperty("endMs");
+      expect(hotspot).toHaveProperty("score");
+      expect(hotspot).not.toHaveProperty("start_ms");
+      expect(hotspot).not.toHaveProperty("end_ms");
+    });
+  });
+
+  it("handles empty hotspots array", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_EMPTY_RESPONSE);
+
+    const result = await getHotspotsForAsset("test-asset-123");
+
+    expect(result).toEqual([]);
+  });
+
+  it("uses default options when none provided", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHotspotsForAsset("test-asset-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("limit=5"),
+    );
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("order_direction=desc"),
+    );
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("order_by=score"),
+    );
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("timeframe%5B%5D=%5B24%3Ahours%5D"),
+    );
+  });
+
+  it("passes custom limit option", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHotspotsForAsset("test-asset-123", { limit: 3 });
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("limit=3"),
+    );
+  });
+
+  it("passes custom orderDirection option", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHotspotsForAsset("test-asset-123", { orderDirection: "asc" });
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("order_direction=asc"),
+    );
+  });
+
+  it("passes custom timeframe option", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHotspotsForAsset("test-asset-123", { timeframe: "[7:days]" });
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("timeframe%5B%5D=%5B7%3Adays%5D"),
+    );
+  });
+
+  it("constructs correct API path for assets", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHotspotsForAsset("test-asset-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("/data/v1/engagement/assets/test-asset-123/hotspots"),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getHotspotsForVideo
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getHotspotsForVideo", () => {
+  it("constructs correct API path for videos", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHotspotsForVideo("test-video-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("/data/v1/engagement/videos/test-video-123/hotspots"),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getHotspotsForPlaybackId
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getHotspotsForPlaybackId", () => {
+  it("constructs correct API path for playback-ids", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_SINGLE_HOTSPOT_RESPONSE);
+
+    await getHotspotsForPlaybackId("test-playback-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("/data/v1/engagement/playback-ids/test-playback-123/hotspots"),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type Safety Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("type Safety", () => {
+  it("accepts all valid option types", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    // This should compile without errors
+    await getHotspotsForAsset("test-asset", {
+      limit: 10,
+      orderDirection: "asc",
+      orderBy: "score",
+      timeframe: "[7:days]",
+    });
+
+    expect(mockMuxGet).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes https://mux1.atlassian.net/browse/AIT-25

This PR adds a new hotspots primitive that provides access to the engagement API, allowing you to identify the most engaging time ranges in a video.

Adds three public functions for fetching hotspots by different identifiers:

getHotspotsForAsset(assetId, options) - Fetch by Mux asset ID
getHotspotsForVideo(videoId, options) - Fetch by Mux video ID
getHotspotsForPlaybackId(playbackId, options) - Fetch by playback ID

Configuration options (Data API options):

limit - Maximum number of hotspots (default: 5)
orderDirection - Sort order: 'asc' or 'desc' (default: 'desc')
orderBy - Sort field (currently only 'score')
timeframe - Time window for data (default: '[24:hours]')
credentials - Optional workflow credentials