### PR TITLE
feat: add heatmap primitive

### DIFF
--- a/src/primitives/heatmap.ts
+++ b/src/primitives/heatmap.ts
@@ -1,0 +1,122 @@
+import { getMuxClientFromEnv } from "@mux/ai/lib/client-factory";
+import type { WorkflowCredentialsInput } from "@mux/ai/types";
+
+export interface HeatmapOptions {
+  /** Time window for results, e.g., ['7:days'] (default: ['7:days']) */
+  timeframe?: string;
+  /** Optional workflow credentials */
+  credentials?: WorkflowCredentialsInput;
+}
+
+/** Raw API response structure from Mux Data API */
+// To be removed when the Mux Node SDK is updated
+interface HeatmapApiResponse {
+  asset_id?: string;
+  video_id?: string;
+  playback_id?: string;
+  heatmap: number[];
+  timeframe: [number, number];
+}
+
+export interface HeatmapResponse {
+  assetId?: string;
+  videoId?: string;
+  playbackId?: string;
+  /** Array of 100 values representing engagement for each 1/100th of the video */
+  heatmap: number[];
+  timeframe: [number, number];
+}
+
+/**
+ * Fetches engagement heatmap for a Mux asset.
+ * Returns a length 100 array where each value represents how many times
+ * that 1/100th of the video was watched.
+ *
+ * @param assetId - The Mux asset ID
+ * @param options - Heatmap query options
+ * @returns Heatmap data with 100 engagement values
+ */
+export async function getHeatmapForAsset(
+  assetId: string,
+  options: HeatmapOptions = {},
+): Promise<HeatmapResponse> {
+  "use step";
+  return fetchHeatmap("assets", assetId, options);
+}
+
+/**
+ * Fetches engagement heatmap for a Mux video ID.
+ * Returns a length 100 array where each value represents how many times
+ * that 1/100th of the video was watched.
+ *
+ * @param videoId - The Mux video ID
+ * @param options - Heatmap query options
+ * @returns Heatmap data with 100 engagement values
+ */
+export async function getHeatmapForVideo(
+  videoId: string,
+  options: HeatmapOptions = {},
+): Promise<HeatmapResponse> {
+  "use step";
+  return fetchHeatmap("videos", videoId, options);
+}
+
+/**
+ * Fetches engagement heatmap for a Mux playback ID.
+ * Returns a length 100 array where each value represents how many times
+ * that 1/100th of the video was watched.
+ *
+ * @param playbackId - The Mux playback ID
+ * @param options - Heatmap query options
+ * @returns Heatmap data with 100 engagement values
+ */
+export async function getHeatmapForPlaybackId(
+  playbackId: string,
+  options: HeatmapOptions = {},
+): Promise<HeatmapResponse> {
+  "use step";
+  return fetchHeatmap("playback-ids", playbackId, options);
+}
+
+/**
+ * Transforms the snake_case API response to camelCase for the public interface.
+ * TODO: Remove when the Mux Node SDK is updated
+ */
+function transformHeatmapResponse(
+  response: HeatmapApiResponse,
+): HeatmapResponse {
+  return {
+    assetId: response.asset_id,
+    videoId: response.video_id,
+    playbackId: response.playback_id,
+    heatmap: response.heatmap,
+    timeframe: response.timeframe,
+  };
+}
+
+/**
+ * Internal helper to fetch heatmap from the Mux Data API.
+ * Uses the raw HTTP methods on the Mux client since the SDK doesn't have
+ * typed methods for the engagement endpoints yet.
+ */
+async function fetchHeatmap(
+  identifierType: "assets" | "videos" | "playback-ids",
+  id: string,
+  options: HeatmapOptions,
+): Promise<HeatmapResponse> {
+  "use step";
+  const { timeframe = "[24:hours]", credentials } = options;
+
+  const muxClient = await getMuxClientFromEnv(credentials);
+  const mux = await muxClient.createClient();
+
+  // Build query parameters
+  const queryParams = new URLSearchParams();
+  queryParams.append("timeframe[]", timeframe);
+
+  // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
+  const path = `/data/v1/engagement/${identifierType}/${id}/heatmap?${queryParams.toString()}`;
+  const response = await mux.get<unknown, HeatmapApiResponse>(path);
+
+  return transformHeatmapResponse(response);
+}

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -1,4 +1,5 @@
 // primitives public surface intentionally minimal; provider plumbing lives in lib/providers
+export * from "./heatmap";
 export * from "./storyboards";
 export * from "./text-chunking";
 export * from "./thumbnails";

--- a/tests/unit/heatmap.test.ts
+++ b/tests/unit/heatmap.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getHeatmapForAsset,
+  getHeatmapForPlaybackId,
+  getHeatmapForVideo,
+} from "../../src/primitives/heatmap";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MOCK_HEATMAP_DATA = Array.from({ length: 100 }, (_, i) =>
+  Math.round((1.0 + Math.sin(i / 10) * 0.5) * 100) / 100);
+
+const MOCK_API_RESPONSE = {
+  asset_id: "test-asset-123",
+  heatmap: MOCK_HEATMAP_DATA,
+  timeframe: [1770831101, 1770917501] as [number, number],
+};
+
+const MOCK_VIDEO_RESPONSE = {
+  video_id: "test-video-123",
+  heatmap: MOCK_HEATMAP_DATA,
+  timeframe: [1770831101, 1770917501] as [number, number],
+};
+
+const MOCK_PLAYBACK_RESPONSE = {
+  playback_id: "test-playback-123",
+  heatmap: MOCK_HEATMAP_DATA,
+  timeframe: [1770831101, 1770917501] as [number, number],
+};
+
+const MOCK_EMPTY_HEATMAP_RESPONSE = {
+  asset_id: "test-asset-empty",
+  heatmap: Array.from({ length: 100 }).fill(0),
+  timeframe: [1770831101, 1770917501] as [number, number],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock Setup
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Mock the getMuxClientFromEnv function
+vi.mock("../../src/lib/client-factory", () => ({
+  getMuxClientFromEnv: vi.fn(),
+}));
+
+const mockMuxGet = vi.fn();
+const mockCreateClient = vi.fn(() => ({
+  get: mockMuxGet,
+}));
+
+// Import after mocking
+const { getMuxClientFromEnv } = await import("../../src/lib/client-factory");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getMuxClientFromEnv).mockResolvedValue({
+    createClient: mockCreateClient,
+  } as any);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getHeatmapForAsset
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getHeatmapForAsset", () => {
+  it("returns transformed heatmap response", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    const result = await getHeatmapForAsset("test-asset-123");
+
+    expect(result.heatmap).toHaveLength(100);
+    expect(result.assetId).toBe("test-asset-123");
+    expect(result.timeframe).toEqual([1770831101, 1770917501]);
+  });
+
+  it("transforms snake_case to camelCase", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    const result = await getHeatmapForAsset("test-asset-123");
+
+    expect(result).toHaveProperty("assetId");
+    expect(result).toHaveProperty("heatmap");
+    expect(result).toHaveProperty("timeframe");
+    expect(result).not.toHaveProperty("asset_id");
+  });
+
+  it("handles empty heatmap array (all zeros)", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_EMPTY_HEATMAP_RESPONSE);
+
+    const result = await getHeatmapForAsset("test-asset-empty");
+
+    expect(result.heatmap).toHaveLength(100);
+    expect(result.heatmap.every(v => v === 0)).toBe(true);
+  });
+
+  it("uses default timeframe when none provided", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHeatmapForAsset("test-asset-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("timeframe%5B%5D=%5B24%3Ahours%5D"),
+    );
+  });
+
+  it("passes custom timeframe option", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHeatmapForAsset("test-asset-123", { timeframe: "[7:days]" });
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("timeframe%5B%5D=%5B7%3Adays%5D"),
+    );
+  });
+
+  it("constructs correct API path for assets", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    await getHeatmapForAsset("test-asset-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("/data/v1/engagement/assets/test-asset-123/heatmap"),
+    );
+  });
+
+  it("returns heatmap with numeric values", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    const result = await getHeatmapForAsset("test-asset-123");
+
+    expect(result.heatmap.every(v => typeof v === "number")).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getHeatmapForVideo
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getHeatmapForVideo", () => {
+  it("constructs correct API path for videos", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_VIDEO_RESPONSE);
+
+    await getHeatmapForVideo("test-video-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("/data/v1/engagement/videos/test-video-123/heatmap"),
+    );
+  });
+
+  it("returns video_id in response", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_VIDEO_RESPONSE);
+
+    const result = await getHeatmapForVideo("test-video-123");
+
+    expect(result.videoId).toBe("test-video-123");
+    expect(result.assetId).toBeUndefined();
+    expect(result.playbackId).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getHeatmapForPlaybackId
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getHeatmapForPlaybackId", () => {
+  it("constructs correct API path for playback-ids", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_PLAYBACK_RESPONSE);
+
+    await getHeatmapForPlaybackId("test-playback-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      expect.stringContaining("/data/v1/engagement/playback-ids/test-playback-123/heatmap"),
+    );
+  });
+
+  it("returns playback_id in response", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_PLAYBACK_RESPONSE);
+
+    const result = await getHeatmapForPlaybackId("test-playback-123");
+
+    expect(result.playbackId).toBe("test-playback-123");
+    expect(result.assetId).toBeUndefined();
+    expect(result.videoId).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type Safety Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("type Safety", () => {
+  it("accepts all valid option types", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    // This should compile without errors
+    await getHeatmapForAsset("test-asset", {
+      timeframe: "[30:days]",
+    });
+
+    expect(mockMuxGet).toHaveBeenCalled();
+  });
+
+  it("heatmap response has correct structure", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_API_RESPONSE);
+
+    const result = await getHeatmapForAsset("test-asset-123");
+
+    expect(result).toHaveProperty("heatmap");
+    expect(result).toHaveProperty("timeframe");
+    expect(Array.isArray(result.heatmap)).toBe(true);
+    expect(Array.isArray(result.timeframe)).toBe(true);
+    expect(result.timeframe).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Fixes https://mux1.atlassian.net/browse/AIT-26

This PR adds a new heatmap primitive that provides access to the engagement API.

Adds three public functions for fetching hotspots by different identifiers:

getHeatmapForAsset(assetId, options) - Fetch by Mux asset ID
geteatmapForVideo(videoId, options) - Fetch by Mux video ID
geteatmapForPlaybackId(playbackId, options) - Fetch by playback ID

Configuration options:

timeframe - Time window for data (default: '[24:hours]')
credentials - Optional workflow credentials