### PR TITLE
chore: Add peer dependency on workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,14 @@
       },
       "engines": {
         "node": ">=21.0.0"
+      },
+      "peerDependencies": {
+        "workflow": ">=4.1.0-beta.55"
+      },
+      "peerDependenciesMeta": {
+        "workflow": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/anthropic": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,14 @@
     "evalite:post-results:production": "npx tsx scripts/export-evalite-results.ts && npx tsx scripts/post-evalite-results.ts",
     "prepare": "husky"
   },
+  "peerDependencies": {
+    "workflow": ">=4.1.0-beta.55"
+  },
+  "peerDependenciesMeta": {
+    "workflow": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.16",
     "@ai-sdk/google": "^3.0.10",
@@ -112,14 +120,6 @@
     "dotenv-expand": "^12.0.3",
     "p-retry": "^7.0.0",
     "zod": "^3.25.76"
-  },
-  "peerDependencies": {
-    "workflow": ">=4.1.0-beta.55"
-  },
-  "peerDependenciesMeta": {
-    "workflow": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@antfu/eslint-config": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,14 @@
     "p-retry": "^7.0.0",
     "zod": "^3.25.76"
   },
+  "peerDependencies": {
+    "workflow": ">=4.1.0-beta.55"
+  },
+  "peerDependenciesMeta": {
+    "workflow": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@antfu/eslint-config": "^6.2.0",
     "@types/node": "^20.0.0",


### PR DESCRIPTION
Adds an optional peer dependency on `workflow`, with a matching version to the one we use today

* When the application that depends on @mux/ai uses workflow, they will be warned if they don't meet the dependent version
* When the application that depends on @mux/ai DOES NOT use workflow, nothing happens