### PR TITLE
feat: Add Authorization Token support

### DIFF
--- a/src/lib/url-signing.ts
+++ b/src/lib/url-signing.ts
@@ -99,13 +99,12 @@ export async function signPlaybackId(
 export async function signUrl(
   url: string,
   playbackId: string,
-  context?: SigningContext,
   type: TokenType = "video",
   params?: Record<string, string | number>,
   credentials?: WorkflowCredentialsInput,
 ): Promise<string> {
   "use step";
-  const resolvedContext = context ?? await resolveMuxSigningContext(credentials);
+  const resolvedContext = await resolveMuxSigningContext(credentials);
   if (!resolvedContext) {
     throw new Error(
       "Signed playback ID requires signing credentials. " +

--- a/src/lib/url-signing.ts
+++ b/src/lib/url-signing.ts
@@ -91,7 +91,6 @@ export async function signPlaybackId(
  *
  * @param url - The base Mux URL (e.g. https://image.mux.com/{playbackId}/thumbnail.png)
  * @param playbackId - The Mux playback ID
- * @param context - Signing context with key credentials
  * @param type - Token type for the URL
  * @param params - Additional parameters for the token
  * @returns URL with token query parameter appended

--- a/src/lib/workflow-credentials.ts
+++ b/src/lib/workflow-credentials.ts
@@ -143,8 +143,9 @@ export async function resolveWorkflowCredentials(
 }
 
 interface DirectMuxCredentials {
-  tokenId: string;
-  tokenSecret: string;
+  tokenId?: string;
+  tokenSecret?: string;
+  authorizationToken?: string;
   signingKey?: string;
   privateKey?: string;
 }
@@ -157,14 +158,15 @@ function readString(record: Record<string, unknown> | undefined, key: string): s
 function resolveDirectMuxCredentials(record: Record<string, unknown> | undefined): DirectMuxCredentials | undefined {
   const tokenId = readString(record, "muxTokenId");
   const tokenSecret = readString(record, "muxTokenSecret");
+  const authorizationToken = readString(record, "muxAuthorizationToken");
   const signingKey = readString(record, "muxSigningKey");
   const privateKey = readString(record, "muxPrivateKey");
 
-  if (!tokenId && !tokenSecret && !signingKey && !privateKey) {
+  if (!tokenId && !tokenSecret && !authorizationToken && !signingKey && !privateKey) {
     return undefined;
   }
 
-  if (!tokenId || !tokenSecret) {
+  if ((!tokenId || !tokenSecret) && !authorizationToken) {
     throw new Error(
       "Both muxTokenId and muxTokenSecret are required when passing direct Mux workflow credentials.",
     );
@@ -173,6 +175,7 @@ function resolveDirectMuxCredentials(record: Record<string, unknown> | undefined
   return {
     tokenId,
     tokenSecret,
+    authorizationToken,
     signingKey,
     privateKey,
   };
@@ -186,6 +189,7 @@ function createWorkflowMuxClient(options: DirectMuxCredentials): WorkflowMuxClie
       return new MuxClient({
         tokenId: options.tokenId,
         tokenSecret: options.tokenSecret,
+        authorizationToken: options.authorizationToken,
       });
     },
     getSigningKey() {

--- a/src/primitives/storyboards.ts
+++ b/src/primitives/storyboards.ts
@@ -22,7 +22,7 @@ export async function getStoryboardUrl(
   const baseUrl = `https://image.mux.com/${playbackId}/storyboard.png`;
 
   if (shouldSign) {
-    return signUrl(baseUrl, playbackId, undefined, "storyboard", { width }, credentials);
+    return signUrl(baseUrl, playbackId, "storyboard", { width }, credentials);
   }
 
   return `${baseUrl}?width=${width}`;

--- a/src/primitives/thumbnails.ts
+++ b/src/primitives/thumbnails.ts
@@ -67,7 +67,7 @@ export async function getThumbnailUrls(
 
   const urlPromises = timestamps.map(async (time) => {
     if (shouldSign) {
-      return signUrl(baseUrl, playbackId, undefined, "thumbnail", { time, width }, credentials);
+      return signUrl(baseUrl, playbackId, "thumbnail", { time, width }, credentials);
     }
 
     return `${baseUrl}?time=${time}&width=${width}`;

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -213,7 +213,7 @@ export async function buildTranscriptUrl(
   const baseUrl = `https://stream.mux.com/${playbackId}/text/${trackId}.vtt`;
 
   if (shouldSign) {
-    return signUrl(baseUrl, playbackId, undefined, "video", undefined, credentials);
+    return signUrl(baseUrl, playbackId, "video", undefined, credentials);
   }
 
   return baseUrl;

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,8 @@ export interface WorkflowCredentials {
   muxTokenId?: string;
   /** Direct Mux API token secret for per-request credential injection. */
   muxTokenSecret?: string;
+  /** Direct Mux API auth token secret for per-request credential injection. */
+  muxAuthorizationToken?: string;
   /** Optional direct Mux signing key ID for signed playback URL generation. */
   muxSigningKey?: string;
   /** Optional direct Mux private key for signed playback URL generation. */

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -459,7 +459,7 @@ async function getThumbnailUrlsFromTimestamps(
   const urlPromises = timestampsMs.map(async (tsMs) => {
     const time = Number((tsMs / 1000).toFixed(2));
     if (shouldSign) {
-      return signUrl(baseUrl, playbackId, undefined, "thumbnail", { time, width }, credentials);
+      return signUrl(baseUrl, playbackId, "thumbnail", { time, width }, credentials);
     }
 
     return `${baseUrl}?time=${time}&width=${width}`;

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -436,7 +436,7 @@ export async function translateAudio(
   // Build audio URL (signed if needed)
   let audioUrl = `https://stream.mux.com/${playbackId}/audio.m4a`;
   if (policy === "signed") {
-    audioUrl = await signUrl(audioUrl, playbackId, undefined, "video", undefined, credentials);
+    audioUrl = await signUrl(audioUrl, playbackId, "video", undefined, credentials);
   }
 
   // Fetch audio from Mux

--- a/tests/integration/signed-playback.test.ts
+++ b/tests/integration/signed-playback.test.ts
@@ -105,7 +105,7 @@ describe("signed Playback Integration Tests", () => {
   describe("signUrl", () => {
     it.skipIf(!hasSigningCredentials)("should append token to URL without query params", async () => {
       const baseUrl = "https://image.mux.com/test-id/storyboard.png";
-      const signedUrl = await signUrl(baseUrl, "test-id", signingContext, "storyboard");
+      const signedUrl = await signUrl(baseUrl, "test-id", "storyboard");
 
       expect(signedUrl).toContain(baseUrl);
       expect(signedUrl).toContain("?token=");
@@ -113,7 +113,7 @@ describe("signed Playback Integration Tests", () => {
 
     it.skipIf(!hasSigningCredentials)("should append token to URL with existing query params", async () => {
       const baseUrl = "https://image.mux.com/test-id/thumbnail.png?width=640";
-      const signedUrl = await signUrl(baseUrl, "test-id", signingContext, "thumbnail");
+      const signedUrl = await signUrl(baseUrl, "test-id", "thumbnail");
 
       expect(signedUrl).toContain(baseUrl);
       expect(signedUrl).toContain("&token=");


### PR DESCRIPTION
# Overview

Adds `muxAuthorizationToken` as an alternative to the `muxTokenId`/`muxTokenSecret` pair for Mux API authentication.

# What was changed

- Added `muxAuthorizationToken` field to `WorkflowCredentials` interface
- Updated credential resolution to accept either token pair OR authorization token
- Removed unused `context` parameter from `signUrl()` and updated all call sites

# Suggested review order

1. [src/types.ts](src/types.ts) - New `muxAuthorizationToken` field in `WorkflowCredentials`
2. [src/lib/workflow-credentials.ts](src/lib/workflow-credentials.ts) - Resolution logic allowing auth token as alternative
3. [src/lib/url-signing.ts](src/lib/url-signing.ts) - Removed unused `context` parameter from `signUrl()`
4. Call site updates: [storyboards.ts](src/primitives/storyboards.ts), [thumbnails.ts](src/primitives/thumbnails.ts), [transcripts.ts](src/primitives/transcripts.ts), [moderation.ts](src/workflows/moderation.ts), [translate-audio.ts](src/workflows/translate-audio.ts)
5. [tests/integration/signed-playback.test.ts](tests/integration/signed-playback.test.ts) - Updated test calls
