### PR TITLE
chore: Audio translation source language

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -312,7 +312,7 @@ player.addChapters([
 
 ## `translateAudio(assetId, toLanguageCode, options?)`
 
-Creates AI-dubbed audio tracks from existing media content using ElevenLabs voice cloning and translation. Uses the default audio track on your asset, language is auto-detected.
+Creates AI-dubbed audio tracks from existing media content using ElevenLabs voice cloning and translation. Uses the default audio track on your asset. Source language is auto-detected unless `fromLanguageCode` is provided.
 
 **Parameters:**
 
@@ -323,6 +323,7 @@ Creates AI-dubbed audio tracks from existing media content using ElevenLabs voic
 **Options:**
 
 - `provider?: 'elevenlabs'` - AI provider (default: 'elevenlabs')
+- `fromLanguageCode?: string` - Optional source language code passed to ElevenLabs `source_lang` (ISO 639-1 or ISO 639-3, default: auto-detect)
 - `numSpeakers?: number` - Number of speakers (default: 0 for auto-detect)
 - `uploadToMux?: boolean` - Whether to upload dubbed track to Mux (default: true)
 - `s3Endpoint?: string` - S3-compatible storage endpoint

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -47,7 +47,7 @@ npm run example:moderation:compare <asset-id>
 npm run example:translate-captions <asset-id> [from-lang] [to-lang] [provider]
 
 # Audio Translation (Dubbing)
-npm run example:translate-audio <asset-id> [to-lang]
+npm run example:translate-audio <asset-id> -- --to <to-lang> [--from <from-lang>]
 
 # Signed Playback (for assets with signed playback policies)
 npm run example:signed-playback <signed-asset-id>
@@ -82,7 +82,7 @@ npm run example:translate-captions abc123 en es anthropic
 npm run example:summarization abc123 anthropic
 
 # Create AI-dubbed audio in French
-npm run example:translate-audio abc123 fr
+npm run example:translate-audio abc123 -- --to fr --from en
 ```
 
 ## Summarization Examples
@@ -216,7 +216,7 @@ npm run aws-sdk-adapter <your-asset-id> -- --s3-bucket <bucket-name>
 ```bash
 cd examples/translate-audio
 npm install
-npm run basic <your-asset-id> es
+npm run basic <your-asset-id> -- --to es [--from en]
 npm run dubbing-only <your-asset-id> fr
 ```
 
@@ -224,7 +224,7 @@ npm run dubbing-only <your-asset-id> fr
 
 1. Checks asset has audio.m4a static rendition
 2. Downloads default audio track from Mux
-3. Creates ElevenLabs dubbing job with automatic language detection
+3. Creates ElevenLabs dubbing job (source language auto-detected unless `--from` is set)
 4. Polls for completion (up to 30 minutes)
 5. Downloads dubbed audio file
 6. Uploads to S3-compatible storage

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -388,12 +388,13 @@ Create AI-dubbed audio tracks using ElevenLabs voice cloning (video or audio-onl
 import { translateAudio } from "@mux/ai/workflows";
 
 // Create dubbed audio and upload to Mux
-// Uses default audio track, language auto-detected
+// Uses default audio track; source language auto-detected unless provided
 const result = await translateAudio(
   "your-mux-asset-id",
   "es", // target language
   {
     provider: "elevenlabs",
+    fromLanguageCode: "en", // optional source language
     numSpeakers: 0 // Auto-detect speakers
   }
 );
@@ -417,7 +418,7 @@ ElevenLabs supports 32+ languages with automatic language name detection via `In
 
 1. Checks asset has audio.m4a static rendition
 2. Downloads default audio track from Mux
-3. Creates ElevenLabs dubbing job with automatic language detection
+3. Creates ElevenLabs dubbing job (source language auto-detected unless `fromLanguageCode` is set)
 4. Polls for completion (up to 30 minutes)
 5. Downloads dubbed audio file
 6. Uploads to S3-compatible storage

--- a/examples/translate-audio/basic-example.ts
+++ b/examples/translate-audio/basic-example.ts
@@ -10,20 +10,23 @@ program
   .name("translate-audio")
   .description("Translate audio (dubbing) for a Mux video asset")
   .argument("<asset-id>", "Mux asset ID to translate")
+  .option("-f, --from <language>", "Source language code (defaults to auto-detect)")
   .option("-t, --to <language>", "Target language code", "es")
   .option("-s, --speakers <number>", "Number of speakers (0 for auto-detect)", "0")
   .option("--no-upload", "Skip uploading translated audio to Mux (returns presigned URL only)")
   .addHelpText("after", `
 Notes:
   - Asset must have an audio.m4a static rendition
-  - Uses default audio track, source language is auto-detected
+  - Uses default audio track, source language is auto-detected unless --from is provided
   - Provider is ElevenLabs (currently the only supported audio translation provider)`)
   .action(async (assetId: string, options: {
+    from?: string;
     to: string;
     speakers: string;
     upload: boolean;
   }) => {
     const numSpeakers = Number.parseInt(options.speakers, 10);
+    const fromLanguageCode = options.from?.trim() || undefined;
 
     if (Number.isNaN(numSpeakers) || numSpeakers < 0) {
       console.error("❌ Invalid number of speakers. Must be a non-negative integer.");
@@ -31,7 +34,7 @@ Notes:
     }
 
     console.log(`Asset ID: ${assetId}`);
-    console.log(`Audio Dubbing: auto-detect -> ${options.to}`);
+    console.log(`Audio Dubbing: ${fromLanguageCode ?? "auto-detect"} -> ${options.to}`);
     console.log(`Number of Speakers: ${numSpeakers === 0 ? "auto-detect" : numSpeakers}`);
     console.log(`Upload to Mux: ${options.upload}\n`);
 
@@ -40,6 +43,7 @@ Notes:
 
       const result = await translateAudio(assetId, options.to, {
         provider: "elevenlabs",
+        fromLanguageCode,
         numSpeakers,
         uploadToMux: options.upload,
       });


### PR DESCRIPTION
Adds a `fromLanguageCode` option to the `translateAudio` workflow to allow explicit specification of the source language for ElevenLabs dubbing.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-26958ff1-bb5c-4570-a200-40eb6eef8d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26958ff1-bb5c-4570-a200-40eb6eef8d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

