### PR TITLE
chore: add dynamic model selection for evals

### DIFF
--- a/.github/workflows/eval-tests.yml
+++ b/.github/workflows/eval-tests.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
+    inputs:
+      eval_model_set:
+        description: "Eval model selection mode"
+        required: false
+        default: "default"
+        type: choice
+        options:
+          - default
+          - all
 
 jobs:
   evals:
@@ -21,6 +31,7 @@ jobs:
 
       - name: Run Evalite
         env:
+          MUX_AI_EVAL_MODEL_SET: ${{ github.event.inputs.eval_model_set || 'default' }}
           MUX_TOKEN_ID: ${{ secrets.MUX_TOKEN_ID }}
           MUX_TOKEN_SECRET: ${{ secrets.MUX_TOKEN_SECRET }}
           MUX_SIGNING_KEY: ${{ secrets.MUX_SIGNING_KEY }}

--- a/.github/workflows/eval-tests.yml
+++ b/.github/workflows/eval-tests.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       eval_model_set:
-        description: "Eval model selection mode"
+        description: Eval model selection mode
         required: false
-        default: "default"
+        default: default
         type: choice
         options:
           - default

--- a/.github/workflows/publish-evalite-results.yml
+++ b/.github/workflows/publish-evalite-results.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
   workflow_dispatch: # Allows manual triggering from any branch
+    inputs:
+      eval_model_set:
+        description: "Eval model selection mode"
+        required: false
+        default: "default"
+        type: choice
+        options:
+          - default
+          - all
 
 jobs:
   build-and-deploy:
@@ -20,6 +29,7 @@ jobs:
 
       - name: Run Evalite and Export Results
         env:
+          MUX_AI_EVAL_MODEL_SET: ${{ github.event.inputs.eval_model_set || 'default' }}
           MUX_TOKEN_ID: ${{ secrets.MUX_TOKEN_ID }}
           MUX_TOKEN_SECRET: ${{ secrets.MUX_TOKEN_SECRET }}
           MUX_SIGNING_KEY: ${{ secrets.MUX_SIGNING_KEY }}

--- a/.github/workflows/publish-evalite-results.yml
+++ b/.github/workflows/publish-evalite-results.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch: # Allows manual triggering from any branch
     inputs:
       eval_model_set:
-        description: "Eval model selection mode"
+        description: Eval model selection mode
         required: false
-        default: "default"
+        default: default
         type: choice
         options:
           - default

--- a/docs/EVALS.md
+++ b/docs/EVALS.md
@@ -59,6 +59,29 @@ npx evalite serve tests/eval
 
 This runs all `*.eval.ts` files in one pass and opens the Evalite UI at `http://localhost:3006` for exploring results. There is no watch mode—you'll need to manually re-run when you're ready to test changes.
 
+By default, evals run against provider default models only:
+
+- `openai:gpt-5.1`
+- `anthropic:claude-sonnet-4-5`
+- `google:gemini-3-flash-preview`
+
+To run all configured models in `LANGUAGE_MODELS`:
+
+```bash
+npx tsx scripts/export-evalite-results.ts --model-set all
+```
+
+To run an explicit list:
+
+```bash
+npx tsx scripts/export-evalite-results.ts --models openai:gpt-5.1,openai:gpt-5-mini,google:gemini-2.5-flash
+```
+
+The same behavior is available via env vars:
+
+- `MUX_AI_EVAL_MODEL_SET=default|all`
+- `MUX_AI_EVAL_MODELS=provider:model,provider:model` (takes precedence over `MUX_AI_EVAL_MODEL_SET`)
+
 **Running a single eval file:**
 
 ```bash
@@ -193,7 +216,13 @@ const COST_THRESHOLD_USD = 0.012;
 
 ## Cross-Provider and Cross-Model Testing
 
-All evals test across multiple providers and models to compare results. The `EVAL_MODEL_CONFIGS` constant provides a flattened list of every (provider, model) pair:
+All evals iterate over `EVAL_MODEL_CONFIGS`, which is resolved at runtime and can represent:
+
+- provider defaults only (`MUX_AI_EVAL_MODEL_SET=default`, the default)
+- all configured models (`MUX_AI_EVAL_MODEL_SET=all`)
+- an explicit list (`MUX_AI_EVAL_MODELS=provider:model,...`)
+
+The `EVAL_MODEL_CONFIGS` constant provides the flattened `(provider, model)` pairs for each run:
 
 ```typescript
 import { EVAL_MODEL_CONFIGS } from "../../src/lib/providers";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,4 +42,9 @@ export default antfu({
     // Operators at end of line, not beginning
     "style/operator-linebreak": ["error", "after"],
   },
+}, {
+  files: ["scripts/**/*.ts"],
+  rules: {
+    "node/no-process-env": ["off"],
+  },
 });

--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
     "example:translate-captions": "npx tsx examples/translate-captions/basic-example.ts",
     "example:translate-captions:aws-sdk": "npx tsx examples/translate-captions/aws-sdk-storage-adapter-example.ts",
     "example:translate-audio": "npx tsx examples/translate-audio/basic-example.ts",
-    "evalite:post-results:dev": "npx tsx scripts/export-evalite-results.ts && npx tsx scripts/post-evalite-results.ts -d -k",
-    "evalite:post-results:production": "npx tsx scripts/export-evalite-results.ts && npx tsx scripts/post-evalite-results.ts",
+    "evalite:post-results:dev": "npx tsx scripts/export-evalite-results.ts --model-set all && npx tsx scripts/post-evalite-results.ts -d -k",
+    "evalite:post-results:production": "npx tsx scripts/export-evalite-results.ts --model-set all && npx tsx scripts/post-evalite-results.ts",
     "prepare": "husky"
   },
   "peerDependencies": {

--- a/scripts/export-evalite-results.ts
+++ b/scripts/export-evalite-results.ts
@@ -1,12 +1,11 @@
-/* eslint-disable node/no-process-env */
-
 import { Command } from "commander";
 import { runEvalite } from "evalite/runner";
 
 import { LANGUAGE_MODELS, resolveEvalModelConfigsFromEnv } from "../src/lib/providers";
+import type { EvalModelSelection } from "../src/lib/providers";
 
 interface Options {
-  modelSet: "default" | "all";
+  modelSet: EvalModelSelection;
   models?: string;
 }
 

--- a/scripts/export-evalite-results.ts
+++ b/scripts/export-evalite-results.ts
@@ -1,7 +1,41 @@
+/* eslint-disable node/no-process-env */
+
+import { Command } from "commander";
 import { runEvalite } from "evalite/runner";
 
-async function runEvals() {
+import { LANGUAGE_MODELS, resolveEvalModelConfigsFromEnv } from "../src/lib/providers";
+
+interface Options {
+  modelSet: "default" | "all";
+  models?: string;
+}
+
+function formatResolvedModelConfigs() {
+  return resolveEvalModelConfigsFromEnv()
+    .map(({ provider, modelId }) => `${provider}:${modelId}`)
+    .join(", ");
+}
+
+async function runEvals(options: Options) {
   try {
+    process.env.MUX_AI_EVAL_MODEL_SET = options.modelSet;
+    if (options.models?.trim()) {
+      process.env.MUX_AI_EVAL_MODELS = options.models.trim();
+    } else {
+      delete process.env.MUX_AI_EVAL_MODELS;
+    }
+
+    console.warn(`Running evals with model set: ${options.modelSet}`);
+    if (options.models?.trim()) {
+      console.warn(`Using explicit model list: ${options.models.trim()}`);
+    } else {
+      const available = Object.entries(LANGUAGE_MODELS)
+        .flatMap(([provider, models]) => models.map(model => `${provider}:${model}`))
+        .join(", ");
+      console.warn(`Available models: ${available}`);
+    }
+    console.warn(`Resolved eval model configs: ${formatResolvedModelConfigs()}`);
+
     await runEvalite({
       mode: "run-once-and-exit",
       scoreThreshold: 75, // Fail if average score < 75
@@ -14,4 +48,28 @@ async function runEvals() {
   }
 }
 
-runEvals();
+const program = new Command();
+
+program
+  .name("export-evalite-results")
+  .description("Run evalite once and export results JSON")
+  .option(
+    "--model-set <set>",
+    "Model selection mode for eval suites (default: provider defaults only)",
+    (value: string) => {
+      if (value !== "default" && value !== "all") {
+        throw new Error(`Invalid --model-set value "${value}". Use "default" or "all".`);
+      }
+      return value;
+    },
+    "default",
+  )
+  .option(
+    "--models <pairs>",
+    "Explicit comma-separated provider:model list (overrides --model-set), e.g. openai:gpt-5.1,google:gemini-2.5-flash",
+  )
+  .action(async (options: Options) => {
+    await runEvals(options);
+  });
+
+program.parse();

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-process-env */
 import { execSync } from "node:child_process";
 import { readFile, unlink } from "node:fs/promises";
 import path from "node:path";

--- a/src/env.ts
+++ b/src/env.ts
@@ -55,6 +55,10 @@ const EnvSchema = z.object({
   MUX_TEST_ASSET_ID_AUDIO_ONLY: optionalString("Mux test asset ID for audio-only assets.", "Mux test asset id for audio-only assets for testing"),
   MUX_TEST_ASSET_ID_VIOLENT_AUDIO_ONLY: optionalString("Mux test asset ID for audio-only assets with violent content.", "Mux test asset id for audio-only assets with violent content for testing"),
 
+  // Eval config
+  MUX_AI_EVAL_MODEL_SET: optionalString("Eval model selection mode.", "Choose between 'default' (provider defaults only) or 'all' (all configured models)"),
+  MUX_AI_EVAL_MODELS: optionalString("Comma-separated eval model pairs.", "Comma-separated provider:model pairs (e.g. 'openai:gpt-5.1,anthropic:claude-sonnet-4-5,google:gemini-3-flash-preview')"),
+
   // AI Providers
   OPENAI_API_KEY: optionalString("OpenAI API key for OpenAI-backed workflows.", "OpenAI API key"),
   ANTHROPIC_API_KEY: optionalString("Anthropic API key for Claude-backed workflows.", "Anthropic API key"),


### PR DESCRIPTION
# Overview

This branch makes eval model coverage configurable at runtime instead of always running all configured models. It adds env/CLI/workflow controls so eval runs can target provider defaults, all models, or an explicit model list.

Additionally this change ensures when we run evals for all _supported_ models when publishing results -- post merge to main

# What was changed

- Added runtime eval model resolution logic in `src/lib/providers.ts`:
  - new `resolveEvalModelConfigs(...)`
  - new `resolveEvalModelConfigsFromEnv(...)`
  - `EVAL_MODEL_CONFIGS` now resolves from env
- Added eval env vars in `src/env.ts`:
  - `MUX_AI_EVAL_MODEL_SET` (`default` | `all`)
  - `MUX_AI_EVAL_MODELS` (comma-separated `provider:model` pairs, overrides model set)
- Updated `scripts/export-evalite-results.ts`:
  - added CLI options `--model-set` and `--models`
  - sets env vars before running Evalite
  - logs available/resolved model configs for visibility
- Updated CI workflows:
  - `.github/workflows/eval-tests.yml` adds `workflow_dispatch` model-set input and passes `MUX_AI_EVAL_MODEL_SET`
  - `.github/workflows/publish-evalite-results.yml` adds matching dispatch input and env wiring
- Updated scripts/docs:
  - `package.json` eval post-results scripts now run with `--model-set all`
  - `docs/EVALS.md` documents default/all/explicit model selection behavior and commands

# Suggested review order

1. `src/lib/providers.ts` (core selection + validation behavior)
2. `scripts/export-evalite-results.ts` (CLI surface and env precedence)
3. `.github/workflows/eval-tests.yml` and `.github/workflows/publish-evalite-results.yml` (CI/manual trigger wiring)
4. `src/env.ts` (new env contract)
5. `docs/EVALS.md` and `package.json` (usage and operational defaults)
