### PR TITLE
feat: Add MUX_IMAGE_URL_OVERRIDE environment variable

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -35,6 +35,10 @@ const EnvSchema = z.object({
 
   MUX_SIGNING_KEY: optionalString("Mux signing key ID for signed playback URLs.", "Used to sign playback URLs"),
   MUX_PRIVATE_KEY: optionalString("Mux signing private key for signed playback URLs.", "Used to sign playback URLs"),
+  MUX_IMAGE_HOST_OVERRIDE: optionalString(
+    "Override for Mux image host (defaults to image.mux.com).",
+    "Mux image host override",
+  ),
 
   // Test-only helpers (used by this repo's integration tests)
   MUX_TEST_ASSET_ID: optionalString("Mux asset ID used by integration tests.", "Mux test asset id"),

--- a/src/env.ts
+++ b/src/env.ts
@@ -35,9 +35,9 @@ const EnvSchema = z.object({
 
   MUX_SIGNING_KEY: optionalString("Mux signing key ID for signed playback URLs.", "Used to sign playback URLs"),
   MUX_PRIVATE_KEY: optionalString("Mux signing private key for signed playback URLs.", "Used to sign playback URLs"),
-  MUX_IMAGE_HOST_OVERRIDE: optionalString(
-    "Override for Mux image host (defaults to image.mux.com).",
-    "Mux image host override",
+  MUX_IMAGE_URL_OVERRIDE: optionalString(
+    "Override for Mux image base URL (defaults to https://image.mux.com).",
+    "Mux image URL override",
   ),
 
   // Test-only helpers (used by this repo's integration tests)

--- a/src/lib/mux-image-url.ts
+++ b/src/lib/mux-image-url.ts
@@ -1,8 +1,8 @@
 import env from "@mux/ai/env";
 
-const DEFAULT_MUX_IMAGE_HOST = "image.mux.com";
+const DEFAULT_MUX_IMAGE_ORIGIN = "https://image.mux.com";
 
-function normalizeMuxImageHost(value: string): string {
+function normalizeMuxImageOrigin(value: string): string {
   const trimmed = value.trim();
   const candidate = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
 
@@ -11,7 +11,7 @@ function normalizeMuxImageHost(value: string): string {
     parsed = new URL(candidate);
   } catch {
     throw new Error(
-      "Invalid MUX_IMAGE_HOST_OVERRIDE. Provide a hostname like " +
+      "Invalid MUX_IMAGE_URL_OVERRIDE. Provide a hostname like " +
       `"image.example.mux.com" (or a URL origin such as "https://image.example.mux.com").`,
     );
   }
@@ -24,26 +24,26 @@ function normalizeMuxImageHost(value: string): string {
     (parsed.pathname && parsed.pathname !== "/")
   ) {
     throw new Error(
-      "Invalid MUX_IMAGE_HOST_OVERRIDE. Only a hostname/origin is allowed " +
+      "Invalid MUX_IMAGE_URL_OVERRIDE. Only a hostname/origin is allowed " +
       "(no credentials, query params, hash fragments, or path).",
     );
   }
 
-  return parsed.host;
+  return parsed.origin;
 }
 
-export function getMuxImageHost(): string {
-  const override = env.MUX_IMAGE_HOST_OVERRIDE;
+export function getMuxImageOrigin(): string {
+  const override = env.MUX_IMAGE_URL_OVERRIDE;
   if (!override) {
-    return DEFAULT_MUX_IMAGE_HOST;
+    return DEFAULT_MUX_IMAGE_ORIGIN;
   }
 
-  return normalizeMuxImageHost(override);
+  return normalizeMuxImageOrigin(override);
 }
 
 export function getMuxImageBaseUrl(playbackId: string, assetType: "storyboard" | "thumbnail"): string {
-  const host = getMuxImageHost();
-  return `https://${host}/${playbackId}/${assetType}.png`;
+  const origin = getMuxImageOrigin();
+  return `${origin}/${playbackId}/${assetType}.png`;
 }
 
 export function getMuxStoryboardBaseUrl(playbackId: string): string {

--- a/src/lib/mux-image-url.ts
+++ b/src/lib/mux-image-url.ts
@@ -1,0 +1,55 @@
+import env from "@mux/ai/env";
+
+const DEFAULT_MUX_IMAGE_HOST = "image.mux.com";
+
+function normalizeMuxImageHost(value: string): string {
+  const trimmed = value.trim();
+  const candidate = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    throw new Error(
+      "Invalid MUX_IMAGE_HOST_OVERRIDE. Provide a hostname like " +
+      `"image.example.mux.com" (or a URL origin such as "https://image.example.mux.com").`,
+    );
+  }
+
+  if (
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash ||
+    (parsed.pathname && parsed.pathname !== "/")
+  ) {
+    throw new Error(
+      "Invalid MUX_IMAGE_HOST_OVERRIDE. Only a hostname/origin is allowed " +
+      "(no credentials, query params, hash fragments, or path).",
+    );
+  }
+
+  return parsed.host;
+}
+
+export function getMuxImageHost(): string {
+  const override = env.MUX_IMAGE_HOST_OVERRIDE;
+  if (!override) {
+    return DEFAULT_MUX_IMAGE_HOST;
+  }
+
+  return normalizeMuxImageHost(override);
+}
+
+export function getMuxImageBaseUrl(playbackId: string, assetType: "storyboard" | "thumbnail"): string {
+  const host = getMuxImageHost();
+  return `https://${host}/${playbackId}/${assetType}.png`;
+}
+
+export function getMuxStoryboardBaseUrl(playbackId: string): string {
+  return getMuxImageBaseUrl(playbackId, "storyboard");
+}
+
+export function getMuxThumbnailBaseUrl(playbackId: string): string {
+  return getMuxImageBaseUrl(playbackId, "thumbnail");
+}

--- a/src/primitives/storyboards.ts
+++ b/src/primitives/storyboards.ts
@@ -1,3 +1,4 @@
+import { getMuxStoryboardBaseUrl } from "@mux/ai/lib/mux-image-url";
 import { signUrl } from "@mux/ai/lib/url-signing";
 import type { WorkflowCredentialsInput } from "@mux/ai/types";
 
@@ -19,7 +20,7 @@ export async function getStoryboardUrl(
   credentials?: WorkflowCredentialsInput,
 ): Promise<string> {
   "use step";
-  const baseUrl = `https://image.mux.com/${playbackId}/storyboard.png`;
+  const baseUrl = getMuxStoryboardBaseUrl(playbackId);
 
   if (shouldSign) {
     return signUrl(baseUrl, playbackId, "storyboard", { width }, credentials);

--- a/src/primitives/thumbnails.ts
+++ b/src/primitives/thumbnails.ts
@@ -1,3 +1,4 @@
+import { getMuxThumbnailBaseUrl } from "@mux/ai/lib/mux-image-url";
 import { signUrl } from "@mux/ai/lib/url-signing";
 import type { WorkflowCredentialsInput } from "@mux/ai/types";
 
@@ -63,7 +64,7 @@ export async function getThumbnailUrls(
     timestamps = newTimestamps;
   }
 
-  const baseUrl = `https://image.mux.com/${playbackId}/thumbnail.png`;
+  const baseUrl = getMuxThumbnailBaseUrl(playbackId);
 
   const urlPromises = timestamps.map(async (time) => {
     if (shouldSign) {

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -8,6 +8,7 @@ import {
   getVideoTrackMaxFrameRateFromAsset,
   isAudioOnlyAsset,
 } from "@mux/ai/lib/mux-assets";
+import { getMuxThumbnailBaseUrl } from "@mux/ai/lib/mux-image-url";
 import { planSamplingTimestamps } from "@mux/ai/lib/sampling-plan";
 import { signUrl } from "@mux/ai/lib/url-signing";
 import { resolveMuxSigningContext } from "@mux/ai/lib/workflow-credentials";
@@ -457,7 +458,7 @@ async function getThumbnailUrlsFromTimestamps(
 ): Promise<string[]> {
   "use step";
   const { width, shouldSign, credentials } = options;
-  const baseUrl = `https://image.mux.com/${playbackId}/thumbnail.png`;
+  const baseUrl = getMuxThumbnailBaseUrl(playbackId);
 
   const urlPromises = timestampsMs.map(async (tsMs) => {
     const time = Number((tsMs / 1000).toFixed(2));

--- a/tests/integration/burned-in-captions.test.workflowdevkit.ts
+++ b/tests/integration/burned-in-captions.test.workflowdevkit.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { start } from "workflow/api";
 
+import { getMuxImageHost } from "../../src/lib/mux-image-url";
 import type { SupportedProvider } from "../../src/lib/providers";
 import { hasBurnedInCaptions } from "../../src/workflows";
 import { muxTestAssets } from "../helpers/mux-test-assets";
@@ -42,7 +43,7 @@ describe("Burned-in Captions Integration Tests for Workflow DevKit", () => {
 
     // Verify storyboardUrl is a valid URL
     expect(typeof result.storyboardUrl).toBe("string");
-    expect(result.storyboardUrl).toContain("image.mux.com");
+    expect(result.storyboardUrl).toContain(getMuxImageHost());
 
     // Verify usage stats
     expect(result.usage).toBeDefined();

--- a/tests/integration/burned-in-captions.test.workflowdevkit.ts
+++ b/tests/integration/burned-in-captions.test.workflowdevkit.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { start } from "workflow/api";
 
-import { getMuxImageHost } from "../../src/lib/mux-image-url";
+import { getMuxImageOrigin } from "../../src/lib/mux-image-url";
 import type { SupportedProvider } from "../../src/lib/providers";
 import { hasBurnedInCaptions } from "../../src/workflows";
 import { muxTestAssets } from "../helpers/mux-test-assets";
@@ -43,7 +43,7 @@ describe("Burned-in Captions Integration Tests for Workflow DevKit", () => {
 
     // Verify storyboardUrl is a valid URL
     expect(typeof result.storyboardUrl).toBe("string");
-    expect(result.storyboardUrl).toContain(getMuxImageHost());
+    expect(result.storyboardUrl).toContain(getMuxImageOrigin());
 
     // Verify usage stats
     expect(result.usage).toBeDefined();

--- a/tests/integration/signed-playback.test.ts
+++ b/tests/integration/signed-playback.test.ts
@@ -2,6 +2,7 @@ import Mux from "@mux/mux-node";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { env, reloadEnv } from "../../src/env";
+import { getMuxImageHost, getMuxStoryboardBaseUrl, getMuxThumbnailBaseUrl } from "../../src/lib/mux-image-url";
 import type { SigningContext } from "../../src/lib/url-signing";
 import { getMuxSigningContextFromEnv, signPlaybackId, signUrl } from "../../src/lib/url-signing";
 import { buildTranscriptUrl, getStoryboardUrl, getThumbnailUrls } from "../../src/primitives";
@@ -104,7 +105,7 @@ describe("signed Playback Integration Tests", () => {
 
   describe("signUrl", () => {
     it.skipIf(!hasSigningCredentials)("should append token to URL without query params", async () => {
-      const baseUrl = "https://image.mux.com/test-id/storyboard.png";
+      const baseUrl = getMuxStoryboardBaseUrl("test-id");
       const signedUrl = await signUrl(baseUrl, "test-id", "storyboard");
 
       expect(signedUrl).toContain(baseUrl);
@@ -112,7 +113,7 @@ describe("signed Playback Integration Tests", () => {
     });
 
     it.skipIf(!hasSigningCredentials)("should append token to URL with existing query params", async () => {
-      const baseUrl = "https://image.mux.com/test-id/thumbnail.png?width=640";
+      const baseUrl = `${getMuxThumbnailBaseUrl("test-id")}?width=640`;
       const signedUrl = await signUrl(baseUrl, "test-id", "thumbnail");
 
       expect(signedUrl).toContain(baseUrl);
@@ -125,7 +126,7 @@ describe("signed Playback Integration Tests", () => {
       it.skipIf(!canRunSignedTests)("should generate signed storyboard URL", async () => {
         const url = await getStoryboardUrl(playbackId, 640, true);
 
-        expect(url).toContain(`https://image.mux.com/${playbackId}/storyboard.png`);
+        expect(url).toContain(`https://${getMuxImageHost()}/${playbackId}/storyboard.png`);
         expect(url).toContain("token=");
 
         // Verify the URL is accessible
@@ -137,7 +138,7 @@ describe("signed Playback Integration Tests", () => {
         const testPlaybackId = "test-playback-id";
         const url = await getStoryboardUrl(testPlaybackId, 640, false);
 
-        expect(url).toBe(`https://image.mux.com/${testPlaybackId}/storyboard.png?width=640`);
+        expect(url).toBe(`${getMuxStoryboardBaseUrl(testPlaybackId)}?width=640`);
         expect(url).not.toContain("token=");
       });
     });
@@ -152,7 +153,7 @@ describe("signed Playback Integration Tests", () => {
 
         expect(urls.length).toBeGreaterThan(0);
         urls.forEach((url) => {
-          expect(url).toContain(`https://image.mux.com/${playbackId}/thumbnail.png`);
+          expect(url).toContain(`https://${getMuxImageHost()}/${playbackId}/thumbnail.png`);
           expect(url).toContain("token=");
         });
 
@@ -171,7 +172,7 @@ describe("signed Playback Integration Tests", () => {
 
         expect(urls.length).toBeGreaterThan(0);
         urls.forEach((url) => {
-          expect(url).toContain(`https://image.mux.com/${testPlaybackId}/thumbnail.png`);
+          expect(url).toContain(`https://${getMuxImageHost()}/${testPlaybackId}/thumbnail.png`);
           expect(url).not.toContain("token=");
         });
       });
@@ -189,7 +190,7 @@ describe("signed Playback Integration Tests", () => {
 
         // All URLs should be signed
         urls.forEach((url) => {
-          expect(url).toContain(`https://image.mux.com/${playbackId}/thumbnail.png`);
+          expect(url).toContain(`https://${getMuxImageHost()}/${playbackId}/thumbnail.png`);
           expect(url).toContain("token=");
         });
 

--- a/tests/integration/signed-playback.test.ts
+++ b/tests/integration/signed-playback.test.ts
@@ -2,7 +2,7 @@ import Mux from "@mux/mux-node";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { env, reloadEnv } from "../../src/env";
-import { getMuxImageHost, getMuxStoryboardBaseUrl, getMuxThumbnailBaseUrl } from "../../src/lib/mux-image-url";
+import { getMuxImageOrigin, getMuxStoryboardBaseUrl, getMuxThumbnailBaseUrl } from "../../src/lib/mux-image-url";
 import type { SigningContext } from "../../src/lib/url-signing";
 import { getMuxSigningContextFromEnv, signPlaybackId, signUrl } from "../../src/lib/url-signing";
 import { buildTranscriptUrl, getStoryboardUrl, getThumbnailUrls } from "../../src/primitives";
@@ -126,7 +126,7 @@ describe("signed Playback Integration Tests", () => {
       it.skipIf(!canRunSignedTests)("should generate signed storyboard URL", async () => {
         const url = await getStoryboardUrl(playbackId, 640, true);
 
-        expect(url).toContain(`https://${getMuxImageHost()}/${playbackId}/storyboard.png`);
+        expect(url).toContain(`${getMuxImageOrigin()}/${playbackId}/storyboard.png`);
         expect(url).toContain("token=");
 
         // Verify the URL is accessible
@@ -153,7 +153,7 @@ describe("signed Playback Integration Tests", () => {
 
         expect(urls.length).toBeGreaterThan(0);
         urls.forEach((url) => {
-          expect(url).toContain(`https://${getMuxImageHost()}/${playbackId}/thumbnail.png`);
+          expect(url).toContain(`${getMuxImageOrigin()}/${playbackId}/thumbnail.png`);
           expect(url).toContain("token=");
         });
 
@@ -172,7 +172,7 @@ describe("signed Playback Integration Tests", () => {
 
         expect(urls.length).toBeGreaterThan(0);
         urls.forEach((url) => {
-          expect(url).toContain(`https://${getMuxImageHost()}/${testPlaybackId}/thumbnail.png`);
+          expect(url).toContain(`${getMuxImageOrigin()}/${testPlaybackId}/thumbnail.png`);
           expect(url).not.toContain("token=");
         });
       });
@@ -190,7 +190,7 @@ describe("signed Playback Integration Tests", () => {
 
         // All URLs should be signed
         urls.forEach((url) => {
-          expect(url).toContain(`https://${getMuxImageHost()}/${playbackId}/thumbnail.png`);
+          expect(url).toContain(`${getMuxImageOrigin()}/${playbackId}/thumbnail.png`);
           expect(url).toContain("token=");
         });
 

--- a/tests/unit/thumbnails.test.ts
+++ b/tests/unit/thumbnails.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { reloadEnv } from "../../src/env";
+import { getMuxImageHost } from "../../src/lib/mux-image-url";
 import { getThumbnailUrls } from "../../src/primitives/thumbnails";
 
 describe("getThumbnailUrls", () => {
   const testPlaybackId = "test-playback-id";
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    reloadEnv();
+  });
 
   describe("basic thumbnail generation", () => {
     it("should generate thumbnails at default 10 second intervals", async () => {
@@ -192,9 +198,23 @@ describe("getThumbnailUrls", () => {
       });
 
       urls.forEach((url) => {
-        expect(url).toContain(`https://image.mux.com/${testPlaybackId}/thumbnail.png`);
+        expect(url).toContain(`https://${getMuxImageHost()}/${testPlaybackId}/thumbnail.png`);
         expect(url).toContain("time=");
         expect(url).toContain("width=");
+      });
+    });
+
+    it("should use MUX_IMAGE_HOST_OVERRIDE when configured", async () => {
+      vi.stubEnv("MUX_IMAGE_HOST_OVERRIDE", "image.example.com");
+      reloadEnv();
+
+      const duration = 30;
+      const urls = await getThumbnailUrls(testPlaybackId, duration, {
+        shouldSign: false,
+      });
+
+      urls.forEach((url) => {
+        expect(url).toContain(`https://image.example.com/${testPlaybackId}/thumbnail.png`);
       });
     });
   });

--- a/tests/unit/thumbnails.test.ts
+++ b/tests/unit/thumbnails.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { reloadEnv } from "../../src/env";
-import { getMuxImageHost } from "../../src/lib/mux-image-url";
+import { getMuxImageOrigin } from "../../src/lib/mux-image-url";
 import { getThumbnailUrls } from "../../src/primitives/thumbnails";
 
 describe("getThumbnailUrls", () => {
@@ -198,14 +198,14 @@ describe("getThumbnailUrls", () => {
       });
 
       urls.forEach((url) => {
-        expect(url).toContain(`https://${getMuxImageHost()}/${testPlaybackId}/thumbnail.png`);
+        expect(url).toContain(`${getMuxImageOrigin()}/${testPlaybackId}/thumbnail.png`);
         expect(url).toContain("time=");
         expect(url).toContain("width=");
       });
     });
 
-    it("should use MUX_IMAGE_HOST_OVERRIDE when configured", async () => {
-      vi.stubEnv("MUX_IMAGE_HOST_OVERRIDE", "image.example.com");
+    it("should use MUX_IMAGE_URL_OVERRIDE when configured", async () => {
+      vi.stubEnv("MUX_IMAGE_URL_OVERRIDE", "image.example.com");
       reloadEnv();
 
       const duration = 30;


### PR DESCRIPTION
# Overview

Adds support for overriding the Mux image url via the `MUX_IMAGE_URL_OVERRIDE` environment variable, allowing customization of the image.mux.com domain used for thumbnail and storyboard URLs.

# What was changed

- **New env var**: `MUX_IMAGE_URL_OVERRIDE` in [env.ts](src/env.ts)
- **New utility module**: [mux-image-url.ts](src/lib/mux-image-url.ts) - centralizes image URL generation with url override support and input validation
- **Updated primitives**: [storyboards.ts](src/primitives/storyboards.ts) and [thumbnails.ts](src/primitives/thumbnails.ts) now use the new helpers
- **Updated workflow**: [moderation.ts](src/workflows/moderation.ts) uses the new thumbnail URL helper
- **Tests updated**: Integration and unit tests use the helpers and verify override behavior

# Suggested review order

1. [src/lib/mux-image-url.ts](src/lib/mux-image-url.ts) - core logic and validation
2. [src/env.ts](src/env.ts) - env var definition
3. [src/primitives/storyboards.ts](src/primitives/storyboards.ts) - usage in storyboards
4. [src/primitives/thumbnails.ts](src/primitives/thumbnails.ts) - usage in thumbnails
5. [tests/unit/thumbnails.test.ts](tests/unit/thumbnails.test.ts) - new test for override
