### PR TITLE
feat: Simple control over title and description length.

### DIFF
--- a/examples/summarization/basic-example.ts
+++ b/examples/summarization/basic-example.ts
@@ -21,11 +21,17 @@ program
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("-t, --tone <tone>", "Tone for summary (neutral, playful, professional)", "neutral")
   .option("--no-transcript", "Exclude transcript from analysis")
+  .option("--title-length <chars>", "Desired title length in characters", parseInt)
+  .option("--description-length <chars>", "Desired description length in characters", parseInt)
+  .option("--tag-count <count>", "Desired number of tags", parseInt)
   .action(async (assetId: string, options: {
     provider: Provider;
     model?: string;
     tone: ToneType;
     transcript: boolean;
+    titleLength?: number;
+    descriptionLength?: number;
+    tagCount?: number;
   }) => {
     // Validate provider
     if (!["openai", "anthropic", "google"].includes(options.provider)) {
@@ -45,7 +51,11 @@ program
     console.log("Asset ID:", assetId);
     console.log(`Provider: ${options.provider} (${model})`);
     console.log(`Tone: ${options.tone}`);
-    console.log(`Include Transcript: ${options.transcript}\n`);
+    console.log(`Include Transcript: ${options.transcript}`);
+    if (options.titleLength) console.log(`Title Length: ~${options.titleLength} chars`);
+    if (options.descriptionLength) console.log(`Description Length: ~${options.descriptionLength} chars`);
+    if (options.tagCount) console.log(`Tag Count: ${options.tagCount}`);
+    console.log();
 
     try {
       // Uses the default prompt built into the library
@@ -55,6 +65,9 @@ program
         provider: options.provider,
         model,
         includeTranscript: options.transcript,
+        titleLength: options.titleLength,
+        descriptionLength: options.descriptionLength,
+        tagCount: options.tagCount,
       });
 
       console.log("📝 Title:");

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -139,105 +139,123 @@ const TONE_INSTRUCTIONS: Record<ToneType, string> = {
   professional: "Provide a professional, executive-level analysis suitable for business reporting.",
 };
 
-/**
- * Prompt builder for the summarization user prompt.
- * Sections can be individually overridden via `promptOverrides` in SummarizationOptions.
- */
-const summarizationPromptBuilder = createPromptBuilder<SummarizationPromptSections>({
-  template: {
-    task: {
-      tag: "task",
-      content: "Analyze the storyboard frames and generate metadata that captures the essence of the video content.",
-    },
-    title: {
-      tag: "title_requirements",
-      content: dedent`
-        A short, compelling headline that immediately communicates the subject or action.
-        Aim for brevity - typically under 10 words. Think of how a news headline or video card title would read.
-        Start with the primary subject, action, or topic - never begin with "A video of" or similar phrasing.
-        Use active, specific language.`,
-    },
-    description: {
-      tag: "description_requirements",
-      content: dedent`
-        A concise summary (2-4 sentences) that describes what happens across the video.
-        Cover the main subjects, actions, setting, and any notable progression visible across frames.
-        Write in present tense. Be specific about observable details rather than making assumptions.
-        If the transcript provides dialogue or narration, incorporate key points but prioritize visual content.`,
-    },
-    keywords: {
-      tag: "keywords_requirements",
-      content: dedent`
-        Specific, searchable terms (up to ${SUMMARY_KEYWORD_LIMIT}) that capture:
-        - Primary subjects (people, animals, objects)
-        - Actions and activities being performed
-        - Setting and environment
-        - Notable objects or tools
-        - Style or genre (if applicable)
-        Prefer concrete nouns and action verbs over abstract concepts.
-        Use lowercase. Avoid redundant or overly generic terms like "video" or "content".`,
-    },
-    qualityGuidelines: {
-      tag: "quality_guidelines",
-      content: dedent`
-        - Examine all frames to understand the full context and progression
-        - Be precise: "golden retriever" is better than "dog" when identifiable
-        - Capture the narrative: what begins, develops, and concludes
-        - Balance brevity with informativeness`,
-    },
-  },
-  sectionOrder: ["task", "title", "description", "keywords", "qualityGuidelines"],
-});
+interface PromptConstraints {
+  titleLength?: number;
+  descriptionLength?: number;
+  tagCount?: number;
+}
 
-/**
- * Prompt builder for audio-only content.
- * Focuses on transcript analysis without visual references.
- */
-const audioOnlyPromptBuilder = createPromptBuilder<SummarizationPromptSections>({
-  template: {
-    task: {
-      tag: "task",
-      content: "Analyze the transcript and generate metadata that captures the essence of the audio content.",
+function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }: PromptConstraints = {}) {
+  const titleBrevity = titleLength != null ?
+    `Aim for approximately ${titleLength} characters.` :
+    "Aim for brevity - typically under 10 words.";
+  const descConstraint = descriptionLength != null ?
+    `approximately ${descriptionLength} characters` :
+    "2-4 sentences";
+  const keywordLimit = tagCount ?? SUMMARY_KEYWORD_LIMIT;
+
+  return createPromptBuilder<SummarizationPromptSections>({
+    template: {
+      task: {
+        tag: "task",
+        content: "Analyze the storyboard frames and generate metadata that captures the essence of the video content.",
+      },
+      title: {
+        tag: "title_requirements",
+        content: dedent`
+          A short, compelling headline that immediately communicates the subject or action.
+          ${titleBrevity} Think of how a news headline or video card title would read.
+          Start with the primary subject, action, or topic - never begin with "A video of" or similar phrasing.
+          Use active, specific language.`,
+      },
+      description: {
+        tag: "description_requirements",
+        content: dedent`
+          A concise summary (${descConstraint}) that describes what happens across the video.
+          Cover the main subjects, actions, setting, and any notable progression visible across frames.
+          Write in present tense. Be specific about observable details rather than making assumptions.
+          If the transcript provides dialogue or narration, incorporate key points but prioritize visual content.`,
+      },
+      keywords: {
+        tag: "keywords_requirements",
+        content: dedent`
+          Specific, searchable terms (up to ${keywordLimit}) that capture:
+          - Primary subjects (people, animals, objects)
+          - Actions and activities being performed
+          - Setting and environment
+          - Notable objects or tools
+          - Style or genre (if applicable)
+          Prefer concrete nouns and action verbs over abstract concepts.
+          Use lowercase. Avoid redundant or overly generic terms like "video" or "content".`,
+      },
+      qualityGuidelines: {
+        tag: "quality_guidelines",
+        content: dedent`
+          - Examine all frames to understand the full context and progression
+          - Be precise: "golden retriever" is better than "dog" when identifiable
+          - Capture the narrative: what begins, develops, and concludes
+          - Balance brevity with informativeness`,
+      },
     },
-    title: {
-      tag: "title_requirements",
-      content: dedent`
-        A short, compelling headline that immediately communicates the subject or topic.
-        Aim for brevity - typically under 10 words. Think of how a podcast title or audio description would read.
-        Start with the primary subject, action, or topic - never begin with "An audio of" or similar phrasing.
-        Use active, specific language.`,
+    sectionOrder: ["task", "title", "description", "keywords", "qualityGuidelines"],
+  });
+}
+
+function createAudioOnlyBuilder({ titleLength, descriptionLength, tagCount }: PromptConstraints = {}) {
+  const titleBrevity = titleLength != null ?
+    `Aim for approximately ${titleLength} characters.` :
+    "Aim for brevity - typically under 10 words.";
+  const descConstraint = descriptionLength != null ?
+    `approximately ${descriptionLength} characters` :
+    "2-4 sentences";
+  const keywordLimit = tagCount ?? SUMMARY_KEYWORD_LIMIT;
+
+  return createPromptBuilder<SummarizationPromptSections>({
+    template: {
+      task: {
+        tag: "task",
+        content: "Analyze the transcript and generate metadata that captures the essence of the audio content.",
+      },
+      title: {
+        tag: "title_requirements",
+        content: dedent`
+          A short, compelling headline that immediately communicates the subject or topic.
+          ${titleBrevity} Think of how a podcast title or audio description would read.
+          Start with the primary subject, action, or topic - never begin with "An audio of" or similar phrasing.
+          Use active, specific language.`,
+      },
+      description: {
+        tag: "description_requirements",
+        content: dedent`
+          A concise summary (${descConstraint}) that describes the audio content.
+          Cover the main topics, speakers, themes, and any notable progression in the discussion or narration.
+          Write in present tense. Be specific about what is discussed or presented rather than making assumptions.
+          Focus on the spoken content and any key insights, dialogue, or narrative elements.`,
+      },
+      keywords: {
+        tag: "keywords_requirements",
+        content: dedent`
+          Specific, searchable terms (up to ${keywordLimit}) that capture:
+          - Primary topics and themes
+          - Speakers or presenters (if named)
+          - Key concepts and terminology
+          - Content type (interview, lecture, music, etc.)
+          - Genre or style (if applicable)
+          Prefer concrete nouns and relevant terms over abstract concepts.
+          Use lowercase. Avoid redundant or overly generic terms like "audio" or "content".`,
+      },
+      qualityGuidelines: {
+        tag: "quality_guidelines",
+        content: dedent`
+          - Analyze the full transcript to understand context and themes
+          - Be precise: use specific terminology when mentioned
+          - Capture the narrative: what is introduced, discussed, and concluded
+          - Balance brevity with informativeness`,
+      },
     },
-    description: {
-      tag: "description_requirements",
-      content: dedent`
-        A concise summary (2-4 sentences) that describes the audio content.
-        Cover the main topics, speakers, themes, and any notable progression in the discussion or narration.
-        Write in present tense. Be specific about what is discussed or presented rather than making assumptions.
-        Focus on the spoken content and any key insights, dialogue, or narrative elements.`,
-    },
-    keywords: {
-      tag: "keywords_requirements",
-      content: dedent`
-        Specific, searchable terms (up to ${SUMMARY_KEYWORD_LIMIT}) that capture:
-        - Primary topics and themes
-        - Speakers or presenters (if named)
-        - Key concepts and terminology
-        - Content type (interview, lecture, music, etc.)
-        - Genre or style (if applicable)
-        Prefer concrete nouns and relevant terms over abstract concepts.
-        Use lowercase. Avoid redundant or overly generic terms like "audio" or "content".`,
-    },
-    qualityGuidelines: {
-      tag: "quality_guidelines",
-      content: dedent`
-        - Analyze the full transcript to understand context and themes
-        - Be precise: use specific terminology when mentioned
-        - Capture the narrative: what is introduced, discussed, and concluded
-        - Balance brevity with informativeness`,
-    },
-  },
-  sectionOrder: ["task", "title", "description", "keywords", "qualityGuidelines"],
-});
+    sectionOrder: ["task", "title", "description", "keywords", "qualityGuidelines"],
+  });
+}
 
 const SYSTEM_PROMPT = dedent`
   <role>
@@ -379,36 +397,12 @@ function buildUserPrompt({
     contextSections.push(createTranscriptSection(transcriptText, format));
   }
 
-  // Use audio-only prompt builder for audio-only assets
-  const promptBuilder = isAudioOnly ? audioOnlyPromptBuilder : summarizationPromptBuilder;
+  const constraints: PromptConstraints = { titleLength, descriptionLength, tagCount };
+  const promptBuilder = isAudioOnly ?
+      createAudioOnlyBuilder(constraints) :
+      createSummarizationBuilder(constraints);
 
-  // Build internal overrides from length/count params (user overrides always win)
-  const internalOverrides: SummarizationPromptOverrides = {};
-
-  if (titleLength != null && !promptOverrides?.title) {
-    internalOverrides.title = promptBuilder.template.title.content.replace(
-      /typically under 10 words/,
-      `Aim for approximately ${titleLength} characters`,
-    );
-  }
-
-  if (descriptionLength != null && !promptOverrides?.description) {
-    internalOverrides.description = promptBuilder.template.description.content.replace(
-      /2-4 sentences/,
-      `approximately ${descriptionLength} characters`,
-    );
-  }
-
-  if (tagCount != null && !promptOverrides?.keywords) {
-    internalOverrides.keywords = promptBuilder.template.keywords.content.replace(
-      `up to ${SUMMARY_KEYWORD_LIMIT}`,
-      `up to ${tagCount}`,
-    );
-  }
-
-  const mergedOverrides = { ...internalOverrides, ...promptOverrides };
-
-  return promptBuilder.buildWithContext(mergedOverrides, contextSections);
+  return promptBuilder.buildWithContext(promptOverrides, contextSections);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds three optional params to `SummarizationOptions` — `titleLength`, `descriptionLength`, `tagCount` — so consumers can control output constraints without resorting to full prompt overrides.

## Changes

- **`titleLength`** (chars): Replaces the default "under 10 words" title brevity hint
- **`descriptionLength`** (chars): Replaces the default "2-4 sentences" description constraint
- **`tagCount`**: Controls both the prompt keyword limit and the `normalizeKeywords` cap

The static prompt builders are now factory functions (`createSummarizationBuilder`, `createAudioOnlyBuilder`) that accept a `PromptConstraints` object, so the template content is parameterised at construction rather than mutated after the fact.

All params are optional. Defaults preserve existing behaviour. User `promptOverrides` still take precedence.

The basic example (`examples/summarization/basic-example.ts`) has been updated with `--title-length`, `--description-length`, and `--tag-count` CLI flags for manual testing.

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm run lint` — clean
- [x] All unit tests pass unchanged