### PR TITLE
feat: Support `outputLanguageCode` in summarisation and chapters.

### DIFF
--- a/examples/chapters/basic-example.ts
+++ b/examples/chapters/basic-example.ts
@@ -15,9 +15,11 @@ program
   .argument("<asset-id>", "Mux asset ID to analyze")
   .option("-l, --language <code>", "Language code for transcription", "en")
   .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("--output-language <code>", "Output language as BCP 47 code (e.g. 'fr', 'ja') or 'auto'")
   .action(async (assetId: string, options: {
     language: string;
     provider: Provider;
+    outputLanguage?: string;
   }) => {
     // Validate provider
     if (!["openai", "anthropic", "google"].includes(options.provider)) {
@@ -27,13 +29,16 @@ program
 
     console.log(`🎯 Generating chapters for asset: ${assetId}`);
     console.log(`📝 Language: ${options.language}`);
-    console.log(`🤖 Provider: ${options.provider}\n`);
+    console.log(`🤖 Provider: ${options.provider}`);
+    if (options.outputLanguage) console.log(`🌐 Output Language: ${options.outputLanguage}`);
+    console.log();
 
     try {
       const start = Date.now();
 
       const result = await generateChapters(assetId, options.language, {
         provider: options.provider,
+        outputLanguageCode: options.outputLanguage,
         promptOverrides: {
           titleGuidelines: "Use concise titles under 6 words.",
         },

--- a/examples/summarization/basic-example.ts
+++ b/examples/summarization/basic-example.ts
@@ -24,7 +24,7 @@ program
   .option("--title-length <chars>", "Desired title length in characters", parseInt)
   .option("--description-length <chars>", "Desired description length in characters", parseInt)
   .option("--tag-count <count>", "Desired number of tags", parseInt)
-  .option("-l, --language <code>", "Output language as BCP 47 code (e.g. 'fr', 'ja') or 'auto'")
+  .option("--output-language <code>", "Output language as BCP 47 code (e.g. 'fr', 'ja') or 'auto'")
   .action(async (assetId: string, options: {
     provider: Provider;
     model?: string;
@@ -33,7 +33,7 @@ program
     titleLength?: number;
     descriptionLength?: number;
     tagCount?: number;
-    language?: string;
+    outputLanguage?: string;
   }) => {
     // Validate provider
     if (!["openai", "anthropic", "google"].includes(options.provider)) {
@@ -57,7 +57,7 @@ program
     if (options.titleLength) console.log(`Title Length: ~${options.titleLength} chars`);
     if (options.descriptionLength) console.log(`Description Length: ~${options.descriptionLength} chars`);
     if (options.tagCount) console.log(`Tag Count: ${options.tagCount}`);
-    if (options.language) console.log(`Output Language: ${options.language}`);
+    if (options.outputLanguage) console.log(`Output Language: ${options.outputLanguage}`);
     console.log();
 
     try {
@@ -71,7 +71,7 @@ program
         titleLength: options.titleLength,
         descriptionLength: options.descriptionLength,
         tagCount: options.tagCount,
-        outputLanguageCode: options.language,
+        outputLanguageCode: options.outputLanguage,
       });
 
       console.log("📝 Title:");

--- a/examples/summarization/basic-example.ts
+++ b/examples/summarization/basic-example.ts
@@ -24,6 +24,7 @@ program
   .option("--title-length <chars>", "Desired title length in characters", parseInt)
   .option("--description-length <chars>", "Desired description length in characters", parseInt)
   .option("--tag-count <count>", "Desired number of tags", parseInt)
+  .option("-l, --language <code>", "Output language as BCP 47 code (e.g. 'fr', 'ja') or 'auto'")
   .action(async (assetId: string, options: {
     provider: Provider;
     model?: string;
@@ -32,6 +33,7 @@ program
     titleLength?: number;
     descriptionLength?: number;
     tagCount?: number;
+    language?: string;
   }) => {
     // Validate provider
     if (!["openai", "anthropic", "google"].includes(options.provider)) {
@@ -55,6 +57,7 @@ program
     if (options.titleLength) console.log(`Title Length: ~${options.titleLength} chars`);
     if (options.descriptionLength) console.log(`Description Length: ~${options.descriptionLength} chars`);
     if (options.tagCount) console.log(`Tag Count: ${options.tagCount}`);
+    if (options.language) console.log(`Output Language: ${options.language}`);
     console.log();
 
     try {
@@ -68,6 +71,7 @@ program
         titleLength: options.titleLength,
         descriptionLength: options.descriptionLength,
         tagCount: options.tagCount,
+        outputLanguageCode: options.language,
       });
 
       console.log("📝 Title:");

--- a/src/lib/prompt-builder.ts
+++ b/src/lib/prompt-builder.ts
@@ -224,19 +224,6 @@ export function createToneSection(instruction: string): PromptSection {
 }
 
 /**
- * Converts a BCP 47 language code to a human-readable display name.
- * Falls back to the raw code if Intl.DisplayNames can't resolve it.
- */
-export function resolveLanguageName(code: string): string {
-  try {
-    const displayNames = new Intl.DisplayNames(["en"], { type: "language" });
-    return displayNames.of(code) ?? code;
-  } catch {
-    return code;
-  }
-}
-
-/**
  * Creates a language section for inclusion in prompts.
  * Instructs the model to produce all output in the specified language.
  */

--- a/src/lib/prompt-builder.ts
+++ b/src/lib/prompt-builder.ts
@@ -222,3 +222,27 @@ export function createToneSection(instruction: string): PromptSection {
     content: instruction,
   };
 }
+
+/**
+ * Converts a BCP 47 language code to a human-readable display name.
+ * Falls back to the raw code if Intl.DisplayNames can't resolve it.
+ */
+export function resolveLanguageName(code: string): string {
+  try {
+    const displayNames = new Intl.DisplayNames(["en"], { type: "language" });
+    return displayNames.of(code) ?? code;
+  } catch {
+    return code;
+  }
+}
+
+/**
+ * Creates a language section for inclusion in prompts.
+ * Instructs the model to produce all output in the specified language.
+ */
+export function createLanguageSection(languageName: string): PromptSection {
+  return {
+    tag: "language",
+    content: `All output (title, description, keywords, chapter titles) MUST be written in ${languageName}.`,
+  };
+}

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -155,6 +155,7 @@ const SYSTEM_PROMPT = dedent`
     - Only describe observable evidence from frames or transcript
     - Do not fabricate details or make unsupported assumptions
     - Return structured data matching the requested schema exactly
+    - Provide reasoning in the same language as the question
   </constraints>
 
   <language_guidelines>

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -94,8 +94,9 @@ export interface ChaptersOptions extends MuxAIOptions {
    */
   maxChaptersPerHour?: number;
   /**
-   * BCP 47 language code for chapter titles (e.g. "en", "fr", "ja"), or "auto"
-   * to detect from the transcript track. When omitted, the LLM decides.
+   * BCP 47 language code for chapter titles (e.g. "en", "fr", "ja").
+   * When omitted, auto-detects from the transcript track's language.
+   * Falls back to unconstrained (LLM decides) if no language metadata is available.
    */
   outputLanguageCode?: string;
 }

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -2,13 +2,14 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
+import { getLanguageName } from "@mux/ai/lib/language-codes";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
   isAudioOnlyAsset,
 } from "@mux/ai/lib/mux-assets";
 import type { PromptOverrides, PromptSection } from "@mux/ai/lib/prompt-builder";
-import { createLanguageSection, createPromptBuilder, resolveLanguageName } from "@mux/ai/lib/prompt-builder";
+import { createLanguageSection, createPromptBuilder } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
 import { withRetry } from "@mux/ai/lib/retry";
@@ -357,9 +358,9 @@ export async function generateChapters(
   let languageName: string | undefined;
   if (outputLanguageCode === "auto") {
     const trackLanguage = transcriptResult.track?.language_code ?? languageCode;
-    languageName = resolveLanguageName(trackLanguage);
+    languageName = getLanguageName(trackLanguage);
   } else if (outputLanguageCode) {
-    languageName = resolveLanguageName(outputLanguageCode);
+    languageName = getLanguageName(outputLanguageCode);
   }
 
   const userPrompt = buildUserPrompt({

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -354,14 +354,11 @@ export async function generateChapters(
     throw new Error(`No usable content found in ${contentLabel}`);
   }
 
-  // Resolve output language: "auto" detects from transcript track, explicit code is converted to a display name
-  let languageName: string | undefined;
-  if (outputLanguageCode === "auto") {
-    const trackLanguage = transcriptResult.track?.language_code ?? languageCode;
-    languageName = getLanguageName(trackLanguage);
-  } else if (outputLanguageCode) {
-    languageName = getLanguageName(outputLanguageCode);
-  }
+  // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track
+  const resolvedLanguageCode = outputLanguageCode && outputLanguageCode !== "auto" ?
+    outputLanguageCode :
+      (transcriptResult.track?.language_code ?? languageCode);
+  const languageName = resolvedLanguageCode ? getLanguageName(resolvedLanguageCode) : undefined;
 
   const userPrompt = buildUserPrompt({
     timestampedTranscript,

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -8,7 +8,7 @@ import {
   isAudioOnlyAsset,
 } from "@mux/ai/lib/mux-assets";
 import type { PromptOverrides, PromptSection } from "@mux/ai/lib/prompt-builder";
-import { createPromptBuilder } from "@mux/ai/lib/prompt-builder";
+import { createLanguageSection, createPromptBuilder, resolveLanguageName } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
 import { withRetry } from "@mux/ai/lib/retry";
@@ -92,6 +92,11 @@ export interface ChaptersOptions extends MuxAIOptions {
    * Defaults to 8.
    */
   maxChaptersPerHour?: number;
+  /**
+   * BCP 47 language code for chapter titles (e.g. "en", "fr", "ja"), or "auto"
+   * to detect from the transcript track. When omitted, the LLM decides.
+   */
+  outputLanguageCode?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -175,7 +180,8 @@ const chapterSystemPromptBuilder = createPromptBuilder<ChapterSystemPromptSectio
       content: dedent`
         - Only use information present in the transcript
         - Return structured data that matches the requested JSON schema
-        - Do not add commentary or extra text outside the JSON`,
+        - Do not add commentary or extra text outside the JSON
+        - When a <language> section is provided, all chapter titles MUST be written in that language`,
     },
     qualityGuidelines: {
       tag: "quality_guidelines",
@@ -243,11 +249,13 @@ function buildUserPrompt({
   promptOverrides,
   minChaptersPerHour = 3,
   maxChaptersPerHour = 8,
+  languageName,
 }: {
   timestampedTranscript: string;
   promptOverrides?: ChaptersPromptOverrides;
   minChaptersPerHour?: number;
   maxChaptersPerHour?: number;
+  languageName?: string;
 }): string {
   const contextSections: PromptSection[] = [
     {
@@ -256,6 +264,10 @@ function buildUserPrompt({
       attributes: { format: "seconds" },
     },
   ];
+
+  if (languageName) {
+    contextSections.push(createLanguageSection(languageName));
+  }
 
   // Build dynamic chapter guidelines with configurable min/max per hour
   const dynamicChapterGuidelines = dedent`
@@ -286,6 +298,7 @@ export async function generateChapters(
     minChaptersPerHour,
     maxChaptersPerHour,
     credentials,
+    outputLanguageCode,
   } = options;
 
   const modelConfig = resolveLanguageModelConfig({
@@ -340,11 +353,21 @@ export async function generateChapters(
     throw new Error(`No usable content found in ${contentLabel}`);
   }
 
+  // Resolve output language: "auto" detects from transcript track, explicit code is converted to a display name
+  let languageName: string | undefined;
+  if (outputLanguageCode === "auto") {
+    const trackLanguage = transcriptResult.track?.language_code ?? languageCode;
+    languageName = resolveLanguageName(trackLanguage);
+  } else if (outputLanguageCode) {
+    languageName = resolveLanguageName(outputLanguageCode);
+  }
+
   const userPrompt = buildUserPrompt({
     timestampedTranscript,
     promptOverrides,
     minChaptersPerHour,
     maxChaptersPerHour,
+    languageName,
   });
 
   // Generate chapters using AI SDK

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -240,7 +240,7 @@ const chaptersPromptBuilder = createPromptBuilder<ChaptersPromptSections>({
       content: dedent`
         - Keep titles concise and descriptive
         - Avoid filler or generic labels like "Chapter 1"
-        - Use the transcript's language and terminology`,
+        - Use the transcript's terminology`,
     },
   },
   sectionOrder: ["task", "outputFormat", "chapterGuidelines", "titleGuidelines"],

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -13,9 +13,11 @@ import type {
   PromptOverrides,
 } from "@mux/ai/lib/prompt-builder";
 import {
+  createLanguageSection,
   createPromptBuilder,
   createToneSection,
   createTranscriptSection,
+  resolveLanguageName,
 } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
@@ -125,6 +127,11 @@ export interface SummarizationOptions extends MuxAIOptions {
   descriptionLength?: number;
   /** Desired number of tags. */
   tagCount?: number;
+  /**
+   * BCP 47 language code for the output (e.g. "en", "fr", "ja"), or "auto"
+   * to detect from the transcript track. When omitted, the LLM decides.
+   */
+  outputLanguageCode?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -290,6 +297,7 @@ const SYSTEM_PROMPT = dedent`
     - Do not fabricate details or make unsupported assumptions
     - Return structured data matching the requested schema
     - Output only the JSON object; no markdown or extra text
+    - When a <language> section is provided, all output text MUST be written in that language
   </constraints>
 
   <tone_guidance>
@@ -345,6 +353,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
     - Return structured data matching the requested schema
     - Focus entirely on audio/spoken content - there are no visual elements
     - Output only the JSON object; no markdown or extra text
+    - When a <language> section is provided, all output text MUST be written in that language
   </constraints>
 
   <tone_guidance>
@@ -377,6 +386,7 @@ interface UserPromptContext {
   titleLength?: number;
   descriptionLength?: number;
   tagCount?: number;
+  languageName?: string;
 }
 
 function buildUserPrompt({
@@ -388,9 +398,14 @@ function buildUserPrompt({
   titleLength,
   descriptionLength,
   tagCount,
+  languageName,
 }: UserPromptContext): string {
   // Build dynamic context sections
   const contextSections = [createToneSection(TONE_INSTRUCTIONS[tone])];
+
+  if (languageName) {
+    contextSections.push(createLanguageSection(languageName));
+  }
 
   if (transcriptText) {
     const format = isCleanTranscript ? "plain text" : "WebVTT";
@@ -552,6 +567,7 @@ export async function getSummaryAndTags(
     titleLength,
     descriptionLength,
     tagCount,
+    outputLanguageCode,
   } = options ?? {};
 
   // Validate tone parameter
@@ -592,15 +608,27 @@ export async function getSummaryAndTags(
     );
   }
 
-  const transcriptText =
+  const transcriptResult =
     includeTranscript ?
-        (await fetchTranscriptForAsset(assetData, playbackId, {
+        await fetchTranscriptForAsset(assetData, playbackId, {
           cleanTranscript,
           shouldSign: policy === "signed",
           credentials: workflowCredentials,
           required: isAudioOnly,
-        })).transcriptText :
-      "";
+        }) :
+      undefined;
+  const transcriptText = transcriptResult?.transcriptText ?? "";
+
+  // Resolve output language: "auto" detects from transcript track, explicit code is converted to a display name
+  let languageName: string | undefined;
+  if (outputLanguageCode === "auto") {
+    const trackLanguage = transcriptResult?.track?.language_code;
+    if (trackLanguage) {
+      languageName = resolveLanguageName(trackLanguage);
+    }
+  } else if (outputLanguageCode) {
+    languageName = resolveLanguageName(outputLanguageCode);
+  }
 
   // Build the user prompt with all context and any overrides
   const userPrompt = buildUserPrompt({
@@ -612,6 +640,7 @@ export async function getSummaryAndTags(
     titleLength,
     descriptionLength,
     tagCount,
+    languageName,
   });
 
   let analysisResponse: AnalysisResponse;

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -128,8 +128,9 @@ export interface SummarizationOptions extends MuxAIOptions {
   /** Desired number of tags. */
   tagCount?: number;
   /**
-   * BCP 47 language code for the output (e.g. "en", "fr", "ja"), or "auto"
-   * to detect from the transcript track. When omitted, the LLM decides.
+   * BCP 47 language code for the output (e.g. "en", "fr", "ja").
+   * When omitted, auto-detects from the transcript track's language.
+   * Falls back to unconstrained (LLM decides) if no language metadata is available.
    */
   outputLanguageCode?: string;
 }

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
+import { getLanguageName } from "@mux/ai/lib/language-codes";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -17,7 +18,6 @@ import {
   createPromptBuilder,
   createToneSection,
   createTranscriptSection,
-  resolveLanguageName,
 } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
@@ -624,10 +624,12 @@ export async function getSummaryAndTags(
   if (outputLanguageCode === "auto") {
     const trackLanguage = transcriptResult?.track?.language_code;
     if (trackLanguage) {
-      languageName = resolveLanguageName(trackLanguage);
+      languageName = getLanguageName(trackLanguage);
+    } else {
+      console.warn(`[summarization] outputLanguageCode "auto" could not resolve: no transcript track language available. Falling back to default behaviour.`);
     }
   } else if (outputLanguageCode) {
-    languageName = resolveLanguageName(outputLanguageCode);
+    languageName = getLanguageName(outputLanguageCode);
   }
 
   // Build the user prompt with all context and any overrides

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -26,7 +26,7 @@ import {
   resolveMuxSigningContext,
 } from "@mux/ai/lib/workflow-credentials";
 import { getStoryboardUrl } from "@mux/ai/primitives/storyboards";
-import { fetchTranscriptForAsset } from "@mux/ai/primitives/transcripts";
+import { fetchTranscriptForAsset, getReadyTextTracks } from "@mux/ai/primitives/transcripts";
 import type {
   ImageSubmissionMode,
   MuxAIOptions,
@@ -619,18 +619,11 @@ export async function getSummaryAndTags(
       undefined;
   const transcriptText = transcriptResult?.transcriptText ?? "";
 
-  // Resolve output language: "auto" detects from transcript track, explicit code is converted to a display name
-  let languageName: string | undefined;
-  if (outputLanguageCode === "auto") {
-    const trackLanguage = transcriptResult?.track?.language_code;
-    if (trackLanguage) {
-      languageName = getLanguageName(trackLanguage);
-    } else {
-      console.warn(`[summarization] outputLanguageCode "auto" could not resolve: no transcript track language available. Falling back to default behaviour.`);
-    }
-  } else if (outputLanguageCode) {
-    languageName = getLanguageName(outputLanguageCode);
-  }
+  // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track
+  const resolvedLanguageCode = outputLanguageCode && outputLanguageCode !== "auto" ?
+    outputLanguageCode :
+      (transcriptResult?.track?.language_code ?? getReadyTextTracks(assetData)[0]?.language_code);
+  const languageName = resolvedLanguageCode ? getLanguageName(resolvedLanguageCode) : undefined;
 
   // Build the user prompt with all context and any overrides
   const userPrompt = buildUserPrompt({

--- a/tests/eval/chapters-translation.eval.ts
+++ b/tests/eval/chapters-translation.eval.ts
@@ -4,17 +4,17 @@ import { reportTrace } from "evalite/traces";
 import { calculateModelCost, EVAL_MODEL_CONFIGS } from "../../src/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "../../src/lib/providers";
 import type { TokenUsage } from "../../src/types";
-import { getSummaryAndTags } from "../../src/workflows";
-import type { SummaryAndTagsResult } from "../../src/workflows";
+import { generateChapters } from "../../src/workflows";
+import type { ChaptersResult } from "../../src/workflows";
 import { getLatencyPerformanceDescription, scoreLatencyPerformance } from "../helpers/latency-performance";
 import { muxTestAssets } from "../helpers/mux-test-assets";
 
 /**
- * Summarization Language Cost Eval
+ * Chapters Language Cost Eval
  *
- * Measures the relative cost/performance impact of requesting output in a
- * different language vs the baseline (no language specified) and vs explicitly
- * requesting the same language.
+ * Measures the relative cost/performance impact of requesting chapter output
+ * in a different language vs the baseline (no language specified) and vs
+ * explicitly requesting the same language.
  *
  * Three variants per provider/model:
  *  - baseline:           outputLanguageCode omitted
@@ -26,10 +26,11 @@ import { muxTestAssets } from "../helpers/mux-test-assets";
 // Thresholds
 // ─────────────────────────────────────────────────────────────────────────────
 
-const TITLE_MAX_LENGTH = 100;
+const TITLE_MIN_LENGTH = 3;
+const TITLE_MAX_LENGTH = 80;
 const LATENCY_THRESHOLD_GOOD_MS = 8000;
 const LATENCY_THRESHOLD_ACCEPTABLE_MS = 20000;
-const TOKEN_THRESHOLD_EFFICIENT = 4000;
+const TOKEN_THRESHOLD_EFFICIENT = 5000;
 const COST_THRESHOLD_USD = 0.015;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -38,7 +39,7 @@ const COST_THRESHOLD_USD = 0.015;
 
 type LanguageVariant = "baseline" | "same-language" | "different-language";
 
-interface EvalOutput extends SummaryAndTagsResult {
+interface EvalOutput extends ChaptersResult {
   provider: SupportedProvider;
   model: ModelIdByProvider[SupportedProvider];
   variant: LanguageVariant;
@@ -66,9 +67,10 @@ const allResults: { provider: string; model: string; variant: LanguageVariant; t
 const data = EVAL_MODEL_CONFIGS.flatMap(({ provider, modelId }) =>
   variants.map(variant => ({
     input: {
-      assetId: muxTestAssets.assetId,
+      assetId: muxTestAssets.chaptersAssetId,
       provider,
       model: modelId,
+      languageCode: "en",
       variant: variant.label,
       outputLanguageCode: variant.outputLanguageCode,
     },
@@ -77,7 +79,7 @@ const data = EVAL_MODEL_CONFIGS.flatMap(({ provider, modelId }) =>
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Evaluation
+// Summary
 // ─────────────────────────────────────────────────────────────────────────────
 
 function printSummary() {
@@ -99,31 +101,33 @@ function printSummary() {
 
   const avg = (arr: number[]) => arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
 
-  console.warn("\n── Summarization Language Cost Summary ──");
+  console.warn("\n── Chapters Translation Summary ──");
   console.warn(`  Same language (en) avg token overhead: ${avg(overheads["same-language"]).toFixed(1)}%`);
   console.warn(`  Different language (es) avg token overhead: ${avg(overheads["different-language"]).toFixed(1)}%`);
   console.warn("");
 }
 
-evalite("Summarization Language Cost", {
+// ─────────────────────────────────────────────────────────────────────────────
+// Evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+evalite("Chapters Translation", {
   data,
-  task: async ({ assetId, provider, model, variant, outputLanguageCode }): Promise<EvalOutput> => {
+  task: async ({ assetId, provider, model, languageCode, variant, outputLanguageCode }): Promise<EvalOutput> => {
     const startTime = performance.now();
-    const result = await getSummaryAndTags(assetId, {
+    const result = await generateChapters(assetId, languageCode, {
       provider,
       model,
-      includeTranscript: true,
       outputLanguageCode,
     });
     const latencyMs = performance.now() - startTime;
 
     console.warn(
-      `[summarization-language][${provider}/${model}][${variant}] ${assetId}`,
-      {
-        title: result.title,
-        description: result.description,
-        tags: result.tags,
-      },
+      `[chapters-language][${provider}/${model}][${variant}] ${assetId}`,
+      result.chapters.map(chapter => ({
+        startTime: chapter.startTime,
+        title: chapter.title,
+      })),
     );
 
     const usage = result.usage ?? {};
@@ -135,7 +139,7 @@ evalite("Summarization Language Cost", {
     );
 
     reportTrace({
-      input: { assetId, provider, model, variant, outputLanguageCode },
+      input: { assetId, provider, model, languageCode, variant, outputLanguageCode },
       output: result,
       usage: {
         inputTokens: usage.inputTokens ?? 0,
@@ -155,7 +159,6 @@ evalite("Summarization Language Cost", {
 
     allResults.push({ provider, model, variant, totalTokens, estimatedCostUsd });
 
-    // Print summary once all tasks have reported in
     if (allResults.length === data.length) {
       printSummary();
     }
@@ -180,45 +183,59 @@ evalite("Summarization Language Cost", {
 
     {
       name: "response-integrity",
-      description: "Validates all required fields are present and properly typed.",
-      scorer: ({ output, input }: { output: EvalOutput; input: { assetId: string } }) => {
+      description: "Validates asset/language integrity and chapter shape.",
+      scorer: ({ output, input }: { output: EvalOutput; input: { assetId: string; languageCode: string } }) => {
         const assetIdValid = output.assetId === input.assetId;
-        const titleValid = typeof output.title === "string" && output.title.length > 0;
-        const descriptionValid = typeof output.description === "string" && output.description.length > 0;
-        const tagsValid = Array.isArray(output.tags) && output.tags.length > 0;
-        const storyboardValid = typeof output.storyboardUrl === "string" && output.storyboardUrl.startsWith("https://");
+        const languageValid = output.languageCode === input.languageCode;
+        const chaptersValid = Array.isArray(output.chapters) && output.chapters.length > 0;
+        const chapterShapeValid = output.chapters.every(chapter =>
+          typeof chapter.startTime === "number" &&
+          Number.isFinite(chapter.startTime) &&
+          chapter.startTime >= 0 &&
+          typeof chapter.title === "string" &&
+          chapter.title.trim().length > 0,
+        );
 
-        return assetIdValid && titleValid && descriptionValid && tagsValid && storyboardValid ? 1 : 0;
+        return assetIdValid && languageValid && chaptersValid && chapterShapeValid ? 1 : 0;
       },
     },
 
     {
       name: "title-quality",
-      description: "Validates title is non-empty, under 100 chars, and doesn't start with filler phrases.",
+      description: "Scores chapter titles for length and descriptive content.",
       scorer: ({ output }: { output: EvalOutput }) => {
-        const { title } = output;
-
-        if (!title || title.trim().length === 0) {
+        const { chapters } = output;
+        if (chapters.length === 0) {
           return 0;
         }
 
-        if (title.length > TITLE_MAX_LENGTH) {
-          return 0.5;
+        const seenTitles = new Set<string>();
+        const genericTitlePattern = /^(?:chapter|segment|part)\s*\d+/i;
+        let validCount = 0;
+
+        for (const chapter of chapters) {
+          const title = chapter.title.trim();
+          const hasLetters = /[a-z]/i.test(title);
+          const lowerTitle = title.toLowerCase();
+          const isDuplicate = seenTitles.has(lowerTitle);
+          const isGeneric = genericTitlePattern.test(title);
+
+          if (
+            title.length >= TITLE_MIN_LENGTH &&
+            title.length <= TITLE_MAX_LENGTH &&
+            hasLetters &&
+            !isDuplicate &&
+            !isGeneric
+          ) {
+            validCount += 1;
+          }
+
+          if (!isDuplicate) {
+            seenTitles.add(lowerTitle);
+          }
         }
 
-        const fillerPhrases = [
-          "a video of",
-          "this video shows",
-          "the video shows",
-          "video of",
-          "this is a video",
-        ];
-        const lowerTitle = title.toLowerCase().trim();
-        if (fillerPhrases.some(phrase => lowerTitle.startsWith(phrase))) {
-          return 0.5;
-        }
-
-        return 1;
+        return validCount / chapters.length;
       },
     },
 
@@ -255,7 +272,7 @@ evalite("Summarization Language Cost", {
 
     {
       name: "usage-data-present",
-      description: "Ensures token usage data is returned for cost analysis (inputTokens and outputTokens must be > 0).",
+      description: "Ensures token usage data is returned for cost analysis.",
       scorer: ({ output }: { output: EvalOutput }) => {
         const { usage } = output;
 
@@ -303,7 +320,7 @@ evalite("Summarization Language Cost", {
       { label: "Provider", value: output.provider },
       { label: "Model", value: output.model },
       { label: "Variant", value: output.variant },
-      { label: "Title", value: output.title },
+      { label: "Chapters", value: output.chapters.length },
       { label: "Latency", value: `${Math.round(output.latencyMs)}ms` },
       { label: "Tokens", value: output.usage?.totalTokens ?? 0 },
       { label: "Token Delta", value: (() => {

--- a/tests/eval/summarization-language.eval.ts
+++ b/tests/eval/summarization-language.eval.ts
@@ -1,0 +1,321 @@
+import { evalite } from "evalite";
+import { reportTrace } from "evalite/traces";
+
+import { calculateModelCost, EVAL_MODEL_CONFIGS } from "../../src/lib/providers";
+import type { ModelIdByProvider, SupportedProvider } from "../../src/lib/providers";
+import type { TokenUsage } from "../../src/types";
+import { getSummaryAndTags } from "../../src/workflows";
+import type { SummaryAndTagsResult } from "../../src/workflows";
+import { getLatencyPerformanceDescription, scoreLatencyPerformance } from "../helpers/latency-performance";
+import { muxTestAssets } from "../helpers/mux-test-assets";
+
+/**
+ * Summarization Language Cost Eval
+ *
+ * Measures the relative cost/performance impact of requesting output in a
+ * different language vs the baseline (no language specified) and vs explicitly
+ * requesting the same language.
+ *
+ * Three variants per provider/model:
+ *  - baseline:           outputLanguageCode omitted
+ *  - same-language:      outputLanguageCode = "en"
+ *  - different-language: outputLanguageCode = "es"
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Thresholds
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TITLE_MAX_LENGTH = 100;
+const LATENCY_THRESHOLD_GOOD_MS = 8000;
+const LATENCY_THRESHOLD_ACCEPTABLE_MS = 20000;
+const TOKEN_THRESHOLD_EFFICIENT = 4000;
+const COST_THRESHOLD_USD = 0.015;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LanguageVariant = "baseline" | "same-language" | "different-language";
+
+interface EvalOutput extends SummaryAndTagsResult {
+  provider: SupportedProvider;
+  model: ModelIdByProvider[SupportedProvider];
+  variant: LanguageVariant;
+  latencyMs: number;
+  usage: TokenUsage;
+  estimatedCostUsd: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test matrix
+// ─────────────────────────────────────────────────────────────────────────────
+
+const variants: { label: LanguageVariant; outputLanguageCode?: string }[] = [
+  { label: "baseline" },
+  { label: "same-language", outputLanguageCode: "en" },
+  { label: "different-language", outputLanguageCode: "es" },
+];
+
+/** Baseline token counts keyed by "provider/model", populated during task execution. */
+const baselineTokens = new Map<string, number>();
+
+/** All results collected for the end-of-run summary. */
+const allResults: { provider: string; model: string; variant: LanguageVariant; totalTokens: number; estimatedCostUsd: number }[] = [];
+
+const data = EVAL_MODEL_CONFIGS.flatMap(({ provider, modelId }) =>
+  variants.map(variant => ({
+    input: {
+      assetId: muxTestAssets.assetId,
+      provider,
+      model: modelId,
+      variant: variant.label,
+      outputLanguageCode: variant.outputLanguageCode,
+    },
+    expected: {},
+  })),
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function printSummary() {
+  const overheads: Record<LanguageVariant, number[]> = {
+    "baseline": [],
+    "same-language": [],
+    "different-language": [],
+  };
+
+  for (const r of allResults) {
+    if (r.variant === "baseline")
+      continue;
+    const base = baselineTokens.get(`${r.provider}/${r.model}`);
+    if (base && base > 0) {
+      const pct = ((r.totalTokens - base) / base) * 100;
+      overheads[r.variant].push(pct);
+    }
+  }
+
+  const avg = (arr: number[]) => arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
+
+  console.warn("\n── Summarization Language Cost Summary ──");
+  console.warn(`  Same language (en) avg token overhead: ${avg(overheads["same-language"]).toFixed(1)}%`);
+  console.warn(`  Different language (es) avg token overhead: ${avg(overheads["different-language"]).toFixed(1)}%`);
+  console.warn("");
+}
+
+evalite("Summarization Language Cost", {
+  data,
+  task: async ({ assetId, provider, model, variant, outputLanguageCode }): Promise<EvalOutput> => {
+    const startTime = performance.now();
+    const result = await getSummaryAndTags(assetId, {
+      provider,
+      model,
+      includeTranscript: true,
+      outputLanguageCode,
+    });
+    const latencyMs = performance.now() - startTime;
+
+    console.warn(
+      `[summarization-language][${provider}/${model}][${variant}] ${assetId}`,
+      {
+        title: result.title,
+        description: result.description,
+        tags: result.tags,
+      },
+    );
+
+    const usage = result.usage ?? {};
+    const estimatedCostUsd = calculateModelCost(
+      model,
+      usage.inputTokens ?? 0,
+      usage.outputTokens ?? 0,
+      usage.cachedInputTokens ?? 0,
+    );
+
+    reportTrace({
+      input: { assetId, provider, model, variant, outputLanguageCode },
+      output: result,
+      usage: {
+        inputTokens: usage.inputTokens ?? 0,
+        outputTokens: usage.outputTokens ?? 0,
+        totalTokens: usage.totalTokens ?? 0,
+      },
+      start: startTime,
+      end: startTime + latencyMs,
+    });
+
+    const totalTokens = usage.totalTokens ?? 0;
+    const key = `${provider}/${model}`;
+
+    if (variant === "baseline") {
+      baselineTokens.set(key, totalTokens);
+    }
+
+    allResults.push({ provider, model, variant, totalTokens, estimatedCostUsd });
+
+    // Print summary once all tasks have reported in
+    if (allResults.length === data.length) {
+      printSummary();
+    }
+
+    return {
+      ...result,
+      provider,
+      model,
+      variant,
+      latencyMs,
+      usage,
+      estimatedCostUsd,
+    };
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Scorers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  scorers: [
+    // EFFICACY — sanity checks
+
+    {
+      name: "response-integrity",
+      description: "Validates all required fields are present and properly typed.",
+      scorer: ({ output, input }: { output: EvalOutput; input: { assetId: string } }) => {
+        const assetIdValid = output.assetId === input.assetId;
+        const titleValid = typeof output.title === "string" && output.title.length > 0;
+        const descriptionValid = typeof output.description === "string" && output.description.length > 0;
+        const tagsValid = Array.isArray(output.tags) && output.tags.length > 0;
+        const storyboardValid = typeof output.storyboardUrl === "string" && output.storyboardUrl.startsWith("https://");
+
+        return assetIdValid && titleValid && descriptionValid && tagsValid && storyboardValid ? 1 : 0;
+      },
+    },
+
+    {
+      name: "title-quality",
+      description: "Validates title is non-empty, under 100 chars, and doesn't start with filler phrases.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { title } = output;
+
+        if (!title || title.trim().length === 0) {
+          return 0;
+        }
+
+        if (title.length > TITLE_MAX_LENGTH) {
+          return 0.5;
+        }
+
+        const fillerPhrases = [
+          "a video of",
+          "this video shows",
+          "the video shows",
+          "video of",
+          "this is a video",
+        ];
+        const lowerTitle = title.toLowerCase().trim();
+        if (fillerPhrases.some(phrase => lowerTitle.startsWith(phrase))) {
+          return 0.5;
+        }
+
+        return 1;
+      },
+    },
+
+    // EFFICIENCY
+
+    {
+      name: "latency-performance",
+      description: getLatencyPerformanceDescription(LATENCY_THRESHOLD_GOOD_MS, LATENCY_THRESHOLD_ACCEPTABLE_MS),
+      scorer: ({ output }: { output: EvalOutput }) => {
+        return scoreLatencyPerformance(
+          output.latencyMs,
+          LATENCY_THRESHOLD_GOOD_MS,
+          LATENCY_THRESHOLD_ACCEPTABLE_MS,
+        );
+      },
+    },
+
+    {
+      name: "token-efficiency",
+      description: `Scores token usage: 1.0 for <${TOKEN_THRESHOLD_EFFICIENT} tokens, scaled down for higher usage.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const totalTokens = output.usage?.totalTokens ?? 0;
+        if (totalTokens === 0) {
+          return 0;
+        }
+        if (totalTokens <= TOKEN_THRESHOLD_EFFICIENT) {
+          return 1;
+        }
+        return Math.max(0, 1 - (totalTokens - TOKEN_THRESHOLD_EFFICIENT) / TOKEN_THRESHOLD_EFFICIENT);
+      },
+    },
+
+    // EXPENSE
+
+    {
+      name: "usage-data-present",
+      description: "Ensures token usage data is returned for cost analysis (inputTokens and outputTokens must be > 0).",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { usage } = output;
+
+        if (!usage) {
+          return { score: 0, metadata: { reason: "No usage object returned" } };
+        }
+
+        const { inputTokens, outputTokens, totalTokens } = usage;
+
+        if (typeof inputTokens !== "number" || inputTokens <= 0) {
+          return { score: 0, metadata: { reason: "inputTokens missing or zero", inputTokens } };
+        }
+
+        if (typeof outputTokens !== "number" || outputTokens <= 0) {
+          return { score: 0, metadata: { reason: "outputTokens missing or zero", outputTokens } };
+        }
+
+        if (typeof totalTokens === "number" && totalTokens < inputTokens + outputTokens) {
+          return { score: 0.5, metadata: { reason: "totalTokens inconsistent with input + output" } };
+        }
+
+        return 1;
+      },
+    },
+
+    {
+      name: "cost-within-budget",
+      description: `Scores cost efficiency: 1.0 for <${COST_THRESHOLD_USD}USD, scaled down for higher costs.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { estimatedCostUsd } = output;
+        if (estimatedCostUsd <= COST_THRESHOLD_USD) {
+          return 1;
+        }
+        return Math.max(0, 1 - (estimatedCostUsd - COST_THRESHOLD_USD) / COST_THRESHOLD_USD);
+      },
+    },
+  ],
+
+  columns: async ({ input, output }: {
+    input: { assetId: string; model: ModelIdByProvider[SupportedProvider] };
+    output: EvalOutput;
+  }) => {
+    return [
+      { label: "Asset ID", value: input.assetId },
+      { label: "Provider", value: output.provider },
+      { label: "Model", value: output.model },
+      { label: "Variant", value: output.variant },
+      { label: "Title", value: output.title },
+      { label: "Latency", value: `${Math.round(output.latencyMs)}ms` },
+      { label: "Tokens", value: output.usage?.totalTokens ?? 0 },
+      { label: "Token Delta", value: (() => {
+        if (output.variant === "baseline")
+          return "N/A";
+        const base = baselineTokens.get(`${output.provider}/${output.model}`);
+        if (!base || base === 0)
+          return "N/A";
+        const pct = ((output.usage?.totalTokens ?? 0) - base) / base * 100;
+        return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+      })() },
+      { label: "Cost", value: `$${output.estimatedCostUsd.toFixed(6)}` },
+    ];
+  },
+});

--- a/tests/eval/summarization-translation.eval.ts
+++ b/tests/eval/summarization-translation.eval.ts
@@ -1,0 +1,321 @@
+import { evalite } from "evalite";
+import { reportTrace } from "evalite/traces";
+
+import { calculateModelCost, EVAL_MODEL_CONFIGS } from "../../src/lib/providers";
+import type { ModelIdByProvider, SupportedProvider } from "../../src/lib/providers";
+import type { TokenUsage } from "../../src/types";
+import { getSummaryAndTags } from "../../src/workflows";
+import type { SummaryAndTagsResult } from "../../src/workflows";
+import { getLatencyPerformanceDescription, scoreLatencyPerformance } from "../helpers/latency-performance";
+import { muxTestAssets } from "../helpers/mux-test-assets";
+
+/**
+ * Summarization Language Cost Eval
+ *
+ * Measures the relative cost/performance impact of requesting output in a
+ * different language vs the baseline (no language specified) and vs explicitly
+ * requesting the same language.
+ *
+ * Three variants per provider/model:
+ *  - baseline:           outputLanguageCode omitted
+ *  - same-language:      outputLanguageCode = "en"
+ *  - different-language: outputLanguageCode = "es"
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Thresholds
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TITLE_MAX_LENGTH = 100;
+const LATENCY_THRESHOLD_GOOD_MS = 8000;
+const LATENCY_THRESHOLD_ACCEPTABLE_MS = 20000;
+const TOKEN_THRESHOLD_EFFICIENT = 4000;
+const COST_THRESHOLD_USD = 0.015;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LanguageVariant = "baseline" | "same-language" | "different-language";
+
+interface EvalOutput extends SummaryAndTagsResult {
+  provider: SupportedProvider;
+  model: ModelIdByProvider[SupportedProvider];
+  variant: LanguageVariant;
+  latencyMs: number;
+  usage: TokenUsage;
+  estimatedCostUsd: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test matrix
+// ─────────────────────────────────────────────────────────────────────────────
+
+const variants: { label: LanguageVariant; outputLanguageCode?: string }[] = [
+  { label: "baseline" },
+  { label: "same-language", outputLanguageCode: "en" },
+  { label: "different-language", outputLanguageCode: "es" },
+];
+
+/** Baseline token counts keyed by "provider/model", populated during task execution. */
+const baselineTokens = new Map<string, number>();
+
+/** All results collected for the end-of-run summary. */
+const allResults: { provider: string; model: string; variant: LanguageVariant; totalTokens: number; estimatedCostUsd: number }[] = [];
+
+const data = EVAL_MODEL_CONFIGS.flatMap(({ provider, modelId }) =>
+  variants.map(variant => ({
+    input: {
+      assetId: muxTestAssets.assetId,
+      provider,
+      model: modelId,
+      variant: variant.label,
+      outputLanguageCode: variant.outputLanguageCode,
+    },
+    expected: {},
+  })),
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function printSummary() {
+  const overheads: Record<LanguageVariant, number[]> = {
+    "baseline": [],
+    "same-language": [],
+    "different-language": [],
+  };
+
+  for (const r of allResults) {
+    if (r.variant === "baseline")
+      continue;
+    const base = baselineTokens.get(`${r.provider}/${r.model}`);
+    if (base && base > 0) {
+      const pct = ((r.totalTokens - base) / base) * 100;
+      overheads[r.variant].push(pct);
+    }
+  }
+
+  const avg = (arr: number[]) => arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
+
+  console.warn("\n── Summarization Translation Summary ──");
+  console.warn(`  Same language (en) avg token overhead: ${avg(overheads["same-language"]).toFixed(1)}%`);
+  console.warn(`  Different language (es) avg token overhead: ${avg(overheads["different-language"]).toFixed(1)}%`);
+  console.warn("");
+}
+
+evalite("Summarization Translation", {
+  data,
+  task: async ({ assetId, provider, model, variant, outputLanguageCode }): Promise<EvalOutput> => {
+    const startTime = performance.now();
+    const result = await getSummaryAndTags(assetId, {
+      provider,
+      model,
+      includeTranscript: true,
+      outputLanguageCode,
+    });
+    const latencyMs = performance.now() - startTime;
+
+    console.warn(
+      `[summarization-language][${provider}/${model}][${variant}] ${assetId}`,
+      {
+        title: result.title,
+        description: result.description,
+        tags: result.tags,
+      },
+    );
+
+    const usage = result.usage ?? {};
+    const estimatedCostUsd = calculateModelCost(
+      model,
+      usage.inputTokens ?? 0,
+      usage.outputTokens ?? 0,
+      usage.cachedInputTokens ?? 0,
+    );
+
+    reportTrace({
+      input: { assetId, provider, model, variant, outputLanguageCode },
+      output: result,
+      usage: {
+        inputTokens: usage.inputTokens ?? 0,
+        outputTokens: usage.outputTokens ?? 0,
+        totalTokens: usage.totalTokens ?? 0,
+      },
+      start: startTime,
+      end: startTime + latencyMs,
+    });
+
+    const totalTokens = usage.totalTokens ?? 0;
+    const key = `${provider}/${model}`;
+
+    if (variant === "baseline") {
+      baselineTokens.set(key, totalTokens);
+    }
+
+    allResults.push({ provider, model, variant, totalTokens, estimatedCostUsd });
+
+    // Print summary once all tasks have reported in
+    if (allResults.length === data.length) {
+      printSummary();
+    }
+
+    return {
+      ...result,
+      provider,
+      model,
+      variant,
+      latencyMs,
+      usage,
+      estimatedCostUsd,
+    };
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Scorers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  scorers: [
+    // EFFICACY — sanity checks
+
+    {
+      name: "response-integrity",
+      description: "Validates all required fields are present and properly typed.",
+      scorer: ({ output, input }: { output: EvalOutput; input: { assetId: string } }) => {
+        const assetIdValid = output.assetId === input.assetId;
+        const titleValid = typeof output.title === "string" && output.title.length > 0;
+        const descriptionValid = typeof output.description === "string" && output.description.length > 0;
+        const tagsValid = Array.isArray(output.tags) && output.tags.length > 0;
+        const storyboardValid = typeof output.storyboardUrl === "string" && output.storyboardUrl.startsWith("https://");
+
+        return assetIdValid && titleValid && descriptionValid && tagsValid && storyboardValid ? 1 : 0;
+      },
+    },
+
+    {
+      name: "title-quality",
+      description: "Validates title is non-empty, under 100 chars, and doesn't start with filler phrases.",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { title } = output;
+
+        if (!title || title.trim().length === 0) {
+          return 0;
+        }
+
+        if (title.length > TITLE_MAX_LENGTH) {
+          return 0.5;
+        }
+
+        const fillerPhrases = [
+          "a video of",
+          "this video shows",
+          "the video shows",
+          "video of",
+          "this is a video",
+        ];
+        const lowerTitle = title.toLowerCase().trim();
+        if (fillerPhrases.some(phrase => lowerTitle.startsWith(phrase))) {
+          return 0.5;
+        }
+
+        return 1;
+      },
+    },
+
+    // EFFICIENCY
+
+    {
+      name: "latency-performance",
+      description: getLatencyPerformanceDescription(LATENCY_THRESHOLD_GOOD_MS, LATENCY_THRESHOLD_ACCEPTABLE_MS),
+      scorer: ({ output }: { output: EvalOutput }) => {
+        return scoreLatencyPerformance(
+          output.latencyMs,
+          LATENCY_THRESHOLD_GOOD_MS,
+          LATENCY_THRESHOLD_ACCEPTABLE_MS,
+        );
+      },
+    },
+
+    {
+      name: "token-efficiency",
+      description: `Scores token usage: 1.0 for <${TOKEN_THRESHOLD_EFFICIENT} tokens, scaled down for higher usage.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const totalTokens = output.usage?.totalTokens ?? 0;
+        if (totalTokens === 0) {
+          return 0;
+        }
+        if (totalTokens <= TOKEN_THRESHOLD_EFFICIENT) {
+          return 1;
+        }
+        return Math.max(0, 1 - (totalTokens - TOKEN_THRESHOLD_EFFICIENT) / TOKEN_THRESHOLD_EFFICIENT);
+      },
+    },
+
+    // EXPENSE
+
+    {
+      name: "usage-data-present",
+      description: "Ensures token usage data is returned for cost analysis (inputTokens and outputTokens must be > 0).",
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { usage } = output;
+
+        if (!usage) {
+          return { score: 0, metadata: { reason: "No usage object returned" } };
+        }
+
+        const { inputTokens, outputTokens, totalTokens } = usage;
+
+        if (typeof inputTokens !== "number" || inputTokens <= 0) {
+          return { score: 0, metadata: { reason: "inputTokens missing or zero", inputTokens } };
+        }
+
+        if (typeof outputTokens !== "number" || outputTokens <= 0) {
+          return { score: 0, metadata: { reason: "outputTokens missing or zero", outputTokens } };
+        }
+
+        if (typeof totalTokens === "number" && totalTokens < inputTokens + outputTokens) {
+          return { score: 0.5, metadata: { reason: "totalTokens inconsistent with input + output" } };
+        }
+
+        return 1;
+      },
+    },
+
+    {
+      name: "cost-within-budget",
+      description: `Scores cost efficiency: 1.0 for <${COST_THRESHOLD_USD}USD, scaled down for higher costs.`,
+      scorer: ({ output }: { output: EvalOutput }) => {
+        const { estimatedCostUsd } = output;
+        if (estimatedCostUsd <= COST_THRESHOLD_USD) {
+          return 1;
+        }
+        return Math.max(0, 1 - (estimatedCostUsd - COST_THRESHOLD_USD) / COST_THRESHOLD_USD);
+      },
+    },
+  ],
+
+  columns: async ({ input, output }: {
+    input: { assetId: string; model: ModelIdByProvider[SupportedProvider] };
+    output: EvalOutput;
+  }) => {
+    return [
+      { label: "Asset ID", value: input.assetId },
+      { label: "Provider", value: output.provider },
+      { label: "Model", value: output.model },
+      { label: "Variant", value: output.variant },
+      { label: "Title", value: output.title },
+      { label: "Latency", value: `${Math.round(output.latencyMs)}ms` },
+      { label: "Tokens", value: output.usage?.totalTokens ?? 0 },
+      { label: "Token Delta", value: (() => {
+        if (output.variant === "baseline")
+          return "N/A";
+        const base = baselineTokens.get(`${output.provider}/${output.model}`);
+        if (!base || base === 0)
+          return "N/A";
+        const pct = ((output.usage?.totalTokens ?? 0) - base) / base * 100;
+        return `${pct >= 0 ? "+" : ""}${pct.toFixed(1)}%`;
+      })() },
+      { label: "Cost", value: `$${output.estimatedCostUsd.toFixed(6)}` },
+    ];
+  },
+});

--- a/tests/integration/chapters.test.ts
+++ b/tests/integration/chapters.test.ts
@@ -18,4 +18,27 @@ describe("chapters Integration Tests", () => {
     expect(result).toHaveProperty("chapters");
     expect(Array.isArray(result.chapters)).toBe(true);
   });
+
+  describe("language parameter", () => {
+    it("should accept an explicit language code for chapter titles", async () => {
+      const result = await generateChapters(assetId, languageCode, {
+        provider: "openai",
+        outputLanguageCode: "es",
+      });
+
+      expect(result).toBeDefined();
+      expect(result.chapters.length).toBeGreaterThan(0);
+      expect(result.chapters[0].title).toBeDefined();
+    });
+
+    it("should accept outputLanguageCode: 'auto' without error", async () => {
+      const result = await generateChapters(assetId, languageCode, {
+        provider: "openai",
+        outputLanguageCode: "auto",
+      });
+
+      expect(result).toBeDefined();
+      expect(result.chapters.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/tests/integration/summarization.test.ts
+++ b/tests/integration/summarization.test.ts
@@ -99,4 +99,38 @@ describe("summarization Integration Tests", () => {
       expect(result.usage?.totalTokens).toBeGreaterThan(0);
     });
   });
+
+  describe("language parameter", () => {
+    it("should produce output in the specified language", async () => {
+      const result = await getSummaryAndTags(testAssetId, {
+        provider: "openai",
+        outputLanguageCode: "es",
+      });
+
+      expect(result).toBeDefined();
+      expect(result.title).toBeDefined();
+      expect(result.description).toBeDefined();
+    });
+
+    it("should accept outputLanguageCode: 'auto' without error", async () => {
+      const result = await getSummaryAndTags(testAssetId, {
+        provider: "openai",
+        outputLanguageCode: "auto",
+      });
+
+      expect(result).toBeDefined();
+      expect(result.title).toBeDefined();
+      expect(result.description).toBeDefined();
+    });
+
+    it("should preserve default behaviour when language is omitted", async () => {
+      const result = await getSummaryAndTags(testAssetId, {
+        provider: "openai",
+      });
+
+      expect(result).toBeDefined();
+      expect(result.title).toBeDefined();
+      expect(result.description).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds `outputLanguageCode` option to summarization and chapters workflows, giving users explicit control over the language of generated output (titles, descriptions, tags, chapter titles).

- Accepts BCP 47 codes (`"en"`, `"fr"`, `"ja"`) to explicitly set the output language.
- When omitted, auto-detects language from the transcript track's `language_code`, so output matches the content language by default.
- Converts codes to human-readable names via `Intl.DisplayNames` (zero new dependencies) and injects a `<language>` prompt section, following the same pattern as `createToneSection`.
- Language constraint reinforced in system prompts for both video and audio-only paths.
- `askQuestions` takes a lighter approach: reasoning now matches the language of the input question via a prompt constraint, no new parameter needed.
- Gracefully handles the no-captions edge case (e.g. vision-only summarisation) — when no language metadata is available, falls back to unconstrained behaviour (LLM decides).

## Changes

- `src/lib/prompt-builder.ts` — `createLanguageSection()`
- `src/workflows/summarization.ts` — `outputLanguageCode` on `SummarizationOptions`, auto-detection from transcript track with `getReadyTextTracks` fallback
- `src/workflows/chapters.ts` — `outputLanguageCode` on `ChaptersOptions`, auto-detection with fallback to positional `languageCode`
- `src/workflows/ask-questions.ts` — prompt constraint for reasoning language
- `examples/summarization/basic-example.ts` — added `-l, --language` CLI option
- `tests/integration/summarization.test.ts` — explicit code, auto, omission tests
- `tests/integration/chapters.test.ts` — explicit code, auto tests
- JSDoc on `SummarizationOptions.outputLanguageCode` and `ChaptersOptions.outputLanguageCode` updated to reflect auto-detect default

## Translation cost evals

New eval files measure the relative cost/performance overhead of the language prompt injection:

- `tests/eval/summarization-translation.eval.ts`
- `tests/eval/chapters-translation.eval.ts`

Each runs three variants per provider/model against the same test asset:

| Variant | `outputLanguageCode` | Purpose |
|---|---|---|
| baseline | omitted | Control — current default behaviour |
| same-language | `"en"` | Overhead of language prompt when language matches |
| different-language | `"es"` | Overhead of cross-language generation |

Scorers: response-integrity, title-quality, latency-performance, token-efficiency, usage-data-present, cost-within-budget. Dashboard includes a **Token Delta** column showing per-row `%` change vs baseline, plus a console summary of average token overhead per variant.

## Testing the example

```bash
cd examples/summarization
npm run basic -- <asset-id> --output-language fr
```

## Breaking change note

The default behaviour when `outputLanguageCode` is omitted has changed: output language is now auto-detected from the transcript track rather than left to the LLM. This means non-English content will now produce non-English output by default. Users who want English output from non-English content should pass `outputLanguageCode: "en"` explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt construction and default output behavior by auto-detecting output language from transcript metadata, which can alter user-visible results and increase provider output variability/cost.
> 
> **Overview**
> Adds an `outputLanguageCode` option to the `generateChapters` and `getSummaryAndTags` workflows, with `auto`/omitted values resolving to the transcript track’s `language_code` (and falling back to unconstrained output when unavailable).
> 
> Implements a shared `<language>` prompt section via `createLanguageSection`, reinforces the language constraint in system prompts, and updates `askQuestions` to require reasoning in the question’s language.
> 
> Updates the CLI examples to accept `--output-language`, adds integration coverage for explicit/`auto` language handling, and introduces new Evalite suites to measure translation prompt overhead (latency/tokens/cost) for baseline vs same-language vs cross-language output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c45d7e84611c200e853c0b04c94edef030118d69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->