### PR TITLE
chore: add gemini 3.1 flash support

### DIFF
--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -61,7 +61,7 @@ const DEFAULT_EMBEDDING_MODELS: { [K in SupportedEmbeddingProvider]: EmbeddingMo
 export const LANGUAGE_MODELS: { [K in SupportedProvider]: ModelIdByProvider[K][] } = {
   openai: ["gpt-5.1", "gpt-5-mini"],
   anthropic: ["claude-sonnet-4-5"],
-  google: ["gemini-3-flash-preview", "gemini-2.5-flash"],
+  google: ["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview", "gemini-2.5-flash"],
 };
 
 /**
@@ -266,6 +266,12 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
 
   // Google models
   // Reference: https://ai.google.dev/pricing
+  "gemini-3.1-flash-lite-preview": {
+    inputPerMillion: 0.25,
+    outputPerMillion: 1.50,
+    cachedInputPerMillion: 0.025,
+    pricingUrl: "https://ai.google.dev/gemini-api/docs/pricing",
+  },
   "gemini-3-flash-preview": {
     inputPerMillion: 0.50,
     outputPerMillion: 3.00,

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -120,15 +120,15 @@ function maybeWarnOrThrowForDeprecatedLanguageModel(provider: SupportedProvider,
   }
 
   const replacementText = deprecation.replacementModelId ?
-    ` Use "${provider}:${deprecation.replacementModelId}" instead.` :
+    ` Use replacement provider="${provider}" model="${deprecation.replacementModelId}" instead.` :
     "";
   const sunsetText = deprecation.sunsetOn ? ` Planned removal date: ${deprecation.sunsetOn}.` : "";
   const reasonText = deprecation.reason ? ` Reason: ${deprecation.reason}` : "";
 
   const message =
     deprecation.phase === "blocked" ?
-      `Language model "${provider}:${modelId}" is no longer supported.${replacementText}${reasonText}` :
-      `Language model "${provider}:${modelId}" is deprecated and in a grace period.${replacementText}${sunsetText}${reasonText}`;
+      `Language model is no longer supported for provider="${provider}" model="${modelId}".${replacementText}${reasonText}` :
+      `Language model is deprecated and in a grace period for provider="${provider}" model="${modelId}".${replacementText}${sunsetText}${reasonText}`;
 
   if (deprecation.phase === "blocked") {
     throw new Error(message);

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -61,7 +61,7 @@ const DEFAULT_EMBEDDING_MODELS: { [K in SupportedEmbeddingProvider]: EmbeddingMo
 export const LANGUAGE_MODELS: { [K in SupportedProvider]: ModelIdByProvider[K][] } = {
   openai: ["gpt-5.1", "gpt-5-mini"],
   anthropic: ["claude-sonnet-4-5"],
-  google: ["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview", "gemini-2.5-flash"],
+  google: ["gemini-3-flash-preview", "gemini-3.1-flash-lite-preview", "gemini-2.5-flash"],
 };
 
 export type ModelDeprecationPhase = "warn" | "blocked";

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -64,6 +64,89 @@ export const LANGUAGE_MODELS: { [K in SupportedProvider]: ModelIdByProvider[K][]
   google: ["gemini-3.1-flash-lite-preview", "gemini-3-flash-preview", "gemini-2.5-flash"],
 };
 
+export type ModelDeprecationPhase = "warn" | "blocked";
+
+/**
+ * Lifecycle metadata for a language model that is being phased out.
+ *
+ * @remarks
+ * - "warn": model is still supported, but logs migration guidance.
+ * - "blocked": model is no longer supported and throws with migration guidance.
+ */
+export interface LanguageModelDeprecation {
+  provider: SupportedProvider;
+  modelId: string;
+  replacementModelId?: string;
+  phase: ModelDeprecationPhase;
+  deprecatedOn: string;
+  sunsetOn?: string;
+  reason?: string;
+}
+
+/**
+ * Deprecated language models that remain supported during a grace period.
+ * This enables gradual migration while clearly signaling planned removal.
+ */
+export const LANGUAGE_MODEL_DEPRECATIONS: LanguageModelDeprecation[] = [
+  {
+    provider: "google",
+    modelId: "gemini-2.5-flash",
+    replacementModelId: "gemini-3.1-flash-lite-preview",
+    phase: "warn",
+    deprecatedOn: "2026-03-03",
+    sunsetOn: "2026-06-30",
+    reason: "Gemini 3.1 Flash-Lite Preview offers better quality/latency/cost balance in current evals.",
+  },
+];
+
+const warnedDeprecatedLanguageModels = new Set<string>();
+
+/**
+ * Returns deprecation metadata for a provider/model pair, if any.
+ */
+export function getLanguageModelDeprecation(
+  provider: SupportedProvider,
+  modelId: string,
+): LanguageModelDeprecation | undefined {
+  return LANGUAGE_MODEL_DEPRECATIONS.find(
+    deprecation => deprecation.provider === provider && deprecation.modelId === modelId,
+  );
+}
+
+function maybeWarnOrThrowForDeprecatedLanguageModel(provider: SupportedProvider, modelId: string): void {
+  const deprecation = getLanguageModelDeprecation(provider, modelId);
+  if (!deprecation) {
+    return;
+  }
+
+  const replacementText = deprecation.replacementModelId ?
+    ` Use "${provider}:${deprecation.replacementModelId}" instead.` :
+    "";
+  const sunsetText = deprecation.sunsetOn ? ` Planned removal date: ${deprecation.sunsetOn}.` : "";
+  const reasonText = deprecation.reason ? ` Reason: ${deprecation.reason}` : "";
+
+  const message =
+    deprecation.phase === "blocked" ?
+      `Language model "${provider}:${modelId}" is no longer supported.${replacementText}${reasonText}` :
+      `Language model "${provider}:${modelId}" is deprecated and in a grace period.${replacementText}${sunsetText}${reasonText}`;
+
+  if (deprecation.phase === "blocked") {
+    throw new Error(message);
+  }
+
+  const warningKey = `${provider}:${modelId}`;
+  if (warnedDeprecatedLanguageModels.has(warningKey)) {
+    return;
+  }
+
+  warnedDeprecatedLanguageModels.add(warningKey);
+  console.warn(message);
+}
+
+export function resetLanguageModelDeprecationWarningsForTests(): void {
+  warnedDeprecatedLanguageModels.clear();
+}
+
 /**
  * A (provider, modelId) pair used for evaluation iteration.
  */
@@ -117,6 +200,8 @@ function parseEvalModelPair(value: string): EvalModelConfig {
       `Unsupported eval model "${modelId}" for provider "${provider}". Supported models: ${supportedModels.join(", ")}.`,
     );
   }
+
+  maybeWarnOrThrowForDeprecatedLanguageModel(provider, modelId);
 
   return {
     provider,
@@ -190,6 +275,7 @@ export function resolveLanguageModelConfig<P extends SupportedProvider = Support
 ): { provider: P; modelId: ModelIdByProvider[P] } {
   const provider = options.provider || ("openai" as P);
   const modelId = (options.model || DEFAULT_LANGUAGE_MODELS[provider]) as ModelIdByProvider[P];
+  maybeWarnOrThrowForDeprecatedLanguageModel(provider, modelId);
 
   return { provider, modelId };
 }
@@ -367,6 +453,8 @@ export async function createLanguageModelFromConfig<P extends SupportedProvider 
   modelId: ModelIdByProvider[P],
   credentials?: WorkflowCredentialsInput,
 ): Promise<LanguageModel> {
+  maybeWarnOrThrowForDeprecatedLanguageModel(provider, modelId);
+
   switch (provider) {
     case "openai": {
       const apiKey = await resolveProviderApiKey("openai", credentials);
@@ -428,6 +516,7 @@ export function resolveLanguageModel<P extends SupportedProvider = SupportedProv
 ): ResolvedModel<P> {
   const provider = options.provider || ("openai" as P);
   const modelId = (options.model || DEFAULT_LANGUAGE_MODELS[provider]) as ModelIdByProvider[P];
+  maybeWarnOrThrowForDeprecatedLanguageModel(provider, modelId);
 
   switch (provider) {
     case "openai": {

--- a/tests/unit/providers.test.ts
+++ b/tests/unit/providers.test.ts
@@ -36,8 +36,8 @@ describe("language model deprecations", () => {
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const firstWarning = String(warnSpy.mock.calls[0]?.[0]);
-    expect(firstWarning).toContain("google:gemini-2.5-flash");
-    expect(firstWarning).toContain("google:gemini-3.1-flash-lite-preview");
+    expect(firstWarning).toContain("provider=\"google\" model=\"gemini-2.5-flash\"");
+    expect(firstWarning).toContain("provider=\"google\" model=\"gemini-3.1-flash-lite-preview\"");
     expect(firstWarning).toContain("Planned removal date");
   });
 

--- a/tests/unit/providers.test.ts
+++ b/tests/unit/providers.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getLanguageModelDeprecation,
+  resetLanguageModelDeprecationWarningsForTests,
+  resolveLanguageModelConfig,
+} from "../../src/lib/providers";
+
+describe("language model deprecations", () => {
+  beforeEach(() => {
+    resetLanguageModelDeprecationWarningsForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("exposes deprecation metadata for deprecated models", () => {
+    const deprecation = getLanguageModelDeprecation("google", "gemini-2.5-flash");
+    expect(deprecation).toMatchObject({
+      provider: "google",
+      modelId: "gemini-2.5-flash",
+      replacementModelId: "gemini-3.1-flash-lite-preview",
+      phase: "warn",
+    });
+  });
+
+  it("warns once per deprecated model during grace period", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    resolveLanguageModelConfig({
+      provider: "google",
+      model: "gemini-2.5-flash",
+    });
+    resolveLanguageModelConfig({
+      provider: "google",
+      model: "gemini-2.5-flash",
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const firstWarning = String(warnSpy.mock.calls[0]?.[0]);
+    expect(firstWarning).toContain("google:gemini-2.5-flash");
+    expect(firstWarning).toContain("google:gemini-3.1-flash-lite-preview");
+    expect(firstWarning).toContain("Planned removal date");
+  });
+
+  it("does not warn for non-deprecated models", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    resolveLanguageModelConfig({
+      provider: "google",
+      model: "gemini-3.1-flash-lite-preview",
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Overview

This branch introduces a language-model deprecation flow for models and updates the preferred model lineup. It adds structured deprecation metadata, warns once during grace periods, and wires this behavior into model resolution/creation paths.

# What was changed

- added support for `gemini-3.1-flash-lite-preview`.
- Added deprecation domain types and config in `src/lib/providers.ts`:
  - `ModelDeprecationPhase` (`warn` | `blocked`)
  - `LanguageModelDeprecation`
  - `LANGUAGE_MODEL_DEPRECATIONS` (currently flags `google:gemini-2.5-flash` in `warn` phase with replacement/sunset metadata)
- Added deprecation helpers:
  - `getLanguageModelDeprecation(provider, modelId)`
  - `maybeWarnOrThrowForDeprecatedLanguageModel(...)` (warn once per model in warn phase, throw in blocked phase)
  - `resetLanguageModelDeprecationWarningsForTests()`
- Integrated deprecation checks into core model paths:
  - eval parsing (`parseEvalModelPair`)
  - config resolution (`resolveLanguageModelConfig`)
  - runtime creation (`createLanguageModelFromConfig`)
  - direct model resolver (`resolveLanguageModel`)
- Added pricing entry for `gemini-3.1-flash-lite-preview` in `MODEL_PRICING`.
- Added unit tests in `tests/unit/providers.test.ts` covering:
  - metadata lookup
  - warn-once behavior
  - no warning for non-deprecated models

# Suggested review order

1. `src/lib/providers.ts` - review the new deprecation model/types/constants and warning/throw behavior.
2. `src/lib/providers.ts` - review each integration point where deprecation checks are called.
3. `src/lib/providers.ts` - review `MODEL_PRICING` addition and Google model list update.
4. `tests/unit/providers.test.ts` - confirm behavior expectations (metadata, warn once, non-deprecated silence).

<img width="2568" height="704" alt="CleanShot 2026-03-03 at 15 35 44@2x" src="https://github.com/user-attachments/assets/f59f9d93-2d93-449b-ac7a-826d7ead2e44" />
