### PR TITLE
feat: Return clearer timing information from moderation workflows

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -87,6 +87,7 @@ Analyzes a Mux asset for inappropriate content using OpenAI's Moderation API or 
   isAudioOnly: boolean;
   thumbnailScores: Array<{ // Individual thumbnail results
     url: string;
+    time?: number; // Time in seconds of the thumbnail within the video
     sexual: number; // 0-1 score
     violence: number; // 0-1 score
     error: boolean;

--- a/docs/PRIMITIVES.md
+++ b/docs/PRIMITIVES.md
@@ -141,8 +141,8 @@ const thumbnails = await getThumbnailUrls("playback-id", 120, {
 });
 
 // [
-//   "https://image.mux.com/playback-id/thumbnail.png?time=0&width=640",
-//   "https://image.mux.com/playback-id/thumbnail.png?time=10&width=640",
+//   { url: "https://image.mux.com/playback-id/thumbnail.png?time=0&width=640", time: 0 },
+//   { url: "https://image.mux.com/playback-id/thumbnail.png?time=10&width=640", time: 10 },
 //   ...
 // ]
 ```

--- a/examples/signed-playback/signed-playback.ts
+++ b/examples/signed-playback/signed-playback.ts
@@ -122,10 +122,10 @@ Notes:
       console.log(`Generated ${thumbnailUrls.length} thumbnail URLs`);
       if (thumbnailUrls.length > 0) {
         console.log("First URL:");
-        console.log(`  ${thumbnailUrls[0].substring(0, 80)}...`);
+        console.log(`  ${thumbnailUrls[0].url.substring(0, 80)}...`);
 
         // Verify the first URL works
-        const response = await fetch(thumbnailUrls[0], { method: "HEAD" });
+        const response = await fetch(thumbnailUrls[0].url, { method: "HEAD" });
         if (response.ok) {
           console.log(`✅ URL is accessible (HTTP ${response.status})`);
         } else {

--- a/src/primitives/thumbnails.ts
+++ b/src/primitives/thumbnails.ts
@@ -28,7 +28,7 @@ export async function getThumbnailUrls(
   playbackId: string,
   duration: number,
   options: ThumbnailOptions = {},
-): Promise<string[]> {
+): Promise<Array<{ url: string; time: number }>> {
   "use step";
   const { interval = 10, width = 640, shouldSign = false, maxSamples, credentials } = options;
   let timestamps: number[] = [];
@@ -67,11 +67,11 @@ export async function getThumbnailUrls(
   const baseUrl = getMuxThumbnailBaseUrl(playbackId);
 
   const urlPromises = timestamps.map(async (time) => {
-    if (shouldSign) {
-      return signUrl(baseUrl, playbackId, "thumbnail", { time, width }, credentials);
-    }
+    const url = shouldSign ?
+        await signUrl(baseUrl, playbackId, "thumbnail", { time, width }, credentials) :
+      `${baseUrl}?time=${time}&width=${width}`;
 
-    return `${baseUrl}?time=${time}&width=${width}`;
+    return { url, time };
   });
 
   return Promise.all(urlPromises);

--- a/src/primitives/thumbnails.ts
+++ b/src/primitives/thumbnails.ts
@@ -22,7 +22,7 @@ export interface ThumbnailOptions {
  * @param playbackId - The Mux playback ID
  * @param duration - Video duration in seconds
  * @param options - Thumbnail generation options
- * @returns Array of thumbnail URLs (signed if shouldSign is true)
+ * @returns Array of objects containing the thumbnail URL and its time in seconds
  */
 export async function getThumbnailUrls(
   playbackId: string,

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -28,6 +28,8 @@ import type {
 /** Per-thumbnail moderation result returned from `getModerationScores`. */
 export interface ThumbnailModerationScore {
   url: string;
+  /** Time in seconds of the thumbnail within the video. Absent for transcript moderation entries. */
+  time?: number;
   sexual: number;
   violence: number;
   error: boolean;
@@ -153,6 +155,7 @@ async function processConcurrently<T>(
 
 async function moderateImageWithOpenAI(entry: {
   url: string;
+  time?: number;
   image: string;
   model: string;
   credentials?: WorkflowCredentialsInput;
@@ -190,6 +193,7 @@ async function moderateImageWithOpenAI(entry: {
 
     return {
       url: entry.url,
+      time: entry.time,
       sexual: categoryScores.sexual || 0,
       violence: categoryScores.violence || 0,
       error: false,
@@ -198,6 +202,7 @@ async function moderateImageWithOpenAI(entry: {
     console.error("OpenAI moderation failed:", error);
     return {
       url: entry.url,
+      time: entry.time,
       sexual: 0,
       violence: 0,
       error: true,
@@ -207,7 +212,7 @@ async function moderateImageWithOpenAI(entry: {
 }
 
 async function requestOpenAIModeration(
-  imageUrls: string[],
+  images: Array<{ url: string; time: number }>,
   model: string,
   maxConcurrent: number = 5,
   submissionMode: "url" | "base64" = "url",
@@ -215,12 +220,15 @@ async function requestOpenAIModeration(
   credentials?: WorkflowCredentialsInput,
 ): Promise<ThumbnailModerationScore[]> {
   "use step";
+  const imageUrls = images.map(img => img.url);
+  const timeByUrl = new Map(images.map(img => [img.url, img.time]));
+
   const targetUrls =
     submissionMode === "base64" ?
         (await downloadImagesAsBase64(imageUrls, downloadOptions, maxConcurrent)).map(
-          img => ({ url: img.url, image: img.base64Data, model, credentials }),
+          img => ({ url: img.url, time: timeByUrl.get(img.url), image: img.base64Data, model, credentials }),
         ) :
-        imageUrls.map(url => ({ url, image: url, model, credentials }));
+        images.map(img => ({ url: img.url, time: img.time, image: img.url, model, credentials }));
 
   return processConcurrently(targetUrls, moderateImageWithOpenAI, maxConcurrent);
 }
@@ -335,6 +343,7 @@ function getHiveCategoryScores(
 
 async function moderateImageWithHive(entry: {
   url: string;
+  time?: number;
   source: HiveModerationSource;
   credentials?: WorkflowCredentialsInput;
 }): Promise<ThumbnailModerationScore> {
@@ -403,6 +412,7 @@ async function moderateImageWithHive(entry: {
 
     return {
       url: entry.url,
+      time: entry.time,
       sexual,
       violence,
       error: false,
@@ -410,6 +420,7 @@ async function moderateImageWithHive(entry: {
   } catch (error) {
     return {
       url: entry.url,
+      time: entry.time,
       sexual: 0,
       violence: 0,
       error: true,
@@ -419,7 +430,7 @@ async function moderateImageWithHive(entry: {
 }
 
 async function requestHiveModeration(
-  imageUrls: string[],
+  images: Array<{ url: string; time: number }>,
   maxConcurrent: number = 5,
   submissionMode: "url" | "base64" = "url",
   downloadOptions?: ImageDownloadOptions,
@@ -427,10 +438,14 @@ async function requestHiveModeration(
 ): Promise<ThumbnailModerationScore[]> {
   "use step";
 
-  const targets: Array<{ url: string; source: HiveModerationSource; credentials?: WorkflowCredentialsInput }> =
+  const imageUrls = images.map(img => img.url);
+  const timeByUrl = new Map(images.map(img => [img.url, img.time]));
+
+  const targets: Array<{ url: string; time?: number; source: HiveModerationSource; credentials?: WorkflowCredentialsInput }> =
     submissionMode === "base64" ?
         (await downloadImagesAsBase64(imageUrls, downloadOptions, maxConcurrent)).map(img => ({
           url: img.url,
+          time: timeByUrl.get(img.url),
           source: {
             kind: "file",
             buffer: img.buffer,
@@ -438,9 +453,10 @@ async function requestHiveModeration(
           },
           credentials,
         })) :
-        imageUrls.map(url => ({
-          url,
-          source: { kind: "url", value: url },
+        images.map(img => ({
+          url: img.url,
+          time: img.time,
+          source: { kind: "url", value: img.url },
           credentials,
         }));
 
@@ -455,18 +471,18 @@ async function getThumbnailUrlsFromTimestamps(
     shouldSign: boolean;
     credentials?: WorkflowCredentialsInput;
   },
-): Promise<string[]> {
+): Promise<Array<{ url: string; time: number }>> {
   "use step";
   const { width, shouldSign, credentials } = options;
   const baseUrl = getMuxThumbnailBaseUrl(playbackId);
 
   const urlPromises = timestampsMs.map(async (tsMs) => {
     const time = Number((tsMs / 1000).toFixed(2));
-    if (shouldSign) {
-      return signUrl(baseUrl, playbackId, "thumbnail", { time, width }, credentials);
-    }
+    const url = shouldSign ?
+        await signUrl(baseUrl, playbackId, "thumbnail", { time, width }, credentials) :
+      `${baseUrl}?time=${time}&width=${width}`;
 
-    return `${baseUrl}?time=${time}&width=${width}`;
+    return { url, time };
   });
 
   return Promise.all(urlPromises);

--- a/tests/integration/signed-playback.test.ts
+++ b/tests/integration/signed-playback.test.ts
@@ -152,13 +152,13 @@ describe("signed Playback Integration Tests", () => {
         });
 
         expect(urls.length).toBeGreaterThan(0);
-        urls.forEach((url) => {
-          expect(url).toContain(`${getMuxImageOrigin()}/${playbackId}/thumbnail.png`);
-          expect(url).toContain("token=");
+        urls.forEach((entry) => {
+          expect(entry.url).toContain(`${getMuxImageOrigin()}/${playbackId}/thumbnail.png`);
+          expect(entry.url).toContain("token=");
         });
 
         // Verify the first URL is accessible
-        const response = await fetch(urls[0], { method: "HEAD" });
+        const response = await fetch(urls[0].url, { method: "HEAD" });
         expect(response.ok).toBe(true);
       });
 
@@ -171,9 +171,9 @@ describe("signed Playback Integration Tests", () => {
         });
 
         expect(urls.length).toBeGreaterThan(0);
-        urls.forEach((url) => {
-          expect(url).toContain(`${getMuxImageOrigin()}/${testPlaybackId}/thumbnail.png`);
-          expect(url).not.toContain("token=");
+        urls.forEach((entry) => {
+          expect(entry.url).toContain(`${getMuxImageOrigin()}/${testPlaybackId}/thumbnail.png`);
+          expect(entry.url).not.toContain("token=");
         });
       });
 
@@ -189,13 +189,13 @@ describe("signed Playback Integration Tests", () => {
         expect(urls.length).toBe(5);
 
         // All URLs should be signed
-        urls.forEach((url) => {
-          expect(url).toContain(`${getMuxImageOrigin()}/${playbackId}/thumbnail.png`);
-          expect(url).toContain("token=");
+        urls.forEach((entry) => {
+          expect(entry.url).toContain(`${getMuxImageOrigin()}/${playbackId}/thumbnail.png`);
+          expect(entry.url).toContain("token=");
         });
 
         // Verify the first URL is accessible
-        const response = await fetch(urls[0], { method: "HEAD" });
+        const response = await fetch(urls[0].url, { method: "HEAD" });
         expect(response.ok).toBe(true);
       });
     });

--- a/tests/unit/thumbnails.test.ts
+++ b/tests/unit/thumbnails.test.ts
@@ -20,8 +20,10 @@ describe("getThumbnailUrls", () => {
 
       // 100 seconds / 10 second interval = 10 thumbnails (0, 10, 20, ..., 90)
       expect(urls.length).toBe(10);
-      expect(urls[0]).toContain("time=0");
-      expect(urls[9]).toContain("time=90");
+      expect(urls[0].url).toContain("time=0");
+      expect(urls[0].time).toBe(0);
+      expect(urls[9].url).toContain("time=90");
+      expect(urls[9].time).toBe(90);
     });
 
     it("should generate thumbnails at custom intervals", async () => {
@@ -33,9 +35,9 @@ describe("getThumbnailUrls", () => {
 
       // 60 seconds / 20 second interval = 3 thumbnails (0, 20, 40)
       expect(urls.length).toBe(3);
-      expect(urls[0]).toContain("time=0");
-      expect(urls[1]).toContain("time=20");
-      expect(urls[2]).toContain("time=40");
+      expect(urls[0].url).toContain("time=0");
+      expect(urls[1].url).toContain("time=20");
+      expect(urls[2].url).toContain("time=40");
     });
 
     it("should generate 5 thumbnails for short videos (≤50 seconds)", async () => {
@@ -80,7 +82,7 @@ describe("getThumbnailUrls", () => {
         shouldSign: false,
       });
 
-      expect(urls[0]).toContain("time=0");
+      expect(urls[0].url).toContain("time=0");
     });
 
     it("should always include last frame when maxSamples >= 2", async () => {
@@ -91,8 +93,8 @@ describe("getThumbnailUrls", () => {
       });
 
       expect(urls.length).toBe(4);
-      expect(urls[0]).toContain("time=0");
-      expect(urls[3]).toContain("time=100");
+      expect(urls[0].url).toContain("time=0");
+      expect(urls[3].url).toContain("time=100");
     });
 
     it("should evenly distribute timestamps when maxSamples is applied", async () => {
@@ -104,11 +106,11 @@ describe("getThumbnailUrls", () => {
 
       // 5 samples: 0, 25, 50, 75, 100 (evenly distributed)
       expect(urls.length).toBe(5);
-      expect(urls[0]).toContain("time=0");
-      expect(urls[1]).toContain("time=25");
-      expect(urls[2]).toContain("time=50");
-      expect(urls[3]).toContain("time=75");
-      expect(urls[4]).toContain("time=100");
+      expect(urls[0].url).toContain("time=0");
+      expect(urls[1].url).toContain("time=25");
+      expect(urls[2].url).toContain("time=50");
+      expect(urls[3].url).toContain("time=75");
+      expect(urls[4].url).toContain("time=100");
     });
 
     it("should handle maxSamples = 1 (only first frame)", async () => {
@@ -119,7 +121,7 @@ describe("getThumbnailUrls", () => {
       });
 
       expect(urls.length).toBe(1);
-      expect(urls[0]).toContain("time=0");
+      expect(urls[0].url).toContain("time=0");
     });
 
     it("should handle maxSamples = 2 (first and last frames)", async () => {
@@ -130,8 +132,8 @@ describe("getThumbnailUrls", () => {
       });
 
       expect(urls.length).toBe(2);
-      expect(urls[0]).toContain("time=0");
-      expect(urls[1]).toContain("time=100");
+      expect(urls[0].url).toContain("time=0");
+      expect(urls[1].url).toContain("time=100");
     });
 
     it("should work with maxSamples on short videos", async () => {
@@ -143,8 +145,8 @@ describe("getThumbnailUrls", () => {
 
       // Short video generates 5 frames, but maxSamples caps it to 3
       expect(urls.length).toBe(3);
-      expect(urls[0]).toContain("time=0");
-      expect(urls[2]).toContain("time=30");
+      expect(urls[0].url).toContain("time=0");
+      expect(urls[2].url).toContain("time=30");
     });
 
     it("should distribute evenly with maxSamples = 10 on 200 second video", async () => {
@@ -159,11 +161,8 @@ describe("getThumbnailUrls", () => {
       // With maxSamples: capped to 10, evenly distributed
       expect(urls.length).toBe(10);
 
-      // Extract timestamps from URLs
-      const timestamps = urls.map((url) => {
-        const match = url.match(/time=(\d+\.?\d*)/);
-        return match ? Number.parseFloat(match[1]) : 0;
-      });
+      // Extract timestamps from the time field
+      const timestamps = urls.map(entry => entry.time);
 
       // First and last should be pinned
       expect(timestamps[0]).toBe(0);
@@ -186,8 +185,8 @@ describe("getThumbnailUrls", () => {
         shouldSign: false,
       });
 
-      urls.forEach((url) => {
-        expect(url).toContain("width=1280");
+      urls.forEach((entry) => {
+        expect(entry.url).toContain("width=1280");
       });
     });
 
@@ -197,10 +196,10 @@ describe("getThumbnailUrls", () => {
         shouldSign: false,
       });
 
-      urls.forEach((url) => {
-        expect(url).toContain(`${getMuxImageOrigin()}/${testPlaybackId}/thumbnail.png`);
-        expect(url).toContain("time=");
-        expect(url).toContain("width=");
+      urls.forEach((entry) => {
+        expect(entry.url).toContain(`${getMuxImageOrigin()}/${testPlaybackId}/thumbnail.png`);
+        expect(entry.url).toContain("time=");
+        expect(entry.url).toContain("width=");
       });
     });
 
@@ -213,8 +212,8 @@ describe("getThumbnailUrls", () => {
         shouldSign: false,
       });
 
-      urls.forEach((url) => {
-        expect(url).toContain(`https://image.example.com/${testPlaybackId}/thumbnail.png`);
+      urls.forEach((entry) => {
+        expect(entry.url).toContain(`https://image.example.com/${testPlaybackId}/thumbnail.png`);
       });
     });
   });
@@ -239,7 +238,7 @@ describe("getThumbnailUrls", () => {
 
       // maxSamples of 0 should result in empty newTimestamps array, but code pushes at least first frame
       expect(urls.length).toBe(1);
-      expect(urls[0]).toContain("time=0");
+      expect(urls[0].url).toContain("time=0");
     });
 
     it("should handle very long video with small maxSamples", async () => {
@@ -251,10 +250,7 @@ describe("getThumbnailUrls", () => {
 
       expect(urls.length).toBe(4);
 
-      const timestamps = urls.map((url) => {
-        const match = url.match(/time=(\d+\.?\d*)/);
-        return match ? Number.parseFloat(match[1]) : 0;
-      });
+      const timestamps = urls.map(entry => entry.time);
 
       expect(timestamps[0]).toBe(0);
       expect(timestamps[3]).toBeCloseTo(3600, 1);


### PR DESCRIPTION
## Summary

Adds `time?: number` to `ThumbnailModerationScore` so consumers can see when in the video a moderation flag occurred without parsing it back out of the thumbnail URL (which is impossible for signed URLs).

**Breaking change:** `getThumbnailUrls` primitive now returns `Array<{ url: string; time: number }>` instead of `string[]`. Any code that treats the return values as strings (e.g. `urls[0].includes(...)`, `fetch(urls[0])`) will need updating to access the `.url` property.

## Example

```typescript
const result = await getModerationScores("asset-id", { provider: "openai" });

for (const score of result.thumbnailScores) {
  if (score.sexual > 0.8) {
    console.log(`Flagged at ${score.time}s: ${score.url}`);
  }
}
```

## Suggested review order

1. `src/primitives/thumbnails.ts` — return type change
2. `src/workflows/moderation.ts` — threading `time` through OpenAI and Hive paths
3. `tests/unit/thumbnails.test.ts` — updated assertions
4. `tests/integration/signed-playback.test.ts` — same
5. `docs/API.md`, `docs/PRIMITIVES.md` — updated type docs
6. `examples/signed-playback/signed-playback.ts` — updated example