### PR TITLE
feat: introducing shots as a primitive

### DIFF
--- a/docs/PRIMITIVES.md
+++ b/docs/PRIMITIVES.md
@@ -17,6 +17,7 @@ import {
   chunkByTokens,
   chunkVTTCues,
   fetchTranscriptForAsset,
+  getShotsForAsset,
   getStoryboardUrl,
   getThumbnailUrls,
   parseVTTCues
@@ -162,6 +163,78 @@ interface ThumbnailOptions {
 - Videos ≤50 seconds: Generates 5 evenly-spaced thumbnails
 - Videos >50 seconds: Uses specified interval
 
+### `requestShotsForAsset(assetId, options?)`
+
+Starts asynchronous shot detection for a Mux asset.
+
+```typescript
+import { requestShotsForAsset } from "@mux/ai/primitives";
+
+const result = await requestShotsForAsset("asset-id");
+// { status: "pending", createdAt: "1773108428" }
+```
+
+**Parameters:**
+
+- `assetId: string` - Mux asset ID
+- `options?.credentials` - Optional workflow credentials
+
+### `getShotsForAsset(assetId, options?)`
+
+Gets the current shot detection status for a Mux asset.
+
+```typescript
+import { getShotsForAsset } from "@mux/ai/primitives";
+
+const result = await getShotsForAsset("asset-id");
+
+if (result.status === "completed") {
+  console.log(result.shots);
+}
+```
+
+**Returns:** `ShotsResult`
+
+```typescript
+interface Shot {
+  startTime: number; // Seconds from start of asset
+  imageUrl: string; // Signed representative frame URL
+}
+
+type ShotsResult =
+  | {
+      status: "pending";
+      createdAt: string;
+    }
+  | {
+      status: "completed";
+      createdAt: string;
+      shots: Shot[];
+    };
+```
+
+### `waitForShotsForAsset(assetId, options?)`
+
+Convenience helper that optionally starts shot detection and polls until results are ready.
+
+```typescript
+import { waitForShotsForAsset } from "@mux/ai/primitives";
+
+const result = await waitForShotsForAsset("asset-id", {
+  pollIntervalMs: 2000,
+  maxAttempts: 60
+});
+
+console.log(result.shots);
+```
+
+**Options:**
+
+- `pollIntervalMs?: number` - Milliseconds between polls (default: 2000)
+- `maxAttempts?: number` - Maximum polling attempts (default: 60)
+- `createIfMissing?: boolean` - Call `requestShotsForAsset()` before polling (default: true)
+- `credentials?: WorkflowCredentialsInput` - Optional workflow credentials
+
 ## Text Chunking Primitives
 
 Utilities for splitting transcripts into manageable chunks for embedding generation or long-form analysis.
@@ -287,6 +360,7 @@ import { generateText } from "ai";
 import {
   chunkVTTCues,
   fetchTranscriptForAsset,
+  getShotsForAsset,
   getStoryboardUrl,
   parseVTTCues
 } from "@mux/ai/primitives";
@@ -303,6 +377,9 @@ async function customVideoAnalysis(assetId: string) {
     { languageCode: "en" }
   );
 
+  // Fetch visual structure
+  const shots = await getShotsForAsset(assetId);
+
   // Get storyboard
   const storyboardUrl = await getStoryboardUrl(playbackId);
 
@@ -315,7 +392,8 @@ async function customVideoAnalysis(assetId: string) {
         content: [
           { type: "text", text: "Analyze this video and extract key insights." },
           { type: "image", image: storyboardUrl },
-          { type: "text", text: `Transcript: ${transcriptText}` }
+          { type: "text", text: `Transcript: ${transcriptText}` },
+          { type: "text", text: `Shot count: ${shots.status === "completed" ? shots.shots.length : "pending"}` }
         ]
       }
     ]

--- a/src/primitives/index.ts
+++ b/src/primitives/index.ts
@@ -1,6 +1,7 @@
 // primitives public surface intentionally minimal; provider plumbing lives in lib/providers
 export * from "./heatmap";
 export * from "./hotspots";
+export * from "./shots";
 export * from "./storyboards";
 export * from "./text-chunking";
 export * from "./thumbnails";

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -13,13 +13,18 @@ export interface PendingShotsResult {
   createdAt: string;
 }
 
+export interface ErroredShotsResult {
+  status: "errored";
+  createdAt: string;
+}
+
 export interface CompletedShotsResult {
   status: "completed";
   createdAt: string;
   shots: Shot[];
 }
 
-export type ShotsResult = PendingShotsResult | CompletedShotsResult;
+export type ShotsResult = PendingShotsResult | ErroredShotsResult | CompletedShotsResult;
 
 export interface ShotRequestOptions {
   /** Optional workflow credentials */
@@ -35,12 +40,17 @@ export interface WaitForShotsOptions extends ShotRequestOptions {
   createIfMissing?: boolean;
 }
 
-interface PendingShotLocationsApiData {
+interface PendingShotsApiData {
   status: "pending";
   created_at: string;
 }
 
-interface CompletedShotLocationsApiData {
+interface ErroredShotsApiData {
+  status: "errored";
+  created_at: string;
+}
+
+interface CompletedShotsApiData {
   status: "completed";
   created_at: string;
   shot_locations: Array<{
@@ -49,25 +59,32 @@ interface CompletedShotLocationsApiData {
   }>;
 }
 
-interface ShotLocationsApiResponse {
-  data: PendingShotLocationsApiData | CompletedShotLocationsApiData;
+interface ShotsApiResponse {
+  data: PendingShotsApiData | ErroredShotsApiData | CompletedShotsApiData;
 }
+
+type RequestShotsApiRequestBody = Record<string, never>;
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DEFAULT_MAX_ATTEMPTS = 60;
 const SHOTS_ALREADY_REQUESTED_MESSAGE = "shots generation has already been requested";
 
-function getShotLocationsPath(assetId: string): string {
+function getShotsPath(assetId: string): string {
   return `/video/v1/assets/${assetId}/shot-locations`;
 }
 
 function transformShotsResponse(
-  response: ShotLocationsApiResponse,
+  response: ShotsApiResponse,
 ): ShotsResult {
   switch (response.data.status) {
     case "pending":
       return {
         status: "pending",
+        createdAt: response.data.created_at,
+      };
+    case "errored":
+      return {
+        status: "errored",
         createdAt: response.data.created_at,
       };
     case "completed":
@@ -102,7 +119,7 @@ function isShotsAlreadyRequestedError(error: unknown): boolean {
 }
 
 /**
- * Starts generating shot locations for an asset.
+ * Starts generating shots for an asset.
  *
  * @param assetId - The Mux asset ID
  * @param options - Request options
@@ -116,8 +133,8 @@ export async function requestShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.post<Record<string, never>, ShotLocationsApiResponse>(
-    getShotLocationsPath(assetId),
+  const response = await mux.post<RequestShotsApiRequestBody, ShotsApiResponse>(
+    getShotsPath(assetId),
     { body: {} },
   );
   const result = transformShotsResponse(response);
@@ -136,7 +153,7 @@ export async function requestShotsForAsset(
  *
  * @param assetId - The Mux asset ID
  * @param options - Request options
- * @returns Pending or completed shot result
+ * @returns Pending, errored, or completed shot result
  */
 export async function getShotsForAsset(
   assetId: string,
@@ -146,8 +163,8 @@ export async function getShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.get<unknown, ShotLocationsApiResponse>(
-    getShotLocationsPath(assetId),
+  const response = await mux.get<unknown, ShotsApiResponse>(
+    getShotsPath(assetId),
   );
 
   return transformShotsResponse(response);
@@ -192,6 +209,10 @@ export async function waitForShotsForAsset(
 
     if (result.status === "completed") {
       return result;
+    }
+
+    if (result.status === "errored") {
+      throw new Error(`Shots generation errored for asset '${assetId}'`);
     }
 
     if (attempt < normalizedMaxAttempts - 1) {

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -32,7 +32,7 @@ export interface ShotRequestOptions {
 }
 
 export interface WaitForShotsOptions extends ShotRequestOptions {
-  /** Polling interval in milliseconds (default: 2000) */
+  /** Polling interval in milliseconds (default: 2000, minimum enforced: 1000) */
   pollIntervalMs?: number;
   /** Maximum number of polling attempts (default: 60) */
   maxAttempts?: number;
@@ -66,6 +66,7 @@ interface ShotsApiResponse {
 type RequestShotsApiRequestBody = Record<string, never>;
 
 const DEFAULT_POLL_INTERVAL_MS = 2000;
+const MIN_POLL_INTERVAL_MS = 1000;
 const DEFAULT_MAX_ATTEMPTS = 60;
 const SHOTS_ALREADY_REQUESTED_MESSAGE = "shots generation has already been requested";
 
@@ -200,7 +201,7 @@ export async function waitForShotsForAsset(
   }
 
   const normalizedMaxAttempts = Math.max(1, maxAttempts);
-  const normalizedPollIntervalMs = Math.max(0, pollIntervalMs);
+  const normalizedPollIntervalMs = Math.max(MIN_POLL_INTERVAL_MS, pollIntervalMs);
   let lastStatus: ShotsResult["status"] | undefined;
 
   for (let attempt = 0; attempt < normalizedMaxAttempts; attempt++) {

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -1,0 +1,205 @@
+import { getMuxClientFromEnv } from "@mux/ai/lib/client-factory";
+import type { WorkflowCredentialsInput } from "@mux/ai/types";
+
+export interface Shot {
+  /** Start time of the shot in seconds from the beginning of the asset. */
+  startTime: number;
+  /** Signed URL for a representative image of the shot. */
+  imageUrl: string;
+}
+
+export interface PendingShotsResult {
+  status: "pending";
+  createdAt: string;
+}
+
+export interface CompletedShotsResult {
+  status: "completed";
+  createdAt: string;
+  shots: Shot[];
+}
+
+export type ShotsResult = PendingShotsResult | CompletedShotsResult;
+
+export interface ShotRequestOptions {
+  /** Optional workflow credentials */
+  credentials?: WorkflowCredentialsInput;
+}
+
+export interface WaitForShotsOptions extends ShotRequestOptions {
+  /** Polling interval in milliseconds (default: 2000) */
+  pollIntervalMs?: number;
+  /** Maximum number of polling attempts (default: 60) */
+  maxAttempts?: number;
+  /** When true, request shot generation before polling (default: true) */
+  createIfMissing?: boolean;
+}
+
+interface PendingShotLocationsApiData {
+  status: "pending";
+  created_at: string;
+}
+
+interface CompletedShotLocationsApiData {
+  status: "completed";
+  created_at: string;
+  shot_locations: Array<{
+    start_time: number;
+    image_url: string;
+  }>;
+}
+
+interface ShotLocationsApiResponse {
+  data: PendingShotLocationsApiData | CompletedShotLocationsApiData;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+const DEFAULT_MAX_ATTEMPTS = 60;
+const SHOTS_ALREADY_REQUESTED_MESSAGE = "shots generation has already been requested";
+
+function getShotLocationsPath(assetId: string): string {
+  return `/video/v1/assets/${assetId}/shot-locations`;
+}
+
+function transformShotsResponse(
+  response: ShotLocationsApiResponse,
+): ShotsResult {
+  switch (response.data.status) {
+    case "pending":
+      return {
+        status: "pending",
+        createdAt: response.data.created_at,
+      };
+    case "completed":
+      return {
+        status: "completed",
+        createdAt: response.data.created_at,
+        shots: response.data.shot_locations.map(shot => ({
+          startTime: shot.start_time,
+          imageUrl: shot.image_url,
+        })),
+      };
+    default: {
+      const exhaustiveCheck: never = response.data;
+      throw new Error(`Unsupported shots response: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isShotsAlreadyRequestedError(error: unknown): boolean {
+  const statusCode = (error as any)?.status ?? (error as any)?.statusCode;
+  const messages: string[] | undefined = (error as any)?.error?.messages;
+  const lowerCaseMessages = messages?.map(message => message.toLowerCase()) ?? [];
+  const errorMessage = error instanceof Error ? error.message.toLowerCase() : "";
+
+  return statusCode === 400 &&
+    (lowerCaseMessages.some(message => message.includes(SHOTS_ALREADY_REQUESTED_MESSAGE)) ||
+      errorMessage.includes(SHOTS_ALREADY_REQUESTED_MESSAGE));
+}
+
+/**
+ * Starts generating shot locations for an asset.
+ *
+ * @param assetId - The Mux asset ID
+ * @param options - Request options
+ * @returns Pending shot generation state
+ */
+export async function requestShotsForAsset(
+  assetId: string,
+  options: ShotRequestOptions = {},
+): Promise<PendingShotsResult> {
+  "use step";
+  const { credentials } = options;
+  const muxClient = await getMuxClientFromEnv(credentials);
+  const mux = await muxClient.createClient();
+  const response = await mux.post<Record<string, never>, ShotLocationsApiResponse>(
+    getShotLocationsPath(assetId),
+    { body: {} },
+  );
+  const result = transformShotsResponse(response);
+
+  if (result.status !== "pending") {
+    throw new Error(
+      `Expected pending status after requesting shots for asset '${assetId}', received '${result.status}'`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Gets the current shot generation status for an asset.
+ *
+ * @param assetId - The Mux asset ID
+ * @param options - Request options
+ * @returns Pending or completed shot result
+ */
+export async function getShotsForAsset(
+  assetId: string,
+  options: ShotRequestOptions = {},
+): Promise<ShotsResult> {
+  "use step";
+  const { credentials } = options;
+  const muxClient = await getMuxClientFromEnv(credentials);
+  const mux = await muxClient.createClient();
+  const response = await mux.get<unknown, ShotLocationsApiResponse>(
+    getShotLocationsPath(assetId),
+  );
+
+  return transformShotsResponse(response);
+}
+
+/**
+ * Requests shot generation if needed and polls until shots are completed.
+ *
+ * @param assetId - The Mux asset ID
+ * @param options - Polling options
+ * @returns Completed shot result
+ */
+export async function waitForShotsForAsset(
+  assetId: string,
+  options: WaitForShotsOptions = {},
+): Promise<CompletedShotsResult> {
+  "use step";
+  const {
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    createIfMissing = true,
+    credentials,
+  } = options;
+
+  if (createIfMissing) {
+    try {
+      await requestShotsForAsset(assetId, { credentials });
+    } catch (error) {
+      if (!isShotsAlreadyRequestedError(error)) {
+        throw error;
+      }
+    }
+  }
+
+  const normalizedMaxAttempts = Math.max(1, maxAttempts);
+  const normalizedPollIntervalMs = Math.max(0, pollIntervalMs);
+  let lastStatus: ShotsResult["status"] | undefined;
+
+  for (let attempt = 0; attempt < normalizedMaxAttempts; attempt++) {
+    const result = await getShotsForAsset(assetId, { credentials });
+    lastStatus = result.status;
+
+    if (result.status === "completed") {
+      return result;
+    }
+
+    if (attempt < normalizedMaxAttempts - 1) {
+      await sleep(normalizedPollIntervalMs);
+    }
+  }
+
+  throw new Error(
+    `Timed out waiting for shots for asset '${assetId}' after ${normalizedMaxAttempts} attempts. Last status: ${lastStatus ?? "unknown"}`,
+  );
+}

--- a/tests/integration/shots.test.ts
+++ b/tests/integration/shots.test.ts
@@ -1,0 +1,49 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import type { CompletedShotsResult } from "../../src/primitives/shots";
+import { getShotsForAsset, waitForShotsForAsset } from "../../src/primitives/shots";
+import { muxTestAssets } from "../helpers/mux-test-assets";
+
+describe("shots Integration Tests", () => {
+  const assetId = muxTestAssets.assetId;
+  let completedShots: CompletedShotsResult;
+
+  beforeAll(async () => {
+    completedShots = await waitForShotsForAsset(assetId, {
+      pollIntervalMs: 2000,
+      maxAttempts: 60,
+    });
+  }, 180000);
+
+  it("should generate completed shots for the integration asset", () => {
+    expect(completedShots).toBeDefined();
+    expect(completedShots.status).toBe("completed");
+    expect(completedShots.createdAt).toBeDefined();
+    expect(typeof completedShots.createdAt).toBe("string");
+    expect(Array.isArray(completedShots.shots)).toBe(true);
+    expect(completedShots.shots.length).toBeGreaterThan(0);
+
+    completedShots.shots.forEach((shot, index) => {
+      expect(typeof shot.startTime).toBe("number");
+      expect(Number.isFinite(shot.startTime)).toBe(true);
+      expect(shot.startTime).toBeGreaterThanOrEqual(0);
+      expect(typeof shot.imageUrl).toBe("string");
+      expect(shot.imageUrl).toMatch(/^https?:\/\//);
+
+      if (index > 0) {
+        expect(shot.startTime).toBeGreaterThanOrEqual(completedShots.shots[index - 1].startTime);
+      }
+    });
+  });
+
+  it("should return completed shots when fetched after generation", async () => {
+    const result = await getShotsForAsset(assetId);
+
+    expect(result.status).toBe("completed");
+
+    if (result.status === "completed") {
+      expect(result.shots.length).toBeGreaterThan(0);
+      expect(result.shots[0].imageUrl).toMatch(/^https?:\/\//);
+    }
+  });
+});

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -266,4 +266,26 @@ describe("waitForShotsForAsset", () => {
     await expectation;
     expect(mockMuxGet).toHaveBeenCalledTimes(1);
   });
+
+  it("enforces a minimum poll interval when zero is provided", async () => {
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    mockMuxPost.mockResolvedValue(MOCK_PENDING_RESPONSE);
+    mockMuxGet
+      .mockResolvedValueOnce(MOCK_PENDING_RESPONSE)
+      .mockResolvedValueOnce(MOCK_COMPLETED_RESPONSE);
+
+    const promise = waitForShotsForAsset("test-asset-123", {
+      pollIntervalMs: 0,
+      maxAttempts: 2,
+    });
+    const expectation = expect(promise).resolves.toMatchObject({
+      status: "completed",
+    });
+
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
+  });
 });

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -13,6 +13,13 @@ const MOCK_PENDING_RESPONSE = {
   },
 };
 
+const MOCK_ERRORED_RESPONSE = {
+  data: {
+    status: "errored" as const,
+    created_at: "1773108428",
+  },
+};
+
 const MOCK_COMPLETED_RESPONSE = {
   data: {
     status: "completed" as const,
@@ -123,6 +130,17 @@ describe("getShotsForAsset", () => {
     });
   });
 
+  it("returns transformed errored result", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_ERRORED_RESPONSE);
+
+    const result = await getShotsForAsset("test-asset-123");
+
+    expect(result).toEqual({
+      status: "errored",
+      createdAt: "1773108428",
+    });
+  });
+
   it("constructs the correct GET path", async () => {
     mockMuxGet.mockResolvedValue(MOCK_PENDING_RESPONSE);
 
@@ -229,5 +247,23 @@ describe("waitForShotsForAsset", () => {
     await vi.runAllTimersAsync();
     await expectation;
     expect(mockMuxGet).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws immediately when shots enter an errored terminal state", async () => {
+    vi.useFakeTimers();
+    mockMuxPost.mockResolvedValue(MOCK_PENDING_RESPONSE);
+    mockMuxGet.mockResolvedValue(MOCK_ERRORED_RESPONSE);
+
+    const promise = waitForShotsForAsset("test-asset-123", {
+      pollIntervalMs: 100,
+      maxAttempts: 3,
+    });
+    const expectation = expect(promise).rejects.toThrow(
+      "Shots generation errored for asset 'test-asset-123'",
+    );
+
+    await vi.runAllTimersAsync();
+    await expectation;
+    expect(mockMuxGet).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getShotsForAsset,
+  requestShotsForAsset,
+  waitForShotsForAsset,
+} from "../../src/primitives/shots";
+
+const MOCK_PENDING_RESPONSE = {
+  data: {
+    status: "pending" as const,
+    created_at: "1773108428",
+  },
+};
+
+const MOCK_COMPLETED_RESPONSE = {
+  data: {
+    status: "completed" as const,
+    created_at: "1773108428",
+    shot_locations: [
+      {
+        start_time: 0.0416667,
+        image_url: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=first",
+      },
+      {
+        start_time: 2.75,
+        image_url: "https://stream.mux.com/aicontext/test-asset/shot_1.webp?signature=second",
+      },
+    ],
+  },
+};
+
+vi.mock("../../src/lib/client-factory", () => ({
+  getMuxClientFromEnv: vi.fn(),
+}));
+
+const mockMuxGet = vi.fn();
+const mockMuxPost = vi.fn();
+const mockCreateClient = vi.fn(() => ({
+  get: mockMuxGet,
+  post: mockMuxPost,
+}));
+
+const { getMuxClientFromEnv } = await import("../../src/lib/client-factory");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getMuxClientFromEnv).mockResolvedValue({
+    createClient: mockCreateClient,
+  } as any);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("requestShotsForAsset", () => {
+  it("returns transformed pending result", async () => {
+    mockMuxPost.mockResolvedValue(MOCK_PENDING_RESPONSE);
+
+    const result = await requestShotsForAsset("test-asset-123");
+
+    expect(result).toEqual({
+      status: "pending",
+      createdAt: "1773108428",
+    });
+  });
+
+  it("constructs the correct POST path and empty body", async () => {
+    mockMuxPost.mockResolvedValue(MOCK_PENDING_RESPONSE);
+
+    await requestShotsForAsset("test-asset-123");
+
+    expect(mockMuxPost).toHaveBeenCalledWith(
+      "/video/v1/assets/test-asset-123/shot-locations",
+      { body: {} },
+    );
+  });
+
+  it("passes credentials through to the mux client factory", async () => {
+    mockMuxPost.mockResolvedValue(MOCK_PENDING_RESPONSE);
+    const credentials = {
+      muxTokenId: "token-id",
+      muxTokenSecret: "token-secret",
+    };
+
+    await requestShotsForAsset("test-asset-123", { credentials });
+
+    expect(getMuxClientFromEnv).toHaveBeenCalledWith(credentials);
+  });
+});
+
+describe("getShotsForAsset", () => {
+  it("returns transformed pending result", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_PENDING_RESPONSE);
+
+    const result = await getShotsForAsset("test-asset-123");
+
+    expect(result).toEqual({
+      status: "pending",
+      createdAt: "1773108428",
+    });
+  });
+
+  it("returns transformed completed result", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_COMPLETED_RESPONSE);
+
+    const result = await getShotsForAsset("test-asset-123");
+
+    expect(result).toEqual({
+      status: "completed",
+      createdAt: "1773108428",
+      shots: [
+        {
+          startTime: 0.0416667,
+          imageUrl: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=first",
+        },
+        {
+          startTime: 2.75,
+          imageUrl: "https://stream.mux.com/aicontext/test-asset/shot_1.webp?signature=second",
+        },
+      ],
+    });
+  });
+
+  it("constructs the correct GET path", async () => {
+    mockMuxGet.mockResolvedValue(MOCK_PENDING_RESPONSE);
+
+    await getShotsForAsset("test-asset-123");
+
+    expect(mockMuxGet).toHaveBeenCalledWith(
+      "/video/v1/assets/test-asset-123/shot-locations",
+    );
+  });
+});
+
+describe("waitForShotsForAsset", () => {
+  it("requests shots and polls until completed", async () => {
+    vi.useFakeTimers();
+    mockMuxPost.mockResolvedValue(MOCK_PENDING_RESPONSE);
+    mockMuxGet
+      .mockResolvedValueOnce(MOCK_PENDING_RESPONSE)
+      .mockResolvedValueOnce(MOCK_COMPLETED_RESPONSE);
+
+    const promise = waitForShotsForAsset("test-asset-123", {
+      pollIntervalMs: 100,
+      maxAttempts: 5,
+    });
+    const expectation = expect(promise).resolves.toEqual({
+      status: "completed",
+      createdAt: "1773108428",
+      shots: [
+        {
+          startTime: 0.0416667,
+          imageUrl: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=first",
+        },
+        {
+          startTime: 2.75,
+          imageUrl: "https://stream.mux.com/aicontext/test-asset/shot_1.webp?signature=second",
+        },
+      ],
+    });
+
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(mockMuxPost).toHaveBeenCalledTimes(1);
+    expect(mockMuxGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues polling when shots were already requested previously", async () => {
+    vi.useFakeTimers();
+    mockMuxPost.mockRejectedValue({
+      status: 400,
+      error: {
+        messages: ["Shots generation has already been requested"],
+      },
+      message: "400 invalid_parameters",
+    });
+    mockMuxGet.mockResolvedValue(MOCK_COMPLETED_RESPONSE);
+
+    const promise = waitForShotsForAsset("test-asset-123", {
+      pollIntervalMs: 100,
+      maxAttempts: 3,
+    });
+    const expectation = expect(promise).resolves.toMatchObject({
+      status: "completed",
+    });
+
+    await vi.runAllTimersAsync();
+    await expectation;
+
+    expect(mockMuxPost).toHaveBeenCalledTimes(1);
+    expect(mockMuxGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("can poll without creating a request first", async () => {
+    vi.useFakeTimers();
+    mockMuxGet.mockResolvedValue(MOCK_COMPLETED_RESPONSE);
+
+    const promise = waitForShotsForAsset("test-asset-123", {
+      createIfMissing: false,
+      pollIntervalMs: 100,
+      maxAttempts: 3,
+    });
+    const expectation = expect(promise).resolves.toMatchObject({
+      status: "completed",
+    });
+
+    await vi.runAllTimersAsync();
+    await expectation;
+    expect(mockMuxPost).not.toHaveBeenCalled();
+    expect(mockMuxGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a timeout error when shots never complete", async () => {
+    vi.useFakeTimers();
+    mockMuxPost.mockResolvedValue(MOCK_PENDING_RESPONSE);
+    mockMuxGet.mockResolvedValue(MOCK_PENDING_RESPONSE);
+
+    const promise = waitForShotsForAsset("test-asset-123", {
+      pollIntervalMs: 100,
+      maxAttempts: 3,
+    });
+    const expectation = expect(promise).rejects.toThrow(
+      "Timed out waiting for shots for asset 'test-asset-123' after 3 attempts. Last status: pending",
+    );
+
+    await vi.runAllTimersAsync();
+    await expectation;
+    expect(mockMuxGet).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
# Overview

This branch adds a new `shots` primitive for Mux assets. It exposes helpers to request shot detection, fetch current shot results, and wait for completion, then wires that primitive into the public exports, docs, and test suite.

# What was changed

- Added `src/primitives/shots.ts` with three public APIs:
  - `requestShotsForAsset()` to start shot generation
  - `getShotsForAsset()` to read pending/completed shot data
  - `waitForShotsForAsset()` to optionally create and then poll until completion
- Exported the new primitive from `src/primitives/index.ts`.
- Added unit coverage for response transformation, request paths, polling behavior, timeout handling, and the "already requested" API error case.
- Added an integration test that waits for shots on a real test asset and validates the returned shot metadata.
- Updated `docs/PRIMITIVES.md` to document the new APIs and show how shot data can be used alongside transcripts and storyboards.

# Suggested review order

1. Read `src/primitives/shots.ts` to understand the new API surface and polling/error-handling behavior.
2. Read `tests/unit/shots.test.ts` to verify the intended contract and edge cases.
3. Read `tests/integration/shots.test.ts` to confirm the real-world workflow against a Mux asset.
4. Skim `src/primitives/index.ts` and `docs/PRIMITIVES.md` for public-surface/export and documentation updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new network calls and polling logic against a Mux Video API endpoint, which could impact reliability and runtime behavior (timeouts/retries) if the endpoint contract or error shapes differ.
> 
> **Overview**
> Adds a new `shots` primitive to request and retrieve Mux asset shot-detection results, including a `waitForShotsForAsset` helper that can auto-request, poll with bounded retries, and surface terminal `errored`/timeout states.
> 
> Wires the primitive into the public exports and updates `docs/PRIMITIVES.md` with API docs and an example combining shots with transcripts/storyboards. Adds unit tests for response shaping, request paths, polling/edge cases (min poll interval, already-requested handling, timeouts) and an integration test that runs shot detection against a real test asset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 291f5be23e7401c5da74d1f42d4d41b34cfb697d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->