### PR TITLE
chore: update shots endpoint

### DIFF
--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -71,7 +71,7 @@ const DEFAULT_MAX_ATTEMPTS = 60;
 const SHOTS_ALREADY_REQUESTED_MESSAGE = "shots generation has already been requested";
 
 function getShotsPath(assetId: string): string {
-  return `/video/v1/assets/${assetId}/shot-locations`;
+  return `/video/v1/assets/${assetId}/shots`;
 }
 
 function transformShotsResponse(

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -16,6 +16,10 @@ export interface PendingShotsResult {
 export interface ErroredShotsResult {
   status: "errored";
   createdAt: string;
+  error: {
+    type: string;
+    messages: string[];
+  };
 }
 
 export interface CompletedShotsResult {
@@ -48,19 +52,27 @@ interface PendingShotsApiData {
 interface ErroredShotsApiData {
   status: "errored";
   created_at: string;
+  error: {
+    type: string;
+    messages: string[];
+  };
 }
 
 interface CompletedShotsApiData {
   status: "completed";
   created_at: string;
-  shot_locations: Array<{
-    start_time: number;
-    image_url: string;
-  }>;
+  shots_manifest_url: string;
 }
 
 interface ShotsApiResponse {
   data: PendingShotsApiData | ErroredShotsApiData | CompletedShotsApiData;
+}
+
+interface ShotsManifestResponse {
+  shots: Array<{
+    startTime: number;
+    imageUrl: string;
+  }>;
 }
 
 type RequestShotsApiRequestBody = Record<string, never>;
@@ -74,9 +86,50 @@ function getShotsPath(assetId: string): string {
   return `/video/v1/assets/${assetId}/shots`;
 }
 
-function transformShotsResponse(
+function mapManifestShots(
+  shots: ShotsManifestResponse["shots"],
+): Shot[] {
+  return shots.map((shot, index) => {
+    const { startTime, imageUrl } = shot;
+
+    if (typeof startTime !== "number" || !Number.isFinite(startTime)) {
+      throw new TypeError(`Invalid shot startTime in shots manifest at index ${index}`);
+    }
+
+    if (typeof imageUrl !== "string" || imageUrl.length === 0) {
+      throw new TypeError(`Invalid shot imageUrl in shots manifest at index ${index}`);
+    }
+
+    return {
+      startTime,
+      imageUrl,
+    };
+  });
+}
+
+async function fetchShotsFromManifest(
+  shotsManifestUrl: string,
+): Promise<Shot[]> {
+  const response = await fetch(shotsManifestUrl);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch shots manifest: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const manifest = await response.json() as ShotsManifestResponse;
+
+  if (!Array.isArray(manifest.shots)) {
+    throw new TypeError("Invalid shots manifest response: missing shots array");
+  }
+
+  return mapManifestShots(manifest.shots);
+}
+
+async function transformShotsResponse(
   response: ShotsApiResponse,
-): ShotsResult {
+): Promise<ShotsResult> {
   switch (response.data.status) {
     case "pending":
       return {
@@ -87,15 +140,13 @@ function transformShotsResponse(
       return {
         status: "errored",
         createdAt: response.data.created_at,
+        error: response.data.error,
       };
     case "completed":
       return {
         status: "completed",
         createdAt: response.data.created_at,
-        shots: response.data.shot_locations.map(shot => ({
-          startTime: shot.start_time,
-          imageUrl: shot.image_url,
-        })),
+        shots: await fetchShotsFromManifest(response.data.shots_manifest_url),
       };
     default: {
       const exhaustiveCheck: never = response.data;
@@ -138,7 +189,7 @@ export async function requestShotsForAsset(
     getShotsPath(assetId),
     { body: {} },
   );
-  const result = transformShotsResponse(response);
+  const result = await transformShotsResponse(response);
 
   if (result.status !== "pending") {
     throw new Error(
@@ -168,7 +219,7 @@ export async function getShotsForAsset(
     getShotsPath(assetId),
   );
 
-  return transformShotsResponse(response);
+  return await transformShotsResponse(response);
 }
 
 /**

--- a/tests/integration/shots.test.ts
+++ b/tests/integration/shots.test.ts
@@ -43,7 +43,9 @@ describe("shots Integration Tests", () => {
 
     if (result.status === "completed") {
       expect(result.shots.length).toBeGreaterThan(0);
+      expect(typeof result.shots[0].startTime).toBe("number");
       expect(result.shots[0].imageUrl).toMatch(/^https?:\/\//);
+      expect(result.shots).toEqual(completedShots.shots);
     }
   });
 });

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -17,6 +17,10 @@ const MOCK_ERRORED_RESPONSE = {
   data: {
     status: "errored" as const,
     created_at: "1773108428",
+    error: {
+      type: "arbitrary string",
+      messages: ["string", "array"],
+    },
   },
 };
 
@@ -24,17 +28,21 @@ const MOCK_COMPLETED_RESPONSE = {
   data: {
     status: "completed" as const,
     created_at: "1773108428",
-    shot_locations: [
-      {
-        start_time: 0.0416667,
-        image_url: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=first",
-      },
-      {
-        start_time: 2.75,
-        image_url: "https://stream.mux.com/aicontext/test-asset/shot_1.webp?signature=second",
-      },
-    ],
+    shots_manifest_url: "https://stream.mux.com/aicontext/test-asset/shots.json?signature=test",
   },
+};
+
+const MOCK_SHOTS_MANIFEST = {
+  shots: [
+    {
+      startTime: 0.0416667,
+      imageUrl: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=first",
+    },
+    {
+      startTime: 2.75,
+      imageUrl: "https://stream.mux.com/aicontext/test-asset/shot_1.webp?signature=second",
+    },
+  ],
 };
 
 vi.mock("../../src/lib/client-factory", () => ({
@@ -43,6 +51,7 @@ vi.mock("../../src/lib/client-factory", () => ({
 
 const mockMuxGet = vi.fn();
 const mockMuxPost = vi.fn();
+const mockFetch = vi.fn();
 const mockCreateClient = vi.fn(() => ({
   get: mockMuxGet,
   post: mockMuxPost,
@@ -51,7 +60,8 @@ const mockCreateClient = vi.fn(() => ({
 const { getMuxClientFromEnv } = await import("../../src/lib/client-factory");
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+  vi.stubGlobal("fetch", mockFetch);
   vi.mocked(getMuxClientFromEnv).mockResolvedValue({
     createClient: mockCreateClient,
   } as any);
@@ -59,6 +69,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.unstubAllGlobals();
 });
 
 describe("requestShotsForAsset", () => {
@@ -107,13 +118,21 @@ describe("getShotsForAsset", () => {
       status: "pending",
       createdAt: "1773108428",
     });
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("returns transformed completed result", async () => {
+  it("fetches and transforms completed shots from a manifest URL", async () => {
     mockMuxGet.mockResolvedValue(MOCK_COMPLETED_RESPONSE);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(MOCK_SHOTS_MANIFEST),
+    });
 
     const result = await getShotsForAsset("test-asset-123");
 
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://stream.mux.com/aicontext/test-asset/shots.json?signature=test",
+    );
     expect(result).toEqual({
       status: "completed",
       createdAt: "1773108428",
@@ -138,7 +157,12 @@ describe("getShotsForAsset", () => {
     expect(result).toEqual({
       status: "errored",
       createdAt: "1773108428",
+      error: {
+        type: "arbitrary string",
+        messages: ["string", "array"],
+      },
     });
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("constructs the correct GET path", async () => {
@@ -159,6 +183,10 @@ describe("waitForShotsForAsset", () => {
     mockMuxGet
       .mockResolvedValueOnce(MOCK_PENDING_RESPONSE)
       .mockResolvedValueOnce(MOCK_COMPLETED_RESPONSE);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(MOCK_SHOTS_MANIFEST),
+    });
 
     const promise = waitForShotsForAsset("test-asset-123", {
       pollIntervalMs: 100,
@@ -184,6 +212,7 @@ describe("waitForShotsForAsset", () => {
 
     expect(mockMuxPost).toHaveBeenCalledTimes(1);
     expect(mockMuxGet).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it("continues polling when shots were already requested previously", async () => {
@@ -196,6 +225,10 @@ describe("waitForShotsForAsset", () => {
       message: "400 invalid_parameters",
     });
     mockMuxGet.mockResolvedValue(MOCK_COMPLETED_RESPONSE);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(MOCK_SHOTS_MANIFEST),
+    });
 
     const promise = waitForShotsForAsset("test-asset-123", {
       pollIntervalMs: 100,
@@ -210,11 +243,16 @@ describe("waitForShotsForAsset", () => {
 
     expect(mockMuxPost).toHaveBeenCalledTimes(1);
     expect(mockMuxGet).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it("can poll without creating a request first", async () => {
     vi.useFakeTimers();
     mockMuxGet.mockResolvedValue(MOCK_COMPLETED_RESPONSE);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(MOCK_SHOTS_MANIFEST),
+    });
 
     const promise = waitForShotsForAsset("test-asset-123", {
       createIfMissing: false,
@@ -229,6 +267,7 @@ describe("waitForShotsForAsset", () => {
     await expectation;
     expect(mockMuxPost).not.toHaveBeenCalled();
     expect(mockMuxGet).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it("throws a timeout error when shots never complete", async () => {
@@ -274,6 +313,10 @@ describe("waitForShotsForAsset", () => {
     mockMuxGet
       .mockResolvedValueOnce(MOCK_PENDING_RESPONSE)
       .mockResolvedValueOnce(MOCK_COMPLETED_RESPONSE);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(MOCK_SHOTS_MANIFEST),
+    });
 
     const promise = waitForShotsForAsset("test-asset-123", {
       pollIntervalMs: 0,
@@ -287,5 +330,6 @@ describe("waitForShotsForAsset", () => {
     await expectation;
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -79,7 +79,7 @@ describe("requestShotsForAsset", () => {
     await requestShotsForAsset("test-asset-123");
 
     expect(mockMuxPost).toHaveBeenCalledWith(
-      "/video/v1/assets/test-asset-123/shot-locations",
+      "/video/v1/assets/test-asset-123/shots",
       { body: {} },
     );
   });
@@ -147,7 +147,7 @@ describe("getShotsForAsset", () => {
     await getShotsForAsset("test-asset-123");
 
     expect(mockMuxGet).toHaveBeenCalledWith(
-      "/video/v1/assets/test-asset-123/shot-locations",
+      "/video/v1/assets/test-asset-123/shots",
     );
   });
 });

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -61,6 +61,10 @@ const { getMuxClientFromEnv } = await import("../../src/lib/client-factory");
 
 beforeEach(() => {
   vi.resetAllMocks();
+  mockCreateClient.mockImplementation(() => ({
+    get: mockMuxGet,
+    post: mockMuxPost,
+  }));
   vi.stubGlobal("fetch", mockFetch);
   vi.mocked(getMuxClientFromEnv).mockResolvedValue({
     createClient: mockCreateClient,


### PR DESCRIPTION
# Overview

This branch updates the shots primitive to match the new Mux API shape. The SDK now reads shots from `/shots`, preserves structured error details on errored results, and fetches completed shot data from the returned manifest URL instead of expecting inline shot locations.

# What was changed

- `src/primitives/shots.ts`
  - Switched the asset endpoint from `/shot-locations` to `/shots`.
  - Added `error.type` and `error.messages` to errored shot results.
  - Changed completed responses to consume `shots_manifest_url`, fetch the manifest, validate its shape, and map it into the existing `Shot[]` output.
  - Made response transformation async so manifest fetching is part of the normal `get` and `request` flow.
- `tests/unit/shots.test.ts`
  - Updated fixtures for the new API response shape.
  - Stubbed `fetch` and added coverage for manifest fetching, manifest-to-shot mapping, and errored responses carrying structured error details.
  - Updated endpoint assertions to `/shots` and ensured polling paths also exercise manifest fetching.
- `tests/integration/shots.test.ts`
  - Tightened the completed-state assertion to verify the returned shots match the resolved fixture shape.

# Suggested review order

1. `src/primitives/shots.ts` to understand the contract change and manifest-fetching flow.
2. `tests/unit/shots.test.ts` to verify the new API shape and async behavior are covered.
3. `tests/integration/shots.test.ts` to confirm the end-to-end expectations still match the public result shape.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the shots primitive to a new upstream API shape, including a new endpoint and an extra network fetch for completed results; failures or manifest shape changes could affect consumers at runtime.
> 
> **Overview**
> Updates the shots primitive to use Mux’s new `GET/POST /video/v1/assets/:assetId/shots` endpoint, and extends `errored` results to return structured `error` details.
> 
> For `completed` results, the SDK now expects a `shots_manifest_url` and fetches/validates the manifest to produce `Shot[]`, making response transformation async. Unit/integration tests are updated to stub `fetch`, assert manifest-based shot mapping, and verify the new endpoint and error shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 548ddc34266013827d5ae68a906742eec9ac0a15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->