### PR TITLE
feat: configurable S3 presigned URL expiry

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -256,6 +256,7 @@ Translates existing captions from one language to another and optionally adds th
 - `s3Region?: string` - S3 region (default: 'auto')
 - `s3Bucket?: string` - S3 bucket name
 - `storageAdapter?: StorageAdapter` - Optional adapter with `putObject` and `createPresignedGetUrl` methods
+- `s3SignedUrlExpirySeconds?: number` - Expiry duration in seconds for S3 presigned GET URLs (default: 86400 / 24 hours)
 - `chunking?: object` - Optional VTT-aware chunking controls for large caption translations
   - `enabled?: boolean` - Set to `false` to translate all cues in a single structured request (default: `true`)
   - `minimumAssetDurationSeconds?: number` - Prefer a single request until the asset is at least this long (default: `1800`)
@@ -276,7 +277,7 @@ interface TranslateCaptionsResult {
   originalVtt: string; // Original VTT content
   translatedVtt: string; // Translated VTT content
   uploadedTrackId?: string; // Mux track ID (if uploaded)
-  presignedUrl?: string; // S3 presigned URL (expires in 1 hour)
+  presignedUrl?: string; // S3 presigned URL (default expiry: 24 hours)
   usage?: TokenUsage; // Token usage from the AI provider
 }
 ```
@@ -320,6 +321,7 @@ Edits a caption track using LLM-powered profanity censorship, static find/replac
 - `s3Bucket?: string` - S3 bucket name
 - `trackNameSuffix?: string` - Suffix appended to the original track name in parentheses (default: 'edited', e.g. "Subtitles (edited)")
 - `storageAdapter?: StorageAdapter` - Optional adapter with `putObject` and `createPresignedGetUrl` methods
+- `s3SignedUrlExpirySeconds?: number` - Expiry duration in seconds for S3 presigned GET URLs (default: 86400 / 24 hours)
 
 At least one of `autoCensorProfanity` or `replacements` must be provided.
 
@@ -345,7 +347,7 @@ interface EditCaptionsResult {
     replacements: ReplacementRecord[]; // Each static replacement with cue timing
   };
   uploadedTrackId?: string; // Mux track ID (if uploaded)
-  presignedUrl?: string; // S3 presigned URL (expires in 1 hour)
+  presignedUrl?: string; // S3 presigned URL (default expiry: 24 hours)
   usage?: TokenUsage; // Token usage (only present if LLM was used)
 }
 ```
@@ -422,6 +424,7 @@ Creates AI-dubbed audio tracks from existing media content using ElevenLabs voic
 - `s3Region?: string` - S3 region (default: 'auto')
 - `s3Bucket?: string` - S3 bucket name
 - `storageAdapter?: StorageAdapter` - Optional adapter with `putObject` and `createPresignedGetUrl` methods
+- `s3SignedUrlExpirySeconds?: number` - Expiry duration in seconds for S3 presigned GET URLs (default: 86400 / 24 hours)
 
 **Returns:**
 
@@ -432,7 +435,7 @@ interface TranslateAudioResult {
   targetLanguage: LanguageCodePair; // { iso639_1: string; iso639_3: string }
   dubbingId: string; // ElevenLabs dubbing job ID
   uploadedTrackId?: string; // Mux audio track ID (if uploaded)
-  presignedUrl?: string; // S3 presigned URL (expires in 1 hour)
+  presignedUrl?: string; // S3 presigned URL (default expiry: 24 hours)
   usage?: TokenUsage; // Workflow usage metadata
 }
 ```

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -547,7 +547,7 @@ ElevenLabs supports 32+ languages with automatic language name detection via `In
 4. Polls for completion (up to 30 minutes)
 5. Downloads dubbed audio file
 6. Uploads to S3-compatible storage
-7. Generates presigned URL (1-hour expiry)
+7. Generates presigned URL (default 24-hour expiry, configurable via `s3SignedUrlExpirySeconds`)
 8. Adds new audio track to Mux asset
 9. Track name: "{Language} (auto-dubbed)"
 

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -75,6 +75,8 @@ export interface EditCaptionsOptions<P extends SupportedProvider = SupportedProv
   s3Bucket?: string;
   /** Suffix appended to the original track name, e.g. "edited" produces "Subtitles (edited)". Defaults to "edited". */
   trackNameSuffix?: string;
+  /** Expiry duration in seconds for S3 presigned GET URLs. Defaults to 86400 (24 hours). */
+  s3SignedUrlExpirySeconds?: number;
 }
 
 /** Output returned from `editCaptions`. */
@@ -336,6 +338,7 @@ async function uploadEditedVttToS3({
   s3Region,
   s3Bucket,
   storageAdapter,
+  s3SignedUrlExpirySeconds,
 }: {
   editedVtt: string;
   assetId: string;
@@ -344,6 +347,7 @@ async function uploadEditedVttToS3({
   s3Region: string;
   s3Bucket: string;
   storageAdapter?: StorageAdapter;
+  s3SignedUrlExpirySeconds?: number;
 }): Promise<string> {
   "use step";
 
@@ -370,7 +374,7 @@ async function uploadEditedVttToS3({
     region: s3Region,
     bucket: s3Bucket,
     key: vttKey,
-    expiresInSeconds: 3600,
+    expiresInSeconds: s3SignedUrlExpirySeconds ?? 86400,
   }, storageAdapter);
 }
 
@@ -563,6 +567,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
       s3Region,
       s3Bucket: s3Bucket!,
       storageAdapter,
+      s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
     });
   } catch (error) {
     throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -62,6 +62,8 @@ export interface AudioTranslationOptions extends MuxAIOptions {
   uploadToMux?: boolean;
   /** Optional storage adapter override for upload + presign operations. */
   storageAdapter?: StorageAdapter;
+  /** Expiry duration in seconds for S3 presigned GET URLs. Defaults to 86400 (24 hours). */
+  s3SignedUrlExpirySeconds?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -305,6 +307,7 @@ async function uploadDubbedAudioToS3({
   s3Region,
   s3Bucket,
   storageAdapter,
+  s3SignedUrlExpirySeconds,
 }: {
   dubbedAudioBuffer: ArrayBuffer;
   assetId: string;
@@ -313,6 +316,7 @@ async function uploadDubbedAudioToS3({
   s3Region: string;
   s3Bucket: string;
   storageAdapter?: StorageAdapter;
+  s3SignedUrlExpirySeconds?: number;
 }): Promise<string> {
   "use step";
 
@@ -340,11 +344,12 @@ async function uploadDubbedAudioToS3({
     region: s3Region,
     bucket: s3Bucket,
     key: audioKey,
-    expiresInSeconds: 3600,
+    expiresInSeconds: s3SignedUrlExpirySeconds ?? 86400,
   }, storageAdapter);
 
+  const expiryHours = Math.round((s3SignedUrlExpirySeconds ?? 86400) / 3600);
   console.warn(`✅ Audio uploaded successfully to: ${audioKey}`);
-  console.warn(`🔗 Generated presigned URL (expires in 1 hour)`);
+  console.warn(`🔗 Generated presigned URL (expires in ${expiryHours} hour${expiryHours === 1 ? "" : "s"})`);
 
   return presignedUrl;
 }
@@ -575,6 +580,7 @@ export async function translateAudio(
       s3Region,
       s3Bucket: s3Bucket!,
       storageAdapter: effectiveStorageAdapter,
+      s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
     });
   } catch (error) {
     throw new Error(`Failed to upload audio to S3: ${error instanceof Error ? error.message : "Unknown error"}`);

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -92,6 +92,8 @@ export interface TranslationOptions<P extends SupportedProvider = SupportedProvi
   uploadToMux?: boolean;
   /** Optional storage adapter override for upload + presign operations. */
   storageAdapter?: StorageAdapter;
+  /** Expiry duration in seconds for S3 presigned GET URLs. Defaults to 86400 (24 hours). */
+  s3SignedUrlExpirySeconds?: number;
   /**
    * Optional VTT-aware chunking for caption translation.
    * When enabled, the workflow splits cue-aligned translation requests by
@@ -630,6 +632,7 @@ async function uploadVttToS3({
   s3Region,
   s3Bucket,
   storageAdapter,
+  s3SignedUrlExpirySeconds,
 }: {
   translatedVtt: string;
   assetId: string;
@@ -639,6 +642,7 @@ async function uploadVttToS3({
   s3Region: string;
   s3Bucket: string;
   storageAdapter?: StorageAdapter;
+  s3SignedUrlExpirySeconds?: number;
 }): Promise<string> {
   "use step";
 
@@ -666,7 +670,7 @@ async function uploadVttToS3({
     region: s3Region,
     bucket: s3Bucket,
     key: vttKey,
-    expiresInSeconds: 3600,
+    expiresInSeconds: s3SignedUrlExpirySeconds ?? 86400,
   }, storageAdapter);
 }
 
@@ -830,6 +834,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
       s3Region,
       s3Bucket: s3Bucket!,
       storageAdapter: effectiveStorageAdapter,
+      s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
     });
   } catch (error) {
     throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);


### PR DESCRIPTION
## Summary

- Adds `s3SignedUrlExpirySeconds` option to `translateAudio`, `translateCaptions`, and `editCaptions` workflows
- Changes the default presigned URL lifetime from 1 hour to 24 hours
- Updates docs (API.md, WORKFLOWS.md) to reflect the new option and default

## Suggested review order

1. `src/workflows/translate-audio.ts` — most interesting change, also updates the console warning dynamically
2. `src/workflows/translate-captions.ts` — same pattern, threaded through `uploadVttToS3`
3. `src/workflows/edit-captions.ts` — same pattern, threaded through `uploadEditedVttToS3`
4. `docs/API.md` / `docs/WORKFLOWS.md` — doc updates