### PR TITLE
feat!: Re-think how length constraints and fallback languages work in summarization

### DIFF
--- a/examples/summarization/basic-example.ts
+++ b/examples/summarization/basic-example.ts
@@ -21,8 +21,8 @@ program
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("-t, --tone <tone>", "Tone for summary (neutral, playful, professional)", "neutral")
   .option("--no-transcript", "Exclude transcript from analysis")
-  .option("--title-length <chars>", "Desired title length in characters", parseInt)
-  .option("--description-length <chars>", "Desired description length in characters", parseInt)
+  .option("--title-length <words>", "Desired title length in words", parseInt)
+  .option("--description-length <words>", "Desired description length in words", parseInt)
   .option("--tag-count <count>", "Desired number of tags", parseInt)
   .option("--output-language <code>", "Output language as BCP 47 code (e.g. 'fr', 'ja') or 'auto'")
   .action(async (assetId: string, options: {
@@ -54,8 +54,8 @@ program
     console.log(`Provider: ${options.provider} (${model})`);
     console.log(`Tone: ${options.tone}`);
     console.log(`Include Transcript: ${options.transcript}`);
-    if (options.titleLength) console.log(`Title Length: ~${options.titleLength} chars`);
-    if (options.descriptionLength) console.log(`Description Length: ~${options.descriptionLength} chars`);
+    if (options.titleLength) console.log(`Title Length: ~${options.titleLength} words`);
+    if (options.descriptionLength) console.log(`Description Length: ~${options.descriptionLength} words`);
     if (options.tagCount) console.log(`Tag Count: ${options.tagCount}`);
     if (options.outputLanguage) console.log(`Output Language: ${options.outputLanguage}`);
     console.log();

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -40,6 +40,8 @@ import type {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const SUMMARY_KEYWORD_LIMIT = 10;
+export const DEFAULT_TITLE_LENGTH = 10;
+export const DEFAULT_DESCRIPTION_LENGTH = 50;
 
 export const summarySchema = z.object({
   keywords: z.array(z.string()),
@@ -121,9 +123,9 @@ export interface SummarizationOptions extends MuxAIOptions {
    * Useful for customizing the AI's output for specific use cases (SEO, social media, etc.)
    */
   promptOverrides?: SummarizationPromptOverrides;
-  /** Desired title length in characters. */
+  /** Desired title length in words. */
   titleLength?: number;
-  /** Desired description length in characters. */
+  /** Desired description length in words. */
   descriptionLength?: number;
   /** Desired number of tags. */
   tagCount?: number;
@@ -154,12 +156,8 @@ interface PromptConstraints {
 }
 
 function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }: PromptConstraints = {}) {
-  const titleBrevity = titleLength != null ?
-    `Aim for approximately ${titleLength} characters.` :
-    "Aim for brevity - typically under 10 words.";
-  const descConstraint = descriptionLength != null ?
-    `approximately ${descriptionLength} characters` :
-    "2-4 sentences";
+  const titleBrevity = `Aim for approximately ${titleLength ?? DEFAULT_TITLE_LENGTH} words.`;
+  const descConstraint = `approximately ${descriptionLength ?? DEFAULT_DESCRIPTION_LENGTH} words, and you may use multiple sentences`;
   const keywordLimit = tagCount ?? SUMMARY_KEYWORD_LIMIT;
 
   return createPromptBuilder<SummarizationPromptSections>({
@@ -179,7 +177,8 @@ function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }
       description: {
         tag: "description_requirements",
         content: dedent`
-          A concise summary (${descConstraint}) that describes what happens across the video.
+          A summary that describes what happens across the video.
+          Aim for ${descConstraint}.
           Cover the main subjects, actions, setting, and any notable progression visible across frames.
           Write in present tense. Be specific about observable details rather than making assumptions.
           If the transcript provides dialogue or narration, incorporate key points but prioritize visual content.`,
@@ -210,12 +209,8 @@ function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }
 }
 
 function createAudioOnlyBuilder({ titleLength, descriptionLength, tagCount }: PromptConstraints = {}) {
-  const titleBrevity = titleLength != null ?
-    `Aim for approximately ${titleLength} characters.` :
-    "Aim for brevity - typically under 10 words.";
-  const descConstraint = descriptionLength != null ?
-    `approximately ${descriptionLength} characters` :
-    "2-4 sentences";
+  const titleBrevity = `Aim for approximately ${titleLength ?? DEFAULT_TITLE_LENGTH} words.`;
+  const descConstraint = `approximately ${descriptionLength ?? DEFAULT_DESCRIPTION_LENGTH} words, and you may use multiple sentences`;
   const keywordLimit = tagCount ?? SUMMARY_KEYWORD_LIMIT;
 
   return createPromptBuilder<SummarizationPromptSections>({
@@ -235,7 +230,8 @@ function createAudioOnlyBuilder({ titleLength, descriptionLength, tagCount }: Pr
       description: {
         tag: "description_requirements",
         content: dedent`
-          A concise summary (${descConstraint}) that describes the audio content.
+          A summary that describes the audio content.
+          Aim for ${descConstraint}.
           Cover the main topics, speakers, themes, and any notable progression in the discussion or narration.
           Write in present tense. Be specific about what is discussed or presented rather than making assumptions.
           Focus on the spoken content and any key insights, dialogue, or narrative elements.`,
@@ -409,7 +405,7 @@ function buildUserPrompt({
   } else {
     contextSections.push({
       tag: "language",
-      content: "Respond in the same language as the input content. Never switch languages to satisfy length constraints.",
+      content: "Respond in English. Never switch languages to satisfy length constraints.",
     });
   }
 

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -406,6 +406,11 @@ function buildUserPrompt({
 
   if (languageName) {
     contextSections.push(createLanguageSection(languageName));
+  } else {
+    contextSections.push({
+      tag: "language",
+      content: "Respond in the same language as the input content. Never switch languages to satisfy length constraints.",
+    });
   }
 
   if (transcriptText) {

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -155,9 +155,52 @@ interface PromptConstraints {
   tagCount?: number;
 }
 
+const DESCRIPTION_LENGTH_THRESHOLD_SMALL = 25;
+const DESCRIPTION_LENGTH_THRESHOLD_LARGE = 100;
+
+function buildDescriptionGuidance(wordCount: number, contentType: "video" | "audio"): string {
+  if (wordCount < DESCRIPTION_LENGTH_THRESHOLD_SMALL) {
+    if (contentType === "video") {
+      return dedent`A brief summary of the video in approximately ${wordCount} words.
+        Focus on the single most important subject or action.
+        Write in present tense.`;
+    }
+    return dedent`A brief summary of the audio content in approximately ${wordCount} words.
+      Focus on the single most important topic or theme.
+      Write in present tense.`;
+  }
+
+  if (wordCount > DESCRIPTION_LENGTH_THRESHOLD_LARGE) {
+    if (contentType === "video") {
+      return dedent`A detailed summary that describes what happens across the video.
+        Aim for approximately ${wordCount} words, and you may use multiple sentences.
+        Be thorough: cover subjects, actions, setting, progression, and any notable details visible across frames.
+        Write in present tense. Be specific about observable details rather than making assumptions.
+        If the transcript provides dialogue or narration, incorporate key points but prioritize visual content.`;
+    }
+    return dedent`A detailed summary that describes the audio content.
+      Aim for approximately ${wordCount} words, and you may use multiple sentences.
+      Be thorough: cover topics, speakers, themes, progression, and any notable insights.
+      Write in present tense. Be specific about what is discussed or presented rather than making assumptions.
+      Focus on the spoken content and any key insights, dialogue, or narrative elements.`;
+  }
+
+  if (contentType === "video") {
+    return dedent`A summary that describes what happens across the video.
+      Aim for approximately ${wordCount} words, and you may use multiple sentences.
+      Cover the main subjects, actions, setting, and any notable progression visible across frames.
+      Write in present tense. Be specific about observable details rather than making assumptions.
+      If the transcript provides dialogue or narration, incorporate key points but prioritize visual content.`;
+  }
+  return dedent`A summary that describes the audio content.
+    Aim for approximately ${wordCount} words, and you may use multiple sentences.
+    Cover the main topics, speakers, themes, and any notable progression in the discussion or narration.
+    Write in present tense. Be specific about what is discussed or presented rather than making assumptions.
+    Focus on the spoken content and any key insights, dialogue, or narrative elements.`;
+}
+
 function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }: PromptConstraints = {}) {
   const titleBrevity = `Aim for approximately ${titleLength ?? DEFAULT_TITLE_LENGTH} words.`;
-  const descConstraint = `approximately ${descriptionLength ?? DEFAULT_DESCRIPTION_LENGTH} words, and you may use multiple sentences`;
   const keywordLimit = tagCount ?? SUMMARY_KEYWORD_LIMIT;
 
   return createPromptBuilder<SummarizationPromptSections>({
@@ -176,12 +219,7 @@ function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }
       },
       description: {
         tag: "description_requirements",
-        content: dedent`
-          A summary that describes what happens across the video.
-          Aim for ${descConstraint}.
-          Cover the main subjects, actions, setting, and any notable progression visible across frames.
-          Write in present tense. Be specific about observable details rather than making assumptions.
-          If the transcript provides dialogue or narration, incorporate key points but prioritize visual content.`,
+        content: buildDescriptionGuidance(descriptionLength ?? DEFAULT_DESCRIPTION_LENGTH, "video"),
       },
       keywords: {
         tag: "keywords_requirements",
@@ -210,7 +248,6 @@ function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }
 
 function createAudioOnlyBuilder({ titleLength, descriptionLength, tagCount }: PromptConstraints = {}) {
   const titleBrevity = `Aim for approximately ${titleLength ?? DEFAULT_TITLE_LENGTH} words.`;
-  const descConstraint = `approximately ${descriptionLength ?? DEFAULT_DESCRIPTION_LENGTH} words, and you may use multiple sentences`;
   const keywordLimit = tagCount ?? SUMMARY_KEYWORD_LIMIT;
 
   return createPromptBuilder<SummarizationPromptSections>({
@@ -229,12 +266,7 @@ function createAudioOnlyBuilder({ titleLength, descriptionLength, tagCount }: Pr
       },
       description: {
         tag: "description_requirements",
-        content: dedent`
-          A summary that describes the audio content.
-          Aim for ${descConstraint}.
-          Cover the main topics, speakers, themes, and any notable progression in the discussion or narration.
-          Write in present tense. Be specific about what is discussed or presented rather than making assumptions.
-          Focus on the spoken content and any key insights, dialogue, or narrative elements.`,
+        content: buildDescriptionGuidance(descriptionLength ?? DEFAULT_DESCRIPTION_LENGTH, "audio"),
       },
       keywords: {
         tag: "keywords_requirements",

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -39,7 +39,7 @@ import type {
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
 
-export const SUMMARY_KEYWORD_LIMIT = 10;
+export const DEFAULT_SUMMARY_KEYWORD_LIMIT = 10;
 export const DEFAULT_TITLE_LENGTH = 10;
 export const DEFAULT_DESCRIPTION_LENGTH = 50;
 
@@ -201,7 +201,7 @@ function buildDescriptionGuidance(wordCount: number, contentType: "video" | "aud
 
 function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }: PromptConstraints = {}) {
   const titleBrevity = `Aim for approximately ${titleLength ?? DEFAULT_TITLE_LENGTH} words.`;
-  const keywordLimit = tagCount ?? SUMMARY_KEYWORD_LIMIT;
+  const keywordLimit = tagCount ?? DEFAULT_SUMMARY_KEYWORD_LIMIT;
 
   return createPromptBuilder<SummarizationPromptSections>({
     template: {
@@ -248,7 +248,7 @@ function createSummarizationBuilder({ titleLength, descriptionLength, tagCount }
 
 function createAudioOnlyBuilder({ titleLength, descriptionLength, tagCount }: PromptConstraints = {}) {
   const titleBrevity = `Aim for approximately ${titleLength ?? DEFAULT_TITLE_LENGTH} words.`;
-  const keywordLimit = tagCount ?? SUMMARY_KEYWORD_LIMIT;
+  const keywordLimit = tagCount ?? DEFAULT_SUMMARY_KEYWORD_LIMIT;
 
   return createPromptBuilder<SummarizationPromptSections>({
     template: {
@@ -553,7 +553,7 @@ async function analyzeAudioOnly(
   };
 }
 
-function normalizeKeywords(keywords?: string[], limit: number = SUMMARY_KEYWORD_LIMIT): string[] {
+function normalizeKeywords(keywords?: string[], limit: number = DEFAULT_SUMMARY_KEYWORD_LIMIT): string[] {
   if (!Array.isArray(keywords) || keywords.length === 0) {
     return [];
   }
@@ -741,7 +741,7 @@ export async function getSummaryAndTags(
     assetId,
     title: analysisResponse.result.title,
     description: analysisResponse.result.description,
-    tags: normalizeKeywords(analysisResponse.result.keywords, tagCount ?? SUMMARY_KEYWORD_LIMIT),
+    tags: normalizeKeywords(analysisResponse.result.keywords, tagCount ?? DEFAULT_SUMMARY_KEYWORD_LIMIT),
     storyboardUrl: imageUrl, // undefined for audio-only assets
     usage: {
       ...analysisResponse.usage,


### PR DESCRIPTION
We've started to find the limitations of our length and language guidance in the summarization workflows.

This PR provides 3 improvements to the feature:

1) Moves from "chars" to "words" as length guidance (potentially breaking change for consumers)
2) Provides a final fallback when language guidance isn't available to "Respond in English. Never switch languages to satisfy length constraints"
3) Provides three length categories, which tune the prompt for better guidance around length, where we were previously giving conflicting guidance

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes prompt constraints from character-based to word-based defaults and adds an explicit English fallback language, which can materially alter generated titles/descriptions and may break callers relying on old semantics.
> 
> **Overview**
> Summarization length controls are redefined from *characters* to *words*, with new defaults (`DEFAULT_TITLE_LENGTH`, `DEFAULT_DESCRIPTION_LENGTH`) applied when callers don’t specify lengths.
> 
> The description prompt guidance is now dynamically generated based on requested word count (brief/normal/detailed for both video and audio-only flows), and the workflow now injects an explicit English language instruction when no output language can be resolved to prevent the model from switching languages to satisfy length constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ddde12a65928d91c869dd28012d18fbdefc24d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->