### PR TITLE
feat: skip question if irrelevant

### DIFF
--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -175,7 +175,7 @@ const SYSTEM_PROMPT = dedent`
 
     For skipped questions:
     - Set skipped to true
-    - Set answer to "__SKIPPED__"
+    - Set answer to "${SKIP_SENTINEL}"
     - Set confidence to 0
     - Use the reasoning field to explain why the question is not answerable
       from the video content

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -28,16 +28,14 @@ export interface Question {
 export interface QuestionAnswer {
   /** The original question */
   question: string;
-  /** Answer selected from the allowed options. Empty string when skipped. */
-  answer: string;
+  /** Answer selected from the allowed options. Undefined when skipped. */
+  answer?: string;
   /** Confidence score between 0 and 1. Always 0 when skipped. */
   confidence: number;
-  /** Reasoning explaining the answer based on observable evidence */
+  /** Reasoning explaining the answer, or why the question was skipped */
   reasoning: string;
   /** Whether the question was skipped due to irrelevance to the video content */
   skipped: boolean;
-  /** Explanation of why the question was skipped (only present when skipped is true) */
-  skipReason?: string;
 }
 
 /** Configuration options for askQuestions workflow. */
@@ -85,13 +83,15 @@ export const questionAnswerSchema = z.object({
   confidence: z.number(),
   reasoning: z.string(),
   skipped: z.boolean(),
-  skipReason: z.string().optional(),
 });
 
 export type QuestionAnswerType = z.infer<typeof questionAnswerSchema>;
 
 function createAskQuestionsSchema(allowedAnswers: [string, ...string[]]) {
-  const answerSchema = z.enum([...allowedAnswers, ""]);
+  // Include a sentinel value for skipped questions — OpenAI structured outputs
+  // require all properties, and Google rejects empty-string enum values.
+  // This sentinel is stripped to undefined in post-processing.
+  const answerSchema = z.enum([...allowedAnswers, "SKIPPED"]);
 
   return z.object({
     answers: z.array(
@@ -170,11 +170,10 @@ const SYSTEM_PROMPT = dedent`
 
     For skipped questions:
     - Set skipped to true
-    - Set answer to an empty string
+    - Set answer to "SKIPPED"
     - Set confidence to 0
-    - Provide a clear skipReason explaining why the question is not answerable
+    - Use the reasoning field to explain why the question is not answerable
       from the video content
-    - Set reasoning to an empty string
 
     For borderline questions that are loosely related to the video content,
     still answer them but use a lower confidence score to reflect uncertainty.
@@ -247,7 +246,7 @@ function buildUserPrompt(
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface AnalysisResponse {
-  result: AskQuestionsType;
+  result: { answers: QuestionAnswer[] };
   usage: TokenUsage;
 }
 
@@ -295,13 +294,13 @@ async function analyzeQuestionsWithStoryboard(
 
   return {
     result: {
-      answers: response.output.answers.map(answer => ({
-        ...answer,
-        // Strip numbering prefix (e.g., "1. " or "2. ") from questions
+      answers: response.output.answers.map((answer): QuestionAnswer => ({
         question: answer.question.replace(/^\d+\.\s*/, ""),
         confidence: answer.skipped ? 0 : Math.min(1, Math.max(0, answer.confidence)),
-        answer: answer.skipped ? "" : answer.answer,
-        skipReason: answer.skipped ? answer.skipReason : undefined,
+        reasoning: answer.reasoning,
+        skipped: answer.skipped,
+        // Strip the "SKIPPED" sentinel used for schema compatibility
+        ...(answer.skipped ? {} : { answer: answer.answer }),
       })),
     },
     usage: {

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -76,10 +76,10 @@ export interface AskQuestionsResult {
 // Zod Schemas
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Zod schema for a single answer. */
+/** Zod schema for a single answer (matches the public QuestionAnswer interface). */
 export const questionAnswerSchema = z.object({
   question: z.string(),
-  answer: z.string(),
+  answer: z.string().optional(),
   confidence: z.number(),
   reasoning: z.string(),
   skipped: z.boolean(),
@@ -87,11 +87,16 @@ export const questionAnswerSchema = z.object({
 
 export type QuestionAnswerType = z.infer<typeof questionAnswerSchema>;
 
+/**
+ * Sentinel value used as the answer for skipped questions in the LLM schema.
+ * OpenAI structured outputs require all properties to be required, and Google
+ * rejects empty-string enum values, so we need a concrete string in the enum
+ * for the "no answer" case. Stripped to `undefined` in post-processing.
+ */
+const SKIP_SENTINEL = "__SKIPPED__";
+
 function createAskQuestionsSchema(allowedAnswers: [string, ...string[]]) {
-  // Include a sentinel value for skipped questions — OpenAI structured outputs
-  // require all properties, and Google rejects empty-string enum values.
-  // This sentinel is stripped to undefined in post-processing.
-  const answerSchema = z.enum([...allowedAnswers, "SKIPPED"]);
+  const answerSchema = z.enum([...allowedAnswers, SKIP_SENTINEL]);
 
   return z.object({
     answers: z.array(
@@ -170,7 +175,7 @@ const SYSTEM_PROMPT = dedent`
 
     For skipped questions:
     - Set skipped to true
-    - Set answer to "SKIPPED"
+    - Set answer to "__SKIPPED__"
     - Set confidence to 0
     - Use the reasoning field to explain why the question is not answerable
       from the video content
@@ -246,7 +251,7 @@ function buildUserPrompt(
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface AnalysisResponse {
-  result: { answers: QuestionAnswer[] };
+  result: AskQuestionsType;
   usage: TokenUsage;
 }
 
@@ -293,16 +298,7 @@ async function analyzeQuestionsWithStoryboard(
   });
 
   return {
-    result: {
-      answers: response.output.answers.map((answer): QuestionAnswer => ({
-        question: answer.question.replace(/^\d+\.\s*/, ""),
-        confidence: answer.skipped ? 0 : Math.min(1, Math.max(0, answer.confidence)),
-        reasoning: answer.reasoning,
-        skipped: answer.skipped,
-        // Strip the "SKIPPED" sentinel used for schema compatibility
-        ...(answer.skipped ? {} : { answer: answer.answer }),
-      })),
-    },
+    result: response.output,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,
@@ -475,9 +471,23 @@ export async function askQuestions(
     );
   }
 
+  // Post-process raw LLM output into the public QuestionAnswer shape.
+  // Treat as skipped if the model flagged it OR if the answer is the sentinel.
+  const answers: QuestionAnswer[] = analysisResponse.result.answers.map((raw) => {
+    const isSkipped = raw.skipped || raw.answer === SKIP_SENTINEL;
+    return {
+      // Strip numbering prefix (e.g., "1. " or "2. ") from questions
+      question: raw.question.replace(/^\d+\.\s*/, ""),
+      confidence: isSkipped ? 0 : Math.min(1, Math.max(0, raw.confidence)),
+      reasoning: raw.reasoning,
+      skipped: isSkipped,
+      ...(isSkipped ? {} : { answer: raw.answer }),
+    };
+  });
+
   return {
     assetId,
-    answers: analysisResponse.result.answers,
+    answers,
     storyboardUrl: imageUrl,
     usage: {
       ...analysisResponse.usage,

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -28,12 +28,16 @@ export interface Question {
 export interface QuestionAnswer {
   /** The original question */
   question: string;
-  /** Answer selected from the allowed options */
+  /** Answer selected from the allowed options. Empty string when skipped. */
   answer: string;
-  /** Confidence score between 0 and 1 */
+  /** Confidence score between 0 and 1. Always 0 when skipped. */
   confidence: number;
   /** Reasoning explaining the answer based on observable evidence */
   reasoning: string;
+  /** Whether the question was skipped due to irrelevance to the video content */
+  skipped: boolean;
+  /** Explanation of why the question was skipped (only present when skipped is true) */
+  skipReason?: string;
 }
 
 /** Configuration options for askQuestions workflow. */
@@ -80,12 +84,14 @@ export const questionAnswerSchema = z.object({
   answer: z.string(),
   confidence: z.number(),
   reasoning: z.string(),
+  skipped: z.boolean(),
+  skipReason: z.string().optional(),
 });
 
 export type QuestionAnswerType = z.infer<typeof questionAnswerSchema>;
 
 function createAskQuestionsSchema(allowedAnswers: [string, ...string[]]) {
-  const answerSchema = z.enum(allowedAnswers);
+  const answerSchema = z.enum([...allowedAnswers, ""]);
 
   return z.object({
     answers: z.array(
@@ -150,8 +156,33 @@ const SYSTEM_PROMPT = dedent`
     - Be precise: cite specific frames, objects, actions, or transcript quotes
   </answer_guidelines>
 
+  <relevance_filtering>
+    Before answering each question, assess whether it can be meaningfully
+    answered based on the video storyboard and/or transcript. A question is
+    relevant if it asks about something observable or inferable from the
+    video content (visuals, audio, dialogue, setting, subjects, actions, etc.).
+
+    Mark a question as skipped (skipped: true) if it:
+    - Is completely unrelated to video content (e.g., math, trivia, personal questions)
+    - Asks about information that cannot be determined from storyboard frames or transcript
+    - Is a general knowledge question with no connection to what is shown or said in the video
+    - Attempts to use the system for non-video-analysis purposes
+
+    For skipped questions:
+    - Set skipped to true
+    - Set answer to an empty string
+    - Set confidence to 0
+    - Provide a clear skipReason explaining why the question is not answerable
+      from the video content
+    - Set reasoning to an empty string
+
+    For borderline questions that are loosely related to the video content,
+    still answer them but use a lower confidence score to reflect uncertainty.
+  </relevance_filtering>
+
   <constraints>
-    - You MUST answer every question with one of the allowed response options
+    - You MUST answer every relevant question with one of the allowed response options
+    - Skip irrelevant questions as described in relevance_filtering
     - Only describe observable evidence from frames or transcript
     - Do not fabricate details or make unsupported assumptions
     - Return structured data matching the requested schema exactly
@@ -268,7 +299,9 @@ async function analyzeQuestionsWithStoryboard(
         ...answer,
         // Strip numbering prefix (e.g., "1. " or "2. ") from questions
         question: answer.question.replace(/^\d+\.\s*/, ""),
-        confidence: Math.min(1, Math.max(0, answer.confidence)),
+        confidence: answer.skipped ? 0 : Math.min(1, Math.max(0, answer.confidence)),
+        answer: answer.skipped ? "" : answer.answer,
+        skipReason: answer.skipped ? answer.skipReason : undefined,
       })),
     },
     usage: {

--- a/tests/eval/ask-questions.eval.ts
+++ b/tests/eval/ask-questions.eval.ts
@@ -178,9 +178,11 @@ evalite("Ask Questions", {
           output.answers.length === input.questions.length;
         const answerFieldsValid = output.answers.every((answer, idx) =>
           answer.question === input.questions[idx].question &&
-          expected.allowedAnswers.includes(answer.answer) &&
-          typeof answer.confidence === "number" &&
-          typeof answer.reasoning === "string");
+          (answer.skipped ?
+            answer.answer === undefined && answer.confidence === 0 :
+              expected.allowedAnswers.includes(answer.answer!)) &&
+              typeof answer.confidence === "number" &&
+              typeof answer.reasoning === "string");
 
         const checks = [assetIdValid, storyboardValid, answersValid, answerFieldsValid];
         return checks.filter(Boolean).length / checks.length;

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -151,7 +151,7 @@ describe("ask Questions Integration Tests", () => {
     ).rejects.toThrow("Question at index 0 is invalid");
   });
 
-  it("should skip irrelevant questions with skipped flag and skipReason", async () => {
+  it("should skip irrelevant questions with reasoning explaining why", async () => {
     const result = await askQuestions(testAssetId, [
       { question: "What is the square root of 144?" },
     ]);
@@ -160,11 +160,10 @@ describe("ask Questions Integration Tests", () => {
 
     const answer = result.answers[0];
     expect(answer.skipped).toBe(true);
-    expect(answer.answer).toBe("");
+    expect(answer.answer).toBeUndefined();
     expect(answer.confidence).toBe(0);
-    expect(answer.skipReason).toBeDefined();
-    expect(typeof answer.skipReason).toBe("string");
-    expect(answer.skipReason!.length).toBeGreaterThan(0);
+    expect(typeof answer.reasoning).toBe("string");
+    expect(answer.reasoning.length).toBeGreaterThan(0);
   });
 
   it("should handle a mix of relevant and irrelevant questions", async () => {
@@ -185,9 +184,9 @@ describe("ask Questions Integration Tests", () => {
 
     // Irrelevant question should be skipped
     expect(result.answers[1].skipped).toBe(true);
-    expect(result.answers[1].answer).toBe("");
+    expect(result.answers[1].answer).toBeUndefined();
     expect(result.answers[1].confidence).toBe(0);
-    expect(result.answers[1].skipReason).toBeDefined();
+    expect(result.answers[1].reasoning.length).toBeGreaterThan(0);
 
     // Relevant question should not be skipped
     expect(result.answers[2].skipped).toBe(false);
@@ -201,7 +200,6 @@ describe("ask Questions Integration Tests", () => {
 
     const answer = result.answers[0];
     expect(answer.skipped).toBe(false);
-    expect(answer.skipReason).toBeUndefined();
     expect(answer.answer).toBe("yes");
   });
 

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -151,6 +151,60 @@ describe("ask Questions Integration Tests", () => {
     ).rejects.toThrow("Question at index 0 is invalid");
   });
 
+  it("should skip irrelevant questions with skipped flag and skipReason", async () => {
+    const result = await askQuestions(testAssetId, [
+      { question: "What is the square root of 144?" },
+    ]);
+
+    expect(result.answers).toHaveLength(1);
+
+    const answer = result.answers[0];
+    expect(answer.skipped).toBe(true);
+    expect(answer.answer).toBe("");
+    expect(answer.confidence).toBe(0);
+    expect(answer.skipReason).toBeDefined();
+    expect(typeof answer.skipReason).toBe("string");
+    expect(answer.skipReason!.length).toBeGreaterThan(0);
+  });
+
+  it("should handle a mix of relevant and irrelevant questions", async () => {
+    const questions = [
+      { question: "Is this video about glasses?" },
+      { question: "What is the capital of France?" },
+      { question: "Is this video in color?" },
+    ];
+
+    const result = await askQuestions(testAssetId, questions);
+
+    expect(result.answers).toHaveLength(3);
+
+    // Relevant questions should not be skipped
+    expect(result.answers[0].skipped).toBe(false);
+    expect(["yes", "no"]).toContain(result.answers[0].answer);
+    expect(result.answers[0].answer).toBe("yes");
+
+    // Irrelevant question should be skipped
+    expect(result.answers[1].skipped).toBe(true);
+    expect(result.answers[1].answer).toBe("");
+    expect(result.answers[1].confidence).toBe(0);
+    expect(result.answers[1].skipReason).toBeDefined();
+
+    // Relevant question should not be skipped
+    expect(result.answers[2].skipped).toBe(false);
+    expect(["yes", "no"]).toContain(result.answers[2].answer);
+  });
+
+  it("should mark relevant questions with skipped false", async () => {
+    const result = await askQuestions(testAssetId, [
+      { question: "Is this video about glasses?" },
+    ]);
+
+    const answer = result.answers[0];
+    expect(answer.skipped).toBe(false);
+    expect(answer.skipReason).toBeUndefined();
+    expect(answer.answer).toBe("yes");
+  });
+
   it("should throw error when answer count doesn't match question count", async () => {
     // This is a defensive test - it should only fail if the AI provider returns
     // an incorrect number of answers, which shouldn't happen in practice


### PR DESCRIPTION
Fixes https://mux1.atlassian.net/browse/AIT-154

# Overview

Adds relevance validation to the `askQuestions` workflow so that questions unrelated to the video content (e.g., math problems, trivia, personal questions) are detected and skipped rather than answered as if they were video-related. This is done via prompt-based filtering in the existing LLM call — no extra API calls or latency.

# What was changed

- **`QuestionAnswer` type & Zod schema** — added `skipped: boolean` and optional `skipReason: string` fields. The answer enum now accepts `""` for skipped questions.
- **System prompt** — added a `<relevance_filtering>` section instructing the model to assess each question's relevance before answering. Irrelevant questions get `skipped: true`, `answer: ""`, `confidence: 0`, and a human-readable `skipReason`. Borderline questions are still answered with lower confidence.
- **Post-processing** — enforces `confidence: 0` and `answer: ""` on skipped answers; clears `skipReason` on non-skipped answers.
- **Tests** — three new integration tests: purely irrelevant question is skipped, mixed relevant/irrelevant batch is handled correctly, and relevant questions have `skipped: false`.

# Suggested review order

1. `src/workflows/ask-questions.ts` — type/schema changes, then the new prompt section, then post-processing
2. `tests/integration/ask-questions.test.ts` — new test cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `askQuestions` response shape (`answer` becomes optional and adds `skipped`), which may break consumers and requires callers to handle skipped answers. Logic relies on LLM adherence to a new sentinel-based schema, so edge cases depend on model behavior and post-processing correctness.
> 
> **Overview**
> `askQuestions` now supports **skipping irrelevant/unanswerable questions** instead of forcing a yes/no output.
> 
> It updates `QuestionAnswer`/`questionAnswerSchema` to include `skipped: boolean` and make `answer` optional, introduces a `__SKIPPED__` sentinel to satisfy structured-output enums across providers, and adds prompt instructions to mark irrelevant questions as skipped with `confidence: 0` and explanatory `reasoning`.
> 
> The workflow post-processes raw LLM output to normalize skipped answers (strip sentinel to `undefined`, clamp confidence for non-skipped) and tests are updated/added to validate skipped behavior in both eval scoring and integration scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25d84cada7c1c339a931e19cbea345870441d4a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->