### PR TITLE
fix: switch answer from optional to nullable

### DIFF
--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -28,8 +28,8 @@ export interface Question {
 export interface QuestionAnswer {
   /** The original question */
   question: string;
-  /** Answer selected from the allowed options. Undefined when skipped. */
-  answer?: string;
+  /** Answer selected from the allowed options. Null when skipped. */
+  answer: string | null;
   /** Confidence score between 0 and 1. Always 0 when skipped. */
   confidence: number;
   /** Reasoning explaining the answer, or why the question was skipped */
@@ -79,7 +79,7 @@ export interface AskQuestionsResult {
 /** Zod schema for a single answer (matches the public QuestionAnswer interface). */
 export const questionAnswerSchema = z.object({
   question: z.string(),
-  answer: z.string().optional(),
+  answer: z.string().nullable(),
   confidence: z.number(),
   reasoning: z.string(),
   skipped: z.boolean(),
@@ -481,7 +481,7 @@ export async function askQuestions(
       confidence: isSkipped ? 0 : Math.min(1, Math.max(0, raw.confidence)),
       reasoning: raw.reasoning,
       skipped: isSkipped,
-      ...(isSkipped ? {} : { answer: raw.answer }),
+      answer: isSkipped ? null : raw.answer,
     };
   });
 

--- a/tests/eval/ask-questions.eval.ts
+++ b/tests/eval/ask-questions.eval.ts
@@ -179,7 +179,7 @@ evalite("Ask Questions", {
         const answerFieldsValid = output.answers.every((answer, idx) =>
           answer.question === input.questions[idx].question &&
           (answer.skipped ?
-            answer.answer === undefined && answer.confidence === 0 :
+            answer.answer === null && answer.confidence === 0 :
               expected.allowedAnswers.includes(answer.answer!)) &&
               typeof answer.confidence === "number" &&
               typeof answer.reasoning === "string");

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -160,7 +160,7 @@ describe("ask Questions Integration Tests", () => {
 
     const answer = result.answers[0];
     expect(answer.skipped).toBe(true);
-    expect(answer.answer).toBeUndefined();
+    expect(answer.answer).toBeNull();
     expect(answer.confidence).toBe(0);
     expect(typeof answer.reasoning).toBe("string");
     expect(answer.reasoning.length).toBeGreaterThan(0);

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -184,7 +184,7 @@ describe("ask Questions Integration Tests", () => {
 
     // Irrelevant question should be skipped
     expect(result.answers[1].skipped).toBe(true);
-    expect(result.answers[1].answer).toBeUndefined();
+    expect(result.answers[1].answer).toBeNull();
     expect(result.answers[1].confidence).toBe(0);
     expect(result.answers[1].reasoning.length).toBeGreaterThan(0);
 


### PR DESCRIPTION
# Overview

Change `QuestionAnswer.answer` from optional (`undefined` when skipped) to explicitly nullable (`null` when skipped). This makes the "no answer" state visible in serialized output (e.g. JSON) and ensures consumers always see the `answer` field.

# What was changed

- **`QuestionAnswer` interface** — `answer?: string` → `answer: string | null`
- **Zod schema** — `z.string().optional()` → `z.string().nullable()`
- **Post-processing** — replaced field omission spread (`...(isSkipped ? {} : { answer })`) with explicit `answer: isSkipped ? null : raw.answer`
- **Tests & eval** — updated assertions from `toBeUndefined()` / `=== undefined` to `toBeNull()` / `=== null`

# Suggested review order

1. `src/workflows/ask-questions.ts` — type, schema, and post-processing changes (the core of this PR)
2. `tests/integration/ask-questions.test.ts` — assertion update
3. `tests/eval/ask-questions.eval.ts` — eval scorer update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public `QuestionAnswer` contract from optional to nullable, which can break consumers relying on `undefined`/missing fields. Logic changes are small and covered by updated tests.
> 
> **Overview**
> **`askQuestions` now returns an explicit `answer: null` for skipped questions** instead of omitting `answer`/leaving it `undefined`, making the “no answer” state visible in serialized output.
> 
> This updates the `QuestionAnswer` type and `questionAnswerSchema`, adjusts post-processing to always set `answer`, and updates integration/eval tests to assert `null` for skipped answers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 533e69abe366e6f85d76998fab8cdab435520517. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->