### PR TITLE
fix: update engagement insights when no engagement data is present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -612,10 +612,16 @@ export async function generateEngagementInsights(
   const { hotspots, heatmap } = engagementResult.value;
 
   if (hotspots.length === 0) {
-    throw new Error(
-      `No engagement data available for asset ${assetId} in timeframe ${timeframe}. ` +
-      `Video may not have been viewed yet or engagement tracking is not enabled.`,
-    );
+    return {
+      assetId,
+      momentInsights: [],
+      overallInsight: {
+        summary:
+          `No engagement data available for asset ${assetId} in timeframe ${timeframe}. ` +
+          `Video may not have been viewed yet, not contain notable engagement patterns, or engagement tracking is not enabled.`,
+        trends: [],
+      },
+    };
   }
 
   // Step 3: Data correlation

--- a/tests/integration/engagement-insights.test.ts
+++ b/tests/integration/engagement-insights.test.ts
@@ -128,12 +128,15 @@ describe("engagement Insights Integration Tests", () => {
     expect(typeof result.usage?.totalTokens).toBe("number");
   });
 
-  it("should throw error when no engagement data is available", async () => {
+  it("should return early with empty moments when no engagement data is available", async () => {
     vi.mocked(getHotspotsForAsset).mockResolvedValue([]);
 
-    await expect(
-      generateEngagementInsights(testAssetId, { timeframe: "1:hour" }),
-    ).rejects.toThrow("No engagement data available");
+    const result = await generateEngagementInsights(testAssetId, { timeframe: "1:hour" });
+
+    expect(result.momentInsights).toEqual([]);
+    expect(result.overallInsight.summary).toContain("No engagement data available");
+    expect(result.overallInsight.trends).toEqual([]);
+    expect(result.usage).toBeUndefined();
   });
 
   it("should handle audio-only assets gracefully", async () => {


### PR DESCRIPTION
# Overview

When a video has no engagement data (e.g., no views yet), the engagement insights workflow now returns a graceful empty result instead of throwing an error. This gives callers a structured response with an explanatory summary they can surface to users.

# What was changed

- **`src/workflows/engagement-insights.ts`** — Replaced `throw new Error(...)` with an early return of `{ assetId, momentInsights: [], overallInsight: { summary: "...", trends: [] } }` when hotspots are empty.
- **`tests/integration/engagement-insights.test.ts`** — Updated the no-engagement-data test from expecting a thrown error to asserting on the early-return shape.
- **`package.json` / `package-lock.json`** — Version bump `0.13.0` → `0.13.1`.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d8fe66637a1ecf80abbfac696b8cfb773af3bb71. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->