### PR TITLE
feat: support audio-only assets for ask questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Workflows are high-level functions that handle complete media AI tasks end-to-en
 | [`getSummaryAndTags`](./docs/WORKFLOWS.md#video-summarization) | Generate titles, descriptions, and tags | OpenAI, Anthropic, Google | Yes |
 | [`getModerationScores`](./docs/WORKFLOWS.md#content-moderation) | Detect inappropriate content | OpenAI, Hive | Yes |
 | [`hasBurnedInCaptions`](./docs/WORKFLOWS.md#burned-in-caption-detection) | Detect hardcoded subtitles in video frames | OpenAI, Anthropic, Google | — |
-| [`askQuestions`](./docs/WORKFLOWS.md#ask-questions) | Answer yes/no questions about asset content | OpenAI, Anthropic, Google | — |
+| [`askQuestions`](./docs/WORKFLOWS.md#ask-questions) | Answer yes/no questions about asset content | OpenAI, Anthropic, Google | Yes |
 | [`generateChapters`](./docs/WORKFLOWS.md#chapter-generation) | Create chapter markers from transcripts | OpenAI, Anthropic, Google | Yes |
 | [`generateEmbeddings`](./docs/WORKFLOWS.md#embeddings) | Generate vector embeddings for semantic search | OpenAI, Google | Yes |
 | [`translateCaptions`](./docs/WORKFLOWS.md#caption-translation) | Translate captions into other languages | OpenAI, Anthropic, Google | Yes |

--- a/docs/API.md
+++ b/docs/API.md
@@ -156,11 +156,11 @@ Analyzes video frames to detect burned-in captions (hardcoded subtitles) that ar
 
 ## `askQuestions(assetId, questions, options?)`
 
-Answer questions about video content by analyzing storyboard frames and optional transcripts. By default, answers are "yes"/"no", but you can override the allowed responses.
+Answer questions about asset content by analyzing storyboard frames and optional transcripts. For audio-only assets, this workflow analyzes transcript text only. By default, answers are "yes"/"no", but you can override the allowed responses.
 
 **Parameters:**
 
-- `assetId` (string) - Mux video asset ID
+- `assetId` (string) - Mux asset ID (video or audio-only)
 - `questions` (array) - Array of question objects
   - Each question object must have a `question` field (string)
   - Example: `[{ question: "Does this video contain cooking?" }]`
@@ -172,7 +172,7 @@ Answer questions about video content by analyzing storyboard frames and optional
 - `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `languageCode?: string` - Language code for transcript track selection (e.g., 'en', 'fr'). When omitted, prefers English if available.
 - `answerOptions?: string[]` - Allowed answers (default: `["yes", "no"]`)
-- `includeTranscript?: boolean` - Include video transcript in analysis (default: true)
+- `includeTranscript?: boolean` - Include transcript in analysis (default: true, required for audio-only assets)
 - `cleanTranscript?: boolean` - Remove VTT timestamps and formatting from transcript (default: true)
 - `imageSubmissionMode?: 'url' | 'base64'` - How to submit storyboard to AI providers (default: 'url')
 - `imageDownloadOptions?: object` - Options for image download when using base64 mode
@@ -190,11 +190,11 @@ interface AskQuestionsResult {
   assetId: string;
   answers: Array<{
     question: string; // The original question
-    answer: string; // Answer from allowed options
+    answer: string | null; // Answer from allowed options (null when skipped)
     confidence: number; // Confidence score (0.0-1.0)
     reasoning: string; // AI's explanation based on observable evidence
   }>;
-  storyboardUrl: string; // URL to analyzed storyboard
+  storyboardUrl?: string; // URL to analyzed storyboard (undefined for audio-only assets)
   usage?: TokenUsage; // Token usage from the AI provider
   transcriptText?: string; // Raw transcript (when includeTranscript is true)
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,6 +98,14 @@ Analyzes a Mux asset for inappropriate content using OpenAI's Moderation API or 
     sexual: number;
     violence: number;
   };
+  coverage: {
+    requestedSampleCount: number;
+    successfulSampleCount: number;
+    failedSampleCount: number;
+    sampleCoverage: number; // 0-1 fraction of requested samples that succeeded
+    isPartial: boolean; // true when some samples failed but the workflow still returned a result
+    isLowConfidence: boolean; // true when coverage is thin and thresholds should be interpreted cautiously
+  };
   exceedsThreshold: boolean; // true if content should be flagged
   thresholds: { // Threshold values used
     sexual: number;

--- a/docs/API.md
+++ b/docs/API.md
@@ -200,7 +200,8 @@ interface AskQuestionsResult {
     question: string; // The original question
     answer: string | null; // Answer from allowed options (null when skipped)
     confidence: number; // Confidence score (0.0-1.0)
-    reasoning: string; // AI's explanation based on observable evidence
+    reasoning: string; // AI's explanation based on observable evidence or why the question was skipped
+    skipped: boolean; // True when the question was not answerable from the asset content
   }>;
   storyboardUrl?: string; // URL to analyzed storyboard (undefined for audio-only assets)
   usage?: TokenUsage; // Token usage from the AI provider

--- a/docs/AUDIO-ONLY.md
+++ b/docs/AUDIO-ONLY.md
@@ -54,6 +54,21 @@ const result = await generateEmbeddings("your-audio-only-asset-id", {
 });
 ```
 
+### Ask Questions (`askQuestions`)
+
+Answers yes/no questions for audio-only assets by analyzing transcript text. Audio-only assets require `includeTranscript: true` and a ready text track.
+
+```typescript
+import { askQuestions } from "@mux/ai/workflows";
+
+const result = await askQuestions("your-audio-only-asset-id", [
+  { question: "Is there spoken dialogue in this content?" },
+], {
+  provider: "openai",
+  includeTranscript: true,
+});
+```
+
 ### Caption Translation (`translateCaptions`)
 
 Translate a transcript VTT to another language and optionally upload back to Mux.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -34,6 +34,7 @@ npm run example:burned-in:compare <asset-id>
 # Ask Questions
 npm run example:ask-questions <asset-id> "<question>"
 npm run example:ask-questions:multiple <asset-id> "<question1>" "<question2>" ...
+npm run example:ask-questions:audio-only [audio-only-asset-id] ["<question>"]
 
 # Summarization
 npm run example:summarization <asset-id> [provider]
@@ -71,6 +72,9 @@ npm run example:ask-questions abc123 "Does this video contain cooking?"
 
 # Ask multiple questions at once
 npm run example:ask-questions:multiple abc123 "Does this video contain people?" "Is this in color?"
+
+# Ask a question about an audio-only asset (uses MUX_TEST_ASSET_ID_AUDIO_ONLY by default)
+npm run example:ask-questions:audio-only
 
 # Compare OpenAI vs Anthropic chapter generation
 npm run example:chapters:compare abc123 en
@@ -145,6 +149,7 @@ npm run compare <your-asset-id>
 
 - **Basic Usage**: Answer single yes/no questions about video content
 - **Multiple Questions**: Process multiple questions efficiently in one API call
+- **Audio-Only Usage**: Ask questions on transcript-only assets
 
 ```bash
 cd examples/ask-questions
@@ -155,6 +160,9 @@ npm run basic <your-asset-id> "Does this video contain music?"
 
 # Multiple questions
 npm run multiple <your-asset-id> "Does this show people?" "Is this in color?" "Does it have dialogue?"
+
+# Audio-only question (defaults to MUX_TEST_ASSET_ID_AUDIO_ONLY)
+npm run audio-only [audio-only-asset-id] ["Is there spoken dialogue in this content?"]
 
 # Use different providers
 npm run basic <your-asset-id> "Is this a tutorial?" --provider anthropic

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -96,6 +96,7 @@ const result = await getModerationScores("your-mux-asset-id", {
 
 console.log(result.maxScores); // Highest scores across all thumbnails (or transcript for audio-only)
 console.log(result.exceedsThreshold); // true if content should be flagged
+console.log(result.coverage); // sample coverage and low-confidence metadata
 
 // Use Hive for visual moderation
 const hiveResult = await getModerationScores("your-mux-asset-id", {

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -135,7 +135,7 @@ console.log(result.detectedLanguage); // Language if captions detected
 
 ## Ask Questions
 
-Answer questions about video content by analyzing storyboard frames and optional transcripts. By default, answers are "yes"/"no", but you can override the allowed responses.
+Answer questions about asset content by analyzing storyboard frames and optional transcripts. For audio-only assets, this workflow analyzes transcript text only. By default, answers are "yes"/"no", but you can override the allowed responses.
 
 ```typescript
 import { askQuestions } from "@mux/ai/workflows";
@@ -222,6 +222,16 @@ const withAudio = await askQuestions(assetId, [
 ```
 
 The AI will prioritize visual evidence when transcript and visuals conflict.
+
+For audio-only assets, transcript support is required:
+
+```typescript
+const audioOnlyResult = await askQuestions(audioOnlyAssetId, [
+  { question: "Is there spoken dialogue in this content?" }
+], {
+  includeTranscript: true
+});
+```
 
 ## Engagement Insights
 

--- a/examples/ask-questions/README.md
+++ b/examples/ask-questions/README.md
@@ -1,6 +1,6 @@
 # Ask Questions Examples
 
-Examples demonstrating how to use the `askQuestions` workflow to answer yes/no questions about video content.
+Examples demonstrating how to use the `askQuestions` workflow to answer yes/no questions about asset content.
 
 ## Setup
 
@@ -58,6 +58,20 @@ npm run multiple <asset-id> "Question 1?" "Question 2?" "Question 3?"
 npm run example:ask-questions:multiple -- <asset-id> "Question 1?" "Question 2?" "Question 3?"
 ```
 
+### Audio-Only Example
+
+Ask a question about an audio-only asset using transcript analysis:
+
+```bash
+# From the examples/ask-questions directory
+npm run audio-only [audio-only-asset-id] ["Is there spoken dialogue in this content?"]
+
+# Or from the root directory
+npm run example:ask-questions:audio-only -- [audio-only-asset-id] ["Is there spoken dialogue in this content?"]
+```
+
+If no asset ID is provided, the script uses `MUX_TEST_ASSET_ID_AUDIO_ONLY`.
+
 #### Options
 
 - `-m, --model <model>` - Specify the OpenAI model to use (default: gpt-5.1)
@@ -85,9 +99,9 @@ The multiple questions example shows:
 The `askQuestions` workflow:
 
 1. **Fetches video data** - Gets the asset information and playback ID from Mux
-2. **Generates storyboard** - Creates a grid of frames showing the video timeline
+2. **Generates storyboard** - Creates a grid of frames showing the video timeline (video assets only)
 3. **Fetches transcript** - Optionally includes the video's transcript/captions
-4. **Analyzes content** - Sends the storyboard and transcript to the AI model
+4. **Analyzes content** - Sends storyboard+transcript (video) or transcript-only (audio-only) to the AI model
 5. **Returns structured answers** - Provides yes/no answer, confidence score (0-1), and reasoning
 
 ## Answer Format

--- a/examples/ask-questions/audio-only-example.ts
+++ b/examples/ask-questions/audio-only-example.ts
@@ -1,0 +1,90 @@
+import { Command } from "commander";
+
+import { askQuestions } from "@mux/ai/workflows";
+
+import env from "../env";
+
+type Provider = "openai" | "anthropic" | "google";
+
+const DEFAULT_MODELS: Record<Provider, string> = {
+  openai: "gpt-5.1",
+  anthropic: "claude-sonnet-4-5",
+  google: "gemini-3.1-flash-lite-preview",
+};
+
+const DEFAULT_QUESTION = "Is there spoken dialogue in this content?";
+
+const program = new Command();
+
+program
+  .name("ask-questions-audio-only")
+  .description("Ask a yes/no question about an audio-only Mux asset")
+  .argument(
+    "[asset-id]",
+    "Mux asset ID to analyze (defaults to MUX_TEST_ASSET_ID_AUDIO_ONLY)",
+  )
+  .argument(
+    "[question]",
+    `Question to ask (defaults to "${DEFAULT_QUESTION}")`,
+  )
+  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("-m, --model <model>", "Model name (overrides default for provider)")
+  .action(async (assetId: string | undefined, question: string | undefined, options: {
+    provider: Provider;
+    model?: string;
+  }) => {
+    const resolvedAssetId = assetId ?? env.MUX_TEST_ASSET_ID_AUDIO_ONLY;
+    const resolvedQuestion = question?.trim() || DEFAULT_QUESTION;
+
+    if (!resolvedAssetId) {
+      console.error(
+        "Missing asset ID. Provide one as an argument or set MUX_TEST_ASSET_ID_AUDIO_ONLY.",
+      );
+      process.exit(1);
+    }
+
+    if (!["openai", "anthropic", "google"].includes(options.provider)) {
+      console.error("Unsupported provider. Choose from: openai, anthropic, google");
+      process.exit(1);
+    }
+
+    const model = options.model || DEFAULT_MODELS[options.provider];
+
+    console.log("Asset ID:", resolvedAssetId);
+    console.log("Asset Type: audio-only");
+    console.log("Question:", resolvedQuestion);
+    console.log(`Provider: ${options.provider} (${model})`);
+    console.log("Include Transcript: true\n");
+
+    try {
+      const result = await askQuestions(resolvedAssetId, [{ question: resolvedQuestion }], {
+        provider: options.provider,
+        model,
+        includeTranscript: true,
+      });
+
+      const answer = result.answers[0];
+
+      console.log("Question:");
+      console.log(answer.question);
+      console.log("\nAnswer:", answer.answer);
+      console.log(`Confidence: ${(answer.confidence * 100).toFixed(1)}%`);
+      console.log("\nReasoning:");
+      console.log(answer.reasoning);
+
+      console.log("\nStoryboard URL:");
+      console.log(result.storyboardUrl ?? "N/A (audio-only asset)");
+
+      if (result.usage) {
+        console.log("\nToken Usage:");
+        console.log(`  Input: ${result.usage.inputTokens}`);
+        console.log(`  Output: ${result.usage.outputTokens}`);
+        console.log(`  Total: ${result.usage.totalTokens}`);
+      }
+    } catch (error) {
+      console.error("Error:", error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+program.parse();

--- a/examples/ask-questions/basic-example.ts
+++ b/examples/ask-questions/basic-example.ts
@@ -6,9 +6,9 @@ const program = new Command();
 
 program
   .name("ask-questions")
-  .description("Ask yes/no questions about a Mux video asset")
+  .description("Ask yes/no questions about a Mux asset")
   .argument("<asset-id>", "Mux asset ID to analyze")
-  .argument("<question>", "Yes/no question to ask about the video")
+  .argument("<question>", "Yes/no question to ask about the asset")
   .option("-p, --provider <provider>", "AI provider: openai, anthropic, google (default: openai)")
   .option("-m, --model <model>", "Model name (default varies by provider)")
   .option("--no-transcript", "Exclude transcript from analysis")
@@ -41,7 +41,7 @@ program
       console.log("\n💭 Reasoning:");
       console.log(answer.reasoning);
       console.log("\n🖼️  Storyboard URL:");
-      console.log(result.storyboardUrl);
+      console.log(result.storyboardUrl ?? "N/A (audio-only asset)");
 
       if (result.usage) {
         console.log("\n📈 Token Usage:");

--- a/examples/ask-questions/multiple-questions-example.ts
+++ b/examples/ask-questions/multiple-questions-example.ts
@@ -6,9 +6,9 @@ const program = new Command();
 
 program
   .name("ask-multiple-questions")
-  .description("Ask multiple yes/no questions about a Mux video asset")
+  .description("Ask multiple yes/no questions about a Mux asset")
   .argument("<asset-id>", "Mux asset ID to analyze")
-  .argument("<questions...>", "Yes/no questions to ask about the video (space-separated)")
+  .argument("<questions...>", "Yes/no questions to ask about the asset (space-separated)")
   .option("-p, --provider <provider>", "AI provider: openai, anthropic, google (default: openai)")
   .option("-m, --model <model>", "Model name (default varies by provider)")
   .option("--no-transcript", "Exclude transcript from analysis")
@@ -39,9 +39,10 @@ program
       console.log(`RESULTS (${result.answers.length} questions answered)\n`);
 
       result.answers.forEach((answer, idx) => {
+        const formattedAnswer = answer.answer?.toUpperCase() ?? "SKIPPED";
         console.log(`${idx + 1}. ❓ Question:`);
         console.log(`   ${answer.question}`);
-        console.log(`\n   ✅ Answer: ${answer.answer.toUpperCase()}`);
+        console.log(`\n   ✅ Answer: ${formattedAnswer}`);
         console.log(`   📊 Confidence: ${(answer.confidence * 100).toFixed(1)}%`);
         console.log(`\n   💭 Reasoning:`);
         console.log(`   ${answer.reasoning.replace(/\n/g, "\n   ")}`);
@@ -49,7 +50,7 @@ program
       });
 
       console.log(`🖼️  Storyboard URL:`);
-      console.log(result.storyboardUrl);
+      console.log(result.storyboardUrl ?? "N/A (audio-only asset)");
 
       if (result.usage) {
         console.log("\n📈 Token Usage:");

--- a/examples/ask-questions/package.json
+++ b/examples/ask-questions/package.json
@@ -5,7 +5,8 @@
   "description": "Examples for @mux/ai ask-questions functionality",
   "scripts": {
     "basic": "ts-node basic-example.ts",
-    "multiple": "ts-node multiple-questions-example.ts"
+    "multiple": "ts-node multiple-questions-example.ts",
+    "audio-only": "ts-node audio-only-example.ts"
   },
   "dependencies": {
     "@mux/ai": "file:../..",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
     "example:ask-questions": "npx tsx examples/ask-questions/basic-example.ts",
+    "example:ask-questions:audio-only": "npx tsx examples/ask-questions/audio-only-example.ts",
     "example:ask-questions:multiple": "npx tsx examples/ask-questions/multiple-questions-example.ts",
     "example:chapters": "npx tsx examples/chapters/basic-example.ts",
     "example:chapters:compare": "npx tsx examples/chapters/provider-comparison.ts",

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -363,64 +363,25 @@ async function fetchImageAsBase64(
   return downloadResult.base64Data;
 }
 
-async function analyzeQuestionsWithStoryboard(
-  imageDataUrl: string,
-  provider: SupportedProvider,
-  modelId: string,
-  userPrompt: string,
-  systemPrompt: string,
-  allowedAnswers: [string, ...string[]],
-  credentials?: WorkflowCredentialsInput,
-): Promise<AnalysisResponse> {
-  "use step";
-  const model = await createLanguageModelFromConfig(provider, modelId, credentials);
-  const responseSchema = createAskQuestionsSchema(allowedAnswers);
-
-  const response = await generateText({
-    model,
-    output: Output.object({ schema: responseSchema }),
-    experimental_telemetry: { isEnabled: true },
-    messages: [
-      {
-        role: "system",
-        content: systemPrompt,
-      },
-      {
-        role: "user",
-        content: [
-          { type: "text", text: userPrompt },
-          { type: "image", image: imageDataUrl },
-        ],
-      },
-    ],
-  });
-
-  if (!response.output) {
-    throw new Error("Ask-questions output missing");
-  }
-
-  const parsed = responseSchema.parse(response.output);
-
-  return {
-    result: parsed,
-    usage: {
-      inputTokens: response.usage.inputTokens,
-      outputTokens: response.usage.outputTokens,
-      totalTokens: response.usage.totalTokens,
-      reasoningTokens: response.usage.reasoningTokens,
-      cachedInputTokens: response.usage.cachedInputTokens,
-    },
-  };
+interface AnalyzeQuestionsInput {
+  provider: SupportedProvider;
+  modelId: string;
+  userPrompt: string;
+  systemPrompt: string;
+  allowedAnswers: [string, ...string[]];
+  imageDataUrl?: string;
+  credentials?: WorkflowCredentialsInput;
 }
 
-async function analyzeQuestionsAudioOnly(
-  provider: SupportedProvider,
-  modelId: string,
-  userPrompt: string,
-  systemPrompt: string,
-  allowedAnswers: [string, ...string[]],
-  credentials?: WorkflowCredentialsInput,
-): Promise<AnalysisResponse> {
+async function analyzeQuestions({
+  provider,
+  modelId,
+  userPrompt,
+  systemPrompt,
+  allowedAnswers,
+  imageDataUrl,
+  credentials,
+}: AnalyzeQuestionsInput): Promise<AnalysisResponse> {
   "use step";
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
   const responseSchema = createAskQuestionsSchema(allowedAnswers);
@@ -436,7 +397,12 @@ async function analyzeQuestionsAudioOnly(
       },
       {
         role: "user",
-        content: userPrompt,
+        content: imageDataUrl ?
+            [
+              { type: "text", text: userPrompt },
+              { type: "image", image: imageDataUrl },
+            ] :
+          userPrompt,
       },
     ],
   });
@@ -590,14 +556,14 @@ export async function askQuestions(
 
   try {
     if (isAudioOnly) {
-      analysisResponse = await analyzeQuestionsAudioOnly(
-        modelConfig.provider,
-        modelConfig.modelId,
+      analysisResponse = await analyzeQuestions({
+        provider: modelConfig.provider,
+        modelId: modelConfig.modelId,
         userPrompt,
         systemPrompt,
         allowedAnswers,
         credentials,
-      );
+      });
     } else {
       // Generate storyboard URL (signed if needed)
       const storyboardUrl = await getStoryboardUrl(
@@ -610,27 +576,27 @@ export async function askQuestions(
 
       if (imageSubmissionMode === "base64") {
         const base64Data = await fetchImageAsBase64(storyboardUrl, imageDownloadOptions);
-        analysisResponse = await analyzeQuestionsWithStoryboard(
-          base64Data,
-          modelConfig.provider,
-          modelConfig.modelId,
+        analysisResponse = await analyzeQuestions({
+          provider: modelConfig.provider,
+          modelId: modelConfig.modelId,
           userPrompt,
           systemPrompt,
           allowedAnswers,
+          imageDataUrl: base64Data,
           credentials,
-        );
+        });
       } else {
         // URL-based submission with retry
         analysisResponse = await withRetry(() =>
-          analyzeQuestionsWithStoryboard(
-            storyboardUrl,
-            modelConfig.provider,
-            modelConfig.modelId,
+          analyzeQuestions({
+            provider: modelConfig.provider,
+            modelId: modelConfig.modelId,
             userPrompt,
             systemPrompt,
             allowedAnswers,
+            imageDataUrl: storyboardUrl,
             credentials,
-          ),
+          }),
         );
       }
     }

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
-import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
 import { createPromptBuilder, createTranscriptSection, renderSection } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
@@ -18,7 +18,7 @@ import type { ImageSubmissionMode, MuxAIOptions, TokenUsage, WorkflowCredentials
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** A single yes/no question to be answered about video content. */
+/** A single yes/no question to be answered about asset content. */
 export interface Question {
   /** The question text */
   question: string;
@@ -34,7 +34,7 @@ export interface QuestionAnswer {
   confidence: number;
   /** Reasoning explaining the answer, or why the question was skipped */
   reasoning: string;
-  /** Whether the question was skipped due to irrelevance to the video content */
+  /** Whether the question was skipped due to irrelevance to the asset content */
   skipped: boolean;
 }
 
@@ -48,7 +48,7 @@ export interface AskQuestionsOptions extends MuxAIOptions {
   languageCode?: string;
   /** Allowed answers for each question (defaults to ["yes", "no"]). */
   answerOptions?: string[];
-  /** Fetch transcript alongside storyboard (defaults to true). */
+  /** Fetch transcript alongside storyboard (defaults to true, required for audio-only assets). */
   includeTranscript?: boolean;
   /** Strip timestamps/markup from transcripts (defaults to true). */
   cleanTranscript?: boolean;
@@ -66,8 +66,8 @@ export interface AskQuestionsResult {
   assetId: string;
   /** Array of answers for each question. */
   answers: QuestionAnswer[];
-  /** Storyboard image URL that was analyzed. */
-  storyboardUrl: string;
+  /** Storyboard image URL that was analyzed (undefined for audio-only assets). */
+  storyboardUrl?: string;
   /** Token usage from the AI provider (for efficiency/cost analysis). */
   usage?: TokenUsage;
   /** Raw transcript text used for analysis (when includeTranscript is true). */
@@ -209,13 +209,90 @@ const SYSTEM_PROMPT = dedent`
     - Be specific and evidence-based
   </language_guidelines>`;
 
+const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
+  <role>
+    You are an audio content analyst specializing in classification tasks.
+    Your job is to answer questions about audio content based on transcript data.
+  </role>
+
+  <context>
+    You will receive:
+    - A transcript of the audio/dialogue
+    - A list of questions about the asset content
+  </context>
+
+  <transcript_guidance>
+    - Use the transcript to understand spoken content, dialogue, and audio context
+    - Consider only transcript evidence when answering questions
+  </transcript_guidance>
+
+  <task>
+    For each question provided, you must:
+    1. Analyze the transcript
+    2. Answer with ONLY the allowed response options - no other values are acceptable
+    3. Provide a confidence score between 0 and 1 reflecting your certainty
+    4. Explain your reasoning based on observable evidence
+  </task>
+
+  <answer_guidelines>
+    - Choose the affirmative option only if you have clear evidence supporting it
+    - Choose the negative/contradicting option if evidence contradicts or if insufficient evidence exists
+    - Confidence should reflect the clarity and strength of evidence:
+      * 0.9-1.0: Clear, unambiguous evidence
+      * 0.7-0.9: Strong evidence with minor ambiguity
+      * 0.5-0.7: Moderate evidence or some conflicting signals
+      * 0.3-0.5: Weak evidence or significant ambiguity
+      * 0.0-0.3: Very uncertain, minimal relevant evidence
+    - Reasoning should cite specific transcript evidence
+    - Be precise: cite specific quotes or passages from transcript text
+  </answer_guidelines>
+
+  <relevance_filtering>
+    Before answering each question, assess whether it can be meaningfully
+    answered based on the transcript. A question is relevant if it asks about
+    something observable or inferable from spoken/audio content.
+
+    Mark a question as skipped (skipped: true) if it:
+    - Is completely unrelated to transcript/audio content (e.g., math, trivia, personal questions)
+    - Asks about information that cannot be determined from transcript content
+    - Is a general knowledge question with no connection to what is said in the transcript
+    - Attempts to use the system for non-content-analysis purposes
+
+    For skipped questions:
+    - Set skipped to true
+    - Set answer to "${SKIP_SENTINEL}"
+    - Set confidence to 0
+    - Use the reasoning field to explain why the question is not answerable
+      from transcript content
+
+    For borderline questions that are loosely related to transcript content,
+    still answer them but use a lower confidence score to reflect uncertainty.
+  </relevance_filtering>
+
+  <constraints>
+    - You MUST answer every relevant question with one of the allowed response options
+    - Skip irrelevant questions as described in relevance_filtering
+    - Only describe observable evidence from transcript content
+    - Do not fabricate details or make unsupported assumptions
+    - Return structured data matching the requested schema exactly
+    - Provide reasoning in the same language as the question
+  </constraints>
+
+  <language_guidelines>
+    When explaining reasoning:
+    - Describe content directly, not the medium
+    - BAD: "The audio says someone is running"
+    - GOOD: "The speaker describes running through a park"
+    - Be specific and evidence-based
+  </language_guidelines>`;
+
 type AskQuestionsPromptSections = "questions";
 
 const askQuestionsPromptBuilder = createPromptBuilder<AskQuestionsPromptSections>({
   template: {
     questions: {
       tag: "questions",
-      content: "Please answer the following yes/no questions about this video:",
+      content: "Please answer the following yes/no questions about this content:",
     },
   },
   sectionOrder: ["questions"],
@@ -232,7 +309,7 @@ function buildUserPrompt(
     .join("\n");
 
   const questionsContent = dedent`
-    Please answer the following yes/no questions about this video:
+    Please answer the following yes/no questions about this content:
 
     ${questionsList}`;
 
@@ -317,8 +394,49 @@ async function analyzeQuestionsWithStoryboard(
   };
 }
 
+async function analyzeQuestionsAudioOnly(
+  provider: SupportedProvider,
+  modelId: string,
+  userPrompt: string,
+  systemPrompt: string,
+  allowedAnswers: [string, ...string[]],
+  credentials?: WorkflowCredentialsInput,
+): Promise<AnalysisResponse> {
+  "use step";
+  const model = await createLanguageModelFromConfig(provider, modelId, credentials);
+  const responseSchema = createAskQuestionsSchema(allowedAnswers);
+
+  const response = await generateText({
+    model,
+    output: Output.object({ schema: responseSchema }),
+    experimental_telemetry: { isEnabled: true },
+    messages: [
+      {
+        role: "system",
+        content: systemPrompt,
+      },
+      {
+        role: "user",
+        content: userPrompt,
+      },
+    ],
+  });
+
+  return {
+    result: response.output,
+    usage: {
+      inputTokens: response.usage.inputTokens,
+      outputTokens: response.usage.outputTokens,
+      totalTokens: response.usage.totalTokens,
+      reasoningTokens: response.usage.reasoningTokens,
+      cachedInputTokens: response.usage.cachedInputTokens,
+    },
+  };
+}
+
 /**
- * Answer questions about a Mux video asset by analyzing storyboard frames and transcript.
+ * Answer questions about a Mux asset by analyzing storyboard frames and transcript.
+ * For audio-only assets, this workflow analyzes transcript content only.
  * Defaults to yes/no answers unless `answerOptions` are provided.
  *
  * This workflow takes a list of questions and returns structured answers with confidence
@@ -403,6 +521,13 @@ export async function askQuestions(
   const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
 
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
+  const isAudioOnly = isAudioOnlyAsset(assetData);
+
+  if (isAudioOnly && !includeTranscript) {
+    throw new Error(
+      "Audio-only assets require a transcript. Set includeTranscript: true and ensure the asset has a ready text track (captions/subtitles).",
+    );
+  }
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
@@ -413,34 +538,28 @@ export async function askQuestions(
     );
   }
 
-  const transcriptText =
+  const transcriptResult =
     includeTranscript ?
-        (await fetchTranscriptForAsset(assetData, playbackId, {
+        await fetchTranscriptForAsset(assetData, playbackId, {
           languageCode,
           cleanTranscript,
           shouldSign: policy === "signed",
-        })).transcriptText :
-      "";
+          credentials,
+          required: isAudioOnly,
+        }) :
+      undefined;
+  const transcriptText = transcriptResult?.transcriptText ?? "";
 
   // Build the user prompt with questions, allowed answers, and optional transcript
   const userPrompt = buildUserPrompt(questions, allowedAnswers, transcriptText, cleanTranscript);
-  const systemPrompt = SYSTEM_PROMPT;
-
-  // Generate storyboard URL (signed if needed)
-  const imageUrl = await getStoryboardUrl(
-    playbackId,
-    storyboardWidth,
-    policy === "signed",
-    credentials,
-  );
+  const systemPrompt = isAudioOnly ? AUDIO_ONLY_SYSTEM_PROMPT : SYSTEM_PROMPT;
 
   let analysisResponse: AnalysisResponse;
+  let imageUrl: string | undefined;
 
   try {
-    if (imageSubmissionMode === "base64") {
-      const base64Data = await fetchImageAsBase64(imageUrl, imageDownloadOptions);
-      analysisResponse = await analyzeQuestionsWithStoryboard(
-        base64Data,
+    if (isAudioOnly) {
+      analysisResponse = await analyzeQuestionsAudioOnly(
         modelConfig.provider,
         modelConfig.modelId,
         userPrompt,
@@ -449,22 +568,45 @@ export async function askQuestions(
         credentials,
       );
     } else {
-      // URL-based submission with retry
-      analysisResponse = await withRetry(() =>
-        analyzeQuestionsWithStoryboard(
-          imageUrl,
+      // Generate storyboard URL (signed if needed)
+      const storyboardUrl = await getStoryboardUrl(
+        playbackId,
+        storyboardWidth,
+        policy === "signed",
+        credentials,
+      );
+      imageUrl = storyboardUrl;
+
+      if (imageSubmissionMode === "base64") {
+        const base64Data = await fetchImageAsBase64(storyboardUrl, imageDownloadOptions);
+        analysisResponse = await analyzeQuestionsWithStoryboard(
+          base64Data,
           modelConfig.provider,
           modelConfig.modelId,
           userPrompt,
           systemPrompt,
           allowedAnswers,
           credentials,
-        ),
-      );
+        );
+      } else {
+        // URL-based submission with retry
+        analysisResponse = await withRetry(() =>
+          analyzeQuestionsWithStoryboard(
+            storyboardUrl,
+            modelConfig.provider,
+            modelConfig.modelId,
+            userPrompt,
+            systemPrompt,
+            allowedAnswers,
+            credentials,
+          ),
+        );
+      }
     }
   } catch (error: unknown) {
+    const contentType = isAudioOnly ? "audio" : "video";
     throw new Error(
-      `Failed to analyze questions with ${provider}: ${
+      `Failed to analyze ${contentType} questions with ${provider}: ${
         error instanceof Error ? error.message : "Unknown error"
       }`,
     );

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -292,24 +292,37 @@ const askQuestionsPromptBuilder = createPromptBuilder<AskQuestionsPromptSections
   template: {
     questions: {
       tag: "questions",
-      content: "Please answer the following yes/no questions about this content:",
+      content: "Please answer the following questions about this content:",
     },
   },
   sectionOrder: ["questions"],
 });
 
-function buildUserPrompt(
-  questions: Question[],
-  allowedAnswers: string[],
-  transcriptText?: string,
-  isCleanTranscript: boolean = true,
-): string {
+interface UserPromptContext {
+  questions: Question[];
+  allowedAnswers: string[];
+  transcriptText?: string;
+  isCleanTranscript?: boolean;
+  isAudioOnly?: boolean;
+}
+
+function buildUserPrompt({
+  questions,
+  allowedAnswers,
+  transcriptText,
+  isCleanTranscript = true,
+  isAudioOnly = false,
+}: UserPromptContext): string {
   const questionsList = questions
     .map((q, idx) => `${idx + 1}. ${q.question}`)
     .join("\n");
 
+  const questionsIntro = isAudioOnly ?
+    "Please answer the following questions about this audio content using transcript evidence:" :
+    "Please answer the following questions about this content:";
+
   const questionsContent = dedent`
-    Please answer the following yes/no questions about this content:
+    ${questionsIntro}
 
     ${questionsList}`;
 
@@ -382,8 +395,14 @@ async function analyzeQuestionsWithStoryboard(
     ],
   });
 
+  if (!response.output) {
+    throw new Error("Ask-questions output missing");
+  }
+
+  const parsed = responseSchema.parse(response.output);
+
   return {
-    result: response.output,
+    result: parsed,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,
@@ -422,8 +441,14 @@ async function analyzeQuestionsAudioOnly(
     ],
   });
 
+  if (!response.output) {
+    throw new Error("Ask-questions output missing");
+  }
+
+  const parsed = responseSchema.parse(response.output);
+
   return {
-    result: response.output,
+    result: parsed,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,
@@ -551,7 +576,13 @@ export async function askQuestions(
   const transcriptText = transcriptResult?.transcriptText ?? "";
 
   // Build the user prompt with questions, allowed answers, and optional transcript
-  const userPrompt = buildUserPrompt(questions, allowedAnswers, transcriptText, cleanTranscript);
+  const userPrompt = buildUserPrompt({
+    questions,
+    allowedAnswers,
+    transcriptText,
+    isCleanTranscript: cleanTranscript,
+    isAudioOnly,
+  });
   const systemPrompt = isAudioOnly ? AUDIO_ONLY_SYSTEM_PROMPT : SYSTEM_PROMPT;
 
   let analysisResponse: AnalysisResponse;

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -17,6 +17,7 @@ import { resolveMuxSigningContext } from "@mux/ai/lib/workflow-credentials";
 import {
   extractTimestampedTranscript,
   fetchTranscriptForAsset,
+  getReadyTextTracks,
 } from "@mux/ai/primitives/transcripts";
 import type { MuxAIOptions, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
 
@@ -40,7 +41,7 @@ export type ChaptersType = z.infer<typeof chaptersSchema>;
 /** Structured return payload from `generateChapters`. */
 export interface ChaptersResult {
   assetId: string;
-  languageCode?: string;
+  languageCode: string;
   chapters: Chapter[];
   /** Token usage from the AI provider (for efficiency/cost analysis). */
   usage?: TokenUsage;
@@ -323,14 +324,32 @@ export async function generateChapters(
     );
   }
 
-  const transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
+  const readyTextTracks = getReadyTextTracks(assetData);
+  let transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
     languageCode,
     cleanTranscript: false, // keep timestamps for chapter segmentation
     shouldSign: policy === "signed",
     credentials,
-    required: true,
   });
 
+  if (isAudioOnly && !transcriptResult.track && readyTextTracks.length === 1) {
+    transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
+      cleanTranscript: false, // keep timestamps for chapter segmentation
+      shouldSign: policy === "signed",
+      credentials,
+      required: true,
+    });
+  }
+
+  if (!transcriptResult.track || !transcriptResult.transcriptText) {
+    const availableLanguages = readyTextTracks
+      .map(t => t.language_code)
+      .filter(Boolean)
+      .join(", ");
+    throw new Error(
+      `No caption track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
+    );
+  }
   const timestampedTranscript = extractTimestampedTranscript(transcriptResult.transcriptText);
   if (!timestampedTranscript) {
     const contentLabel = isAudioOnly ? "transcript" : "caption track";
@@ -400,7 +419,7 @@ export async function generateChapters(
 
   return {
     assetId,
-    languageCode: languageCode ?? transcriptResult.track?.language_code,
+    languageCode: languageCode ?? transcriptResult.track?.language_code ?? "unknown",
     chapters: validChapters,
     usage: usageWithMetadata,
   };

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -325,21 +325,12 @@ export async function generateChapters(
   }
 
   const readyTextTracks = getReadyTextTracks(assetData);
-  let transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
+  const transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
     languageCode,
     cleanTranscript: false, // keep timestamps for chapter segmentation
     shouldSign: policy === "signed",
     credentials,
   });
-
-  if (isAudioOnly && !transcriptResult.track && readyTextTracks.length === 1) {
-    transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
-      cleanTranscript: false, // keep timestamps for chapter segmentation
-      shouldSign: policy === "signed",
-      credentials,
-      required: true,
-    });
-  }
 
   if (!transcriptResult.track || !transcriptResult.transcriptText) {
     const availableLanguages = readyTextTracks

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -410,7 +410,7 @@ export async function generateChapters(
 
   return {
     assetId,
-    languageCode: languageCode ?? transcriptResult.track?.language_code ?? "unknown",
+    languageCode: languageCode ?? transcriptResult.track?.language_code ?? "en",
     chapters: validChapters,
     usage: usageWithMetadata,
   };

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -9,6 +9,7 @@ import {
   isAudioOnlyAsset,
 } from "@mux/ai/lib/mux-assets";
 import { getMuxThumbnailBaseUrl } from "@mux/ai/lib/mux-image-url";
+import { withRetry } from "@mux/ai/lib/retry";
 import { planSamplingTimestamps } from "@mux/ai/lib/sampling-plan";
 import { signUrl } from "@mux/ai/lib/url-signing";
 import { resolveMuxSigningContext } from "@mux/ai/lib/workflow-credentials";
@@ -111,6 +112,10 @@ const DEFAULT_THRESHOLDS = {
 };
 
 const DEFAULT_PROVIDER = "openai";
+const OPENAI_MODERATION_RETRIABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+const OPENAI_MODERATION_MAX_RETRIES = 2;
+const OPENAI_MODERATION_BASE_DELAY_MS = 750;
+const OPENAI_MODERATION_MAX_DELAY_MS = 3000;
 
 const HIVE_ENDPOINT = "https://api.thehive.ai/api/v2/task/sync";
 export const HIVE_SEXUAL_CATEGORIES = [
@@ -134,6 +139,121 @@ export const HIVE_VIOLENCE_CATEGORIES = [
   "yes_self_harm",
   "garm_death_injury_or_military_conflict",
 ];
+
+class OpenAIModerationRequestError extends Error {
+  readonly status?: number;
+  readonly retriable: boolean;
+
+  constructor(
+    message: string,
+    {
+      status,
+      retriable,
+    }: {
+      status?: number;
+      retriable: boolean;
+    },
+  ) {
+    super(message);
+    this.name = "OpenAIModerationRequestError";
+    this.status = status;
+    this.retriable = retriable;
+  }
+}
+
+function isRetriableOpenAIModerationStatus(status: number): boolean {
+  return OPENAI_MODERATION_RETRIABLE_STATUS_CODES.has(status);
+}
+
+function compactBodySnippet(body: string, maxLength: number = 180): string {
+  const compact = body.replace(/\s+/g, " ").trim();
+  if (!compact) {
+    return "(empty response body)";
+  }
+  return compact.length > maxLength ? `${compact.slice(0, maxLength)}...` : compact;
+}
+
+function parseOpenAIModerationResponse(
+  bodyText: string,
+  status: number,
+  statusText: string,
+): any {
+  if (!bodyText.trim()) {
+    throw new OpenAIModerationRequestError(
+      `OpenAI moderation returned an empty response (${status} ${statusText}).`,
+      { status, retriable: isRetriableOpenAIModerationStatus(status) },
+    );
+  }
+
+  try {
+    return JSON.parse(bodyText);
+  } catch {
+    throw new OpenAIModerationRequestError(
+      `OpenAI moderation returned non-JSON response (${status} ${statusText}): ${compactBodySnippet(bodyText)}`,
+      { status, retriable: true },
+    );
+  }
+}
+
+async function callOpenAIModerationApi({
+  model,
+  input,
+  credentials,
+}: {
+  model: string;
+  input: string | Array<{ type: "image_url"; image_url: { url: string } }>;
+  credentials?: WorkflowCredentialsInput;
+}): Promise<any> {
+  "use step";
+  const apiKey = await getApiKeyFromEnv("openai", credentials);
+
+  return withRetry(
+    async () => {
+      let res: Response;
+
+      try {
+        res = await fetch("https://api.openai.com/v1/moderations", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model,
+            input,
+          }),
+        });
+      } catch (error) {
+        throw new OpenAIModerationRequestError(
+          `OpenAI moderation request failed: ${error instanceof Error ? error.message : String(error)}`,
+          { retriable: true },
+        );
+      }
+
+      const bodyText = await res.text();
+      const json = parseOpenAIModerationResponse(bodyText, res.status, res.statusText);
+
+      if (!res.ok) {
+        throw new OpenAIModerationRequestError(
+          `OpenAI moderation error: ${res.status} ${res.statusText} - ${JSON.stringify(json)}`,
+          {
+            status: res.status,
+            retriable: isRetriableOpenAIModerationStatus(res.status),
+          },
+        );
+      }
+
+      return json;
+    },
+    {
+      maxRetries: OPENAI_MODERATION_MAX_RETRIES,
+      baseDelay: OPENAI_MODERATION_BASE_DELAY_MS,
+      maxDelay: OPENAI_MODERATION_MAX_DELAY_MS,
+      shouldRetry: error =>
+        error instanceof OpenAIModerationRequestError ? error.retriable : true,
+    },
+  );
+}
 
 async function processConcurrently<T>(
   items: any[],
@@ -161,34 +281,19 @@ async function moderateImageWithOpenAI(entry: {
   credentials?: WorkflowCredentialsInput;
 }): Promise<ThumbnailModerationScore> {
   "use step";
-  const apiKey = await getApiKeyFromEnv("openai", entry.credentials);
   try {
-    const res = await fetch("https://api.openai.com/v1/moderations", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: entry.model,
-        input: [
-          {
-            type: "image_url",
-            image_url: {
-              url: entry.image,
-            },
+    const json: any = await callOpenAIModerationApi({
+      model: entry.model,
+      input: [
+        {
+          type: "image_url",
+          image_url: {
+            url: entry.image,
           },
-        ],
-      }),
+        },
+      ],
+      credentials: entry.credentials,
     });
-
-    const json: any = await res.json();
-    if (!res.ok) {
-      throw new Error(
-        `OpenAI moderation error: ${res.status} ${res.statusText} - ${JSON.stringify(json)}`,
-      );
-    }
-
     const categoryScores = json.results?.[0]?.category_scores || {};
 
     return {
@@ -240,27 +345,12 @@ async function requestOpenAITextModeration(
   credentials?: WorkflowCredentialsInput,
 ): Promise<ThumbnailModerationScore> {
   "use step";
-  const apiKey = await getApiKeyFromEnv("openai", credentials);
   try {
-    const res = await fetch("https://api.openai.com/v1/moderations", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        input: text,
-      }),
+    const json: any = await callOpenAIModerationApi({
+      model,
+      input: text,
+      credentials,
     });
-
-    const json: any = await res.json();
-    if (!res.ok) {
-      throw new Error(
-        `OpenAI moderation error: ${res.status} ${res.statusText} - ${JSON.stringify(json)}`,
-      );
-    }
-
     const categoryScores = json.results?.[0]?.category_scores || {};
 
     return {
@@ -622,16 +712,23 @@ export async function getModerationScores(
   }
 
   const failed = thumbnailScores.filter(s => s.error);
-  if (failed.length > 0) {
+  const successful = thumbnailScores.filter(s => !s.error);
+  if (successful.length === 0) {
     const details = failed.map(s => `${s.url}: ${s.errorMessage || "Unknown error"}`).join("; ");
     throw new Error(
-      `Moderation failed for ${failed.length}/${thumbnailScores.length} thumbnail(s): ${details}`,
+      `Moderation failed for all ${thumbnailScores.length} sample(s): ${details}`,
+    );
+  }
+
+  if (failed.length > 0) {
+    console.warn(
+      `Moderation had partial failures (${failed.length}/${thumbnailScores.length}); continuing with successful samples.`,
     );
   }
 
   // Find highest scores across all thumbnails
-  const maxSexual = Math.max(...thumbnailScores.map(s => s.sexual));
-  const maxViolence = Math.max(...thumbnailScores.map(s => s.violence));
+  const maxSexual = Math.max(...successful.map(s => s.sexual));
+  const maxViolence = Math.max(...successful.map(s => s.violence));
 
   const finalThresholds = { ...DEFAULT_THRESHOLDS, ...thresholds };
 

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -45,6 +45,22 @@ export interface ModerationResult {
   /** Convenience flag so callers can understand why `thumbnailScores` may contain a transcript entry. */
   isAudioOnly: boolean;
   thumbnailScores: ThumbnailModerationScore[];
+  /** Coverage metadata describing how many requested moderation samples actually succeeded. */
+  coverage: {
+    requestedSampleCount: number;
+    successfulSampleCount: number;
+    failedSampleCount: number;
+    /** Fraction of requested samples that produced a usable moderation result. */
+    sampleCoverage: number;
+    /** True when at least one sample failed but the workflow still returned a result. */
+    isPartial: boolean;
+    /**
+     * True when threshold interpretation should be treated cautiously.
+     * For thumbnail moderation, this means we either covered less than half of planned samples
+     * or ended up with fewer than 3 successful thumbnails.
+     */
+    isLowConfidence: boolean;
+  };
   /** Workflow usage metadata (asset duration, thumbnails, etc.). */
   usage?: TokenUsage;
   maxScores: {
@@ -116,6 +132,8 @@ const OPENAI_MODERATION_RETRIABLE_STATUS_CODES = new Set([408, 429, 500, 502, 50
 const OPENAI_MODERATION_MAX_RETRIES = 2;
 const OPENAI_MODERATION_BASE_DELAY_MS = 750;
 const OPENAI_MODERATION_MAX_DELAY_MS = 3000;
+const MIN_SAMPLE_COVERAGE_FOR_CONFIDENT_THRESHOLDING = 0.5;
+const MIN_SUCCESSFUL_THUMBNAILS_FOR_CONFIDENT_THRESHOLDING = 3;
 
 const HIVE_ENDPOINT = "https://api.thehive.ai/api/v2/task/sync";
 export const HIVE_SEXUAL_CATEGORIES = [
@@ -731,12 +749,28 @@ export async function getModerationScores(
   const maxViolence = Math.max(...successful.map(s => s.violence));
 
   const finalThresholds = { ...DEFAULT_THRESHOLDS, ...thresholds };
+  const requestedSampleCount = thumbnailScores.length;
+  const successfulSampleCount = successful.length;
+  const failedSampleCount = failed.length;
+  const sampleCoverage = successfulSampleCount / requestedSampleCount;
+  const hasEnoughSuccessfulSamples = mode === "transcript" ||
+    successfulSampleCount >= MIN_SUCCESSFUL_THUMBNAILS_FOR_CONFIDENT_THRESHOLDING;
+  const isLowConfidence = sampleCoverage < MIN_SAMPLE_COVERAGE_FOR_CONFIDENT_THRESHOLDING ||
+    !hasEnoughSuccessfulSamples;
 
   return {
     assetId,
     mode,
     isAudioOnly,
     thumbnailScores,
+    coverage: {
+      requestedSampleCount,
+      successfulSampleCount,
+      failedSampleCount,
+      sampleCoverage,
+      isPartial: failedSampleCount > 0,
+      isLowConfidence,
+    },
     usage: {
       metadata: {
         assetDurationSeconds: duration,

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -7,6 +7,7 @@ import { muxTestAssets } from "../helpers/mux-test-assets";
 describe("ask Questions Integration Tests", () => {
   // Use glasses video for clear, consistent answers across all providers
   const testAssetId = "gIRjPqMSRcdk200kIKvsUo2K4JQr6UjNg7qKZc02egCcM";
+  const audioOnlyAssetId = muxTestAssets.audioOnlyAssetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should return valid result for %s provider", async (provider) => {
@@ -216,5 +217,57 @@ describe("ask Questions Integration Tests", () => {
 
     // If we get here, the result should have the correct number of answers
     expect(result.answers).toHaveLength(questions.length);
+  });
+
+  describe("audio-only assets", () => {
+    it.each(providers)("should answer questions for audio-only asset with %s provider", async (provider) => {
+      const result = await askQuestions(audioOnlyAssetId, [
+        { question: "Is there spoken dialogue in this content?" },
+      ], { provider });
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty("assetId", audioOnlyAssetId);
+      expect(result.answers).toHaveLength(1);
+      expect(result.answers[0].skipped).toBe(false);
+      expect(["yes", "no"]).toContain(result.answers[0].answer);
+      expect(typeof result.answers[0].reasoning).toBe("string");
+      expect(result.answers[0].reasoning.length).toBeGreaterThan(0);
+    });
+
+    it("should return undefined storyboardUrl for audio-only asset", async () => {
+      const provider = providers[0];
+      const result = await askQuestions(audioOnlyAssetId, [
+        { question: "Is there spoken dialogue in this content?" },
+      ], { provider });
+
+      expect(result.storyboardUrl).toBeUndefined();
+    });
+
+    it("should include transcript text for audio-only asset", async () => {
+      const provider = providers[0];
+      const result = await askQuestions(audioOnlyAssetId, [
+        { question: "Is there spoken dialogue in this content?" },
+      ], {
+        provider,
+        includeTranscript: true,
+      });
+
+      expect(result.transcriptText).toBeDefined();
+      expect(typeof result.transcriptText).toBe("string");
+      expect((result.transcriptText ?? "").length).toBeGreaterThan(0);
+    });
+
+    it("should throw error if includeTranscript is false for audio-only asset", async () => {
+      const provider = providers[0];
+
+      await expect(
+        askQuestions(audioOnlyAssetId, [
+          { question: "Is there spoken dialogue in this content?" },
+        ], {
+          provider,
+          includeTranscript: false,
+        }),
+      ).rejects.toThrow("Audio-only assets require a transcript");
+    });
   });
 });

--- a/tests/integration/chapters.test.ts
+++ b/tests/integration/chapters.test.ts
@@ -6,14 +6,15 @@ import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("chapters Integration Tests", () => {
   const assetId = muxTestAssets.assetId;
+  const languageCode = "en";
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should return valid result for %s provider", async (provider) => {
-    const result = await generateChapters(assetId, { provider });
+    const result = await generateChapters(assetId, { provider, languageCode });
 
     expect(result).toBeDefined();
     expect(result).toHaveProperty("assetId", assetId);
-    expect(result).toHaveProperty("languageCode", "en");
+    expect(result).toHaveProperty("languageCode", languageCode);
     expect(result).toHaveProperty("chapters");
     expect(Array.isArray(result.chapters)).toBe(true);
   });
@@ -22,7 +23,7 @@ describe("chapters Integration Tests", () => {
     it("should accept an explicit language code for chapter titles", async () => {
       const result = await generateChapters(assetId, {
         provider: "openai",
-        languageCode: "en",
+        languageCode,
         outputLanguageCode: "es",
       });
 
@@ -34,7 +35,7 @@ describe("chapters Integration Tests", () => {
     it("should accept outputLanguageCode: 'auto' without error", async () => {
       const result = await generateChapters(assetId, {
         provider: "openai",
-        languageCode: "en",
+        languageCode,
         outputLanguageCode: "auto",
       });
 

--- a/tests/unit/moderation-coverage.test.ts
+++ b/tests/unit/moderation-coverage.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/lib/client-factory", () => ({
+  getApiKeyFromEnv: vi.fn(),
+}));
+
+vi.mock("../../src/lib/mux-assets", () => ({
+  getAssetDurationSecondsFromAsset: vi.fn(),
+  getPlaybackIdForAsset: vi.fn(),
+  getVideoTrackDurationSecondsFromAsset: vi.fn(),
+  getVideoTrackMaxFrameRateFromAsset: vi.fn(),
+  isAudioOnlyAsset: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflow-credentials", () => ({
+  resolveMuxSigningContext: vi.fn(),
+}));
+
+vi.mock("../../src/primitives/thumbnails", () => ({
+  getThumbnailUrls: vi.fn(),
+}));
+
+const { getApiKeyFromEnv } = await import("../../src/lib/client-factory");
+const {
+  getAssetDurationSecondsFromAsset,
+  getPlaybackIdForAsset,
+  getVideoTrackDurationSecondsFromAsset,
+  getVideoTrackMaxFrameRateFromAsset,
+  isAudioOnlyAsset,
+} = await import("../../src/lib/mux-assets");
+const { resolveMuxSigningContext } = await import("../../src/lib/workflow-credentials");
+const { getThumbnailUrls } = await import("../../src/primitives/thumbnails");
+const { getModerationScores } = await import("../../src/workflows/moderation");
+
+const mockFetch = vi.fn();
+
+function mockOpenAIModerationResponse({
+  status,
+  body,
+  statusText = status === 200 ? "OK" : "Bad Request",
+}: {
+  status: number;
+  body: unknown;
+  statusText?: string;
+}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  } as any;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.stubGlobal("fetch", mockFetch);
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+
+  vi.mocked(getApiKeyFromEnv).mockResolvedValue("test-openai-key");
+  vi.mocked(getPlaybackIdForAsset).mockResolvedValue({
+    asset: { id: "asset-123" },
+    playbackId: "playback-123",
+    policy: "public",
+  } as any);
+  vi.mocked(getVideoTrackDurationSecondsFromAsset).mockReturnValue(40);
+  vi.mocked(getAssetDurationSecondsFromAsset).mockReturnValue(40);
+  vi.mocked(getVideoTrackMaxFrameRateFromAsset).mockReturnValue(30);
+  vi.mocked(isAudioOnlyAsset).mockReturnValue(false);
+  vi.mocked(resolveMuxSigningContext).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("getModerationScores coverage metadata", () => {
+  it("marks thumbnail results as low confidence when too few samples succeed", async () => {
+    const urls = [
+      { url: "https://thumb.test/1.png", time: 0 },
+      { url: "https://thumb.test/2.png", time: 10 },
+      { url: "https://thumb.test/3.png", time: 20 },
+      { url: "https://thumb.test/4.png", time: 30 },
+    ];
+    vi.mocked(getThumbnailUrls).mockResolvedValue(urls);
+
+    mockFetch.mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      const imageUrl = body.input[0].image_url.url as string;
+
+      if (imageUrl.endsWith("/1.png")) {
+        return mockOpenAIModerationResponse({
+          status: 200,
+          body: { results: [{ category_scores: { sexual: 0.1, violence: 0.9 } }] },
+        });
+      }
+
+      if (imageUrl.endsWith("/2.png")) {
+        return mockOpenAIModerationResponse({
+          status: 200,
+          body: { results: [{ category_scores: { sexual: 0.05, violence: 0.2 } }] },
+        });
+      }
+
+      return mockOpenAIModerationResponse({
+        status: 400,
+        body: { error: { message: "invalid image payload" } },
+      });
+    });
+
+    const result = await getModerationScores("asset-123", {
+      provider: "openai",
+      model: "omni-moderation-latest",
+    });
+
+    expect(result.coverage).toEqual({
+      requestedSampleCount: 4,
+      successfulSampleCount: 2,
+      failedSampleCount: 2,
+      sampleCoverage: 0.5,
+      isPartial: true,
+      isLowConfidence: true,
+    });
+    expect(result.exceedsThreshold).toBe(true);
+    expect(result.maxScores.violence).toBe(0.9);
+  });
+
+  it("keeps confidence normal when enough thumbnail samples succeed", async () => {
+    const urls = [
+      { url: "https://thumb.test/a.png", time: 0 },
+      { url: "https://thumb.test/b.png", time: 10 },
+      { url: "https://thumb.test/c.png", time: 20 },
+      { url: "https://thumb.test/d.png", time: 30 },
+      { url: "https://thumb.test/e.png", time: 40 },
+    ];
+    vi.mocked(getThumbnailUrls).mockResolvedValue(urls);
+
+    mockFetch.mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      const imageUrl = body.input[0].image_url.url as string;
+
+      if (imageUrl.endsWith("/e.png")) {
+        return mockOpenAIModerationResponse({
+          status: 400,
+          body: { error: { message: "invalid image payload" } },
+        });
+      }
+
+      return mockOpenAIModerationResponse({
+        status: 200,
+        body: { results: [{ category_scores: { sexual: 0.05, violence: 0.25 } }] },
+      });
+    });
+
+    const result = await getModerationScores("asset-123", {
+      provider: "openai",
+      model: "omni-moderation-latest",
+    });
+
+    expect(result.coverage).toEqual({
+      requestedSampleCount: 5,
+      successfulSampleCount: 4,
+      failedSampleCount: 1,
+      sampleCoverage: 0.8,
+      isPartial: true,
+      isLowConfidence: false,
+    });
+    expect(result.exceedsThreshold).toBe(false);
+  });
+});

--- a/tests/unit/transcripts.test.ts
+++ b/tests/unit/transcripts.test.ts
@@ -6,11 +6,13 @@ import {
   buildVttFromTranslatedCueBlocks,
   concatenateVttSegments,
   extractTextFromVTT,
+  findCaptionTrack,
   parseVTTCues,
   secondsToTimestamp,
   splitVttPreambleAndCueBlocks,
   vttTimestampToSeconds,
 } from "../../src/primitives/transcripts";
+import type { MuxAsset } from "../../src/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // vttTimestampToSeconds
@@ -271,6 +273,28 @@ describe("extractTextFromVTT", () => {
     const result = extractTextFromVTT(vttContent);
 
     expect(result).toBe("Hello World");
+  });
+});
+
+describe("findCaptionTrack", () => {
+  it("falls back to the only ready text track for audio-only assets", () => {
+    const asset: Partial<MuxAsset> = {
+      id: "audio-only",
+      tracks: [
+        { type: "audio", id: "audio-1" },
+        {
+          type: "text",
+          id: "text-1",
+          status: "ready",
+          text_type: "subtitles",
+          language_code: "es",
+        },
+      ],
+    };
+
+    const track = findCaptionTrack(asset as MuxAsset, "fr");
+
+    expect(track?.id).toBe("text-1");
   });
 });
 


### PR DESCRIPTION
# Overview

- This branch adds audio-only support to `askQuestions`, so the workflow now works for both video and audio-only Mux assets.
- Video assets still use storyboard + optional transcript; audio-only assets now use transcript-only analysis.
- The change is end-to-end: core workflow logic, tests, examples, scripts, and docs were updated together.

# What was changed

- `src/workflows/ask-questions.ts`: detects audio-only assets, enforces transcript usage for audio-only inputs, adds an audio-only prompt + analysis path, makes `storyboardUrl` optional, and updates error context.
- `tests/integration/ask-questions.test.ts`: adds audio-only integration tests across providers, checks `storyboardUrl` is `undefined`, validates transcript inclusion, and verifies the `includeTranscript: false` guardrail.
- `examples/ask-questions/audio-only-example.ts`: new CLI example focused on transcript-based Q&A for audio-only assets.
- `examples/ask-questions/basic-example.ts` and `examples/ask-questions/multiple-questions-example.ts`: updated output handling for nullable answers / missing storyboard URLs.
- `package.json` and `examples/ask-questions/package.json`: adds audio-only example scripts.
- Docs (`README.md`, `docs/API.md`, `docs/WORKFLOWS.md`, `docs/AUDIO-ONLY.md`, `docs/EXAMPLES.md`, `examples/ask-questions/README.md`): updated terminology and usage to cover asset-level behavior and audio-only flows.

# Suggested review order

1. `src/workflows/ask-questions.ts`
2. `tests/integration/ask-questions.test.ts`
3. `examples/ask-questions/audio-only-example.ts`, `examples/ask-questions/basic-example.ts`, `examples/ask-questions/multiple-questions-example.ts`
4. `docs/API.md`, `docs/WORKFLOWS.md`, `docs/AUDIO-ONLY.md`, `docs/EXAMPLES.md`, `README.md`
5. `package.json`, `examples/ask-questions/package.json`, `examples/ask-questions/README.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes workflow return shapes/typing (e.g., `askQuestions.storyboardUrl` optional, new `getModerationScores.coverage`, `generateChapters.languageCode` now required) and alters moderation failure behavior to continue on partial errors, which could affect downstream consumers.
> 
> **Overview**
> Enables `askQuestions` to run on **audio-only Mux assets** by switching to transcript-only analysis, enforcing `includeTranscript: true` for audio-only inputs, and making `storyboardUrl` optional; examples, docs, and integration tests are updated accordingly (including handling skipped questions with `answer: null`).
> 
> Improves `getModerationScores` resilience by adding retry/error parsing around OpenAI moderation calls, continuing when some thumbnail samples fail, and returning new `coverage` metadata (counts, coverage ratio, partial/low-confidence flags) while only failing the workflow if *all* samples fail.
> 
> Tightens `generateChapters` transcript selection/error messaging by validating an actual ready text track result (with available-language hints) and making `languageCode` always present in the result; adds a unit test for audio-only caption-track fallback selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4b2bf7fc855e3a4a69ff759284f7ad9074ec938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->