### PR TITLE
feat: add uploadToS3 parameter for translation workflows

### DIFF
--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -437,7 +437,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
 
   const deleteOriginal = deleteOriginalTrack !== false;
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = uploadToS3Option ?? uploadToMux; // Default to uploadToMux; explicit true/false always wins
+  const uploadToS3 = (uploadToS3Option ?? uploadToMux) || uploadToMux; // Default to uploadToMux; uploadToMux: true forces S3 upload
 
   // S3 configuration
   const s3Endpoint = providedS3Endpoint ?? env.S3_ENDPOINT;

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -65,6 +65,8 @@ export interface EditCaptionsOptions<P extends SupportedProvider = SupportedProv
   /**
    * When true (default) the edited VTT is uploaded to the configured
    * S3-compatible bucket and a `presignedUrl` is returned.
+   * Note: even when explicitly set to `false`, S3 upload still occurs if
+   * `uploadToMux` is `true` (since Mux track creation requires a presigned URL).
    */
   uploadToS3?: boolean;
   /**

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -63,10 +63,11 @@ export interface EditCaptionsOptions<P extends SupportedProvider = SupportedProv
   /** Delete the original track after creating the edited one. Defaults to true. */
   deleteOriginalTrack?: boolean;
   /**
-   * When true (default) the edited VTT is uploaded to the configured
+   * When `true` the edited VTT is uploaded to the configured
    * S3-compatible bucket and a `presignedUrl` is returned.
-   * Note: even when explicitly set to `false`, S3 upload still occurs if
-   * `uploadToMux` is `true` (since Mux track creation requires a presigned URL).
+   * Defaults to the value of `uploadToMux` when omitted.
+   * Ignored (treated as `true`) when `uploadToMux` is `true`,
+   * since Mux track creation requires a presigned URL.
    */
   uploadToS3?: boolean;
   /**

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -437,7 +437,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
 
   const deleteOriginal = deleteOriginalTrack !== false;
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = uploadToS3Option !== false || uploadToMux; // Default to true; implied by uploadToMux
+  const uploadToS3 = uploadToS3Option ?? uploadToMux; // Default to uploadToMux; explicit true/false always wins
 
   // S3 configuration
   const s3Endpoint = providedS3Endpoint ?? env.S3_ENDPOINT;

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -438,7 +438,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
 
   const deleteOriginal = deleteOriginalTrack !== false;
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = (uploadToS3Option ?? uploadToMux) || uploadToMux; // Default to uploadToMux; uploadToMux: true forces S3 upload
+  const uploadToS3 = uploadToS3Option || uploadToMux; // Defaults to uploadToMux; uploadToMux: true forces S3 upload
 
   // S3 configuration
   const s3Endpoint = providedS3Endpoint ?? env.S3_ENDPOINT;

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -64,9 +64,13 @@ export interface EditCaptionsOptions<P extends SupportedProvider = SupportedProv
   deleteOriginalTrack?: boolean;
   /**
    * When true (default) the edited VTT is uploaded to the configured
-   * bucket and attached as a track on the Mux asset.
-   * When false the edited VTT is still uploaded to S3 and a `presignedUrl`
-   * is returned, but no track is created on the Mux asset.
+   * S3-compatible bucket and a `presignedUrl` is returned.
+   */
+  uploadToS3?: boolean;
+  /**
+   * When true (default) the edited VTT is attached as a track on the
+   * Mux asset. Implies `uploadToS3: true` because a presigned URL is
+   * required for track creation.
    */
   uploadToMux?: boolean;
   /** Optional override for the S3-compatible endpoint used for uploads. */
@@ -408,6 +412,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
     autoCensorProfanity: autoCensorOption,
     replacements: replacementsOption,
     deleteOriginalTrack,
+    uploadToS3: uploadToS3Option,
     uploadToMux: uploadToMuxOption,
     s3Endpoint: providedS3Endpoint,
     s3Region: providedS3Region,
@@ -429,7 +434,8 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
   }
 
   const deleteOriginal = deleteOriginalTrack !== false;
-  const uploadToMux = uploadToMuxOption !== false;
+  const uploadToMux = uploadToMuxOption !== false; // Default to true
+  const uploadToS3 = uploadToS3Option !== false || uploadToMux; // Default to true; implied by uploadToMux
 
   // S3 configuration
   const s3Endpoint = providedS3Endpoint ?? env.S3_ENDPOINT;
@@ -438,9 +444,9 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
 
-  if (!s3Endpoint || !s3Bucket || (!storageAdapter && (!s3AccessKeyId || !s3SecretAccessKey))) {
+  if (uploadToS3 && (!s3Endpoint || !s3Bucket || (!storageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
     throw new Error(
-      "Storage configuration is required. Provide s3Endpoint and s3Bucket. " +
+      "Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. " +
       "If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options " +
       "or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.",
     );
@@ -544,49 +550,50 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
     undefined;
 
   // Upload edited VTT to S3-compatible storage
-  let presignedUrl: string;
-
-  try {
-    presignedUrl = await uploadEditedVttToS3({
-      editedVtt,
-      assetId,
-      trackId,
-      s3Endpoint: s3Endpoint!,
-      s3Region,
-      s3Bucket: s3Bucket!,
-      storageAdapter,
-      s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
-    });
-  } catch (error) {
-    throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
-  }
-
-  // Add edited track to Mux asset (only when uploadToMux is true)
+  let presignedUrl: string | undefined;
   let uploadedTrackId: string | undefined;
 
-  if (uploadToMux) {
+  if (uploadToS3) {
     try {
-      const languageCode = sourceTrack.language_code || "en";
-      const suffix = trackNameSuffix ?? "edited";
-      const trackName = `${sourceTrack.name || "Subtitles"} (${suffix})`;
-
-      uploadedTrackId = await createTextTrackOnMux(
+      presignedUrl = await uploadEditedVttToS3({
+        editedVtt,
         assetId,
-        languageCode,
-        trackName,
-        presignedUrl,
-        credentials,
-      );
+        trackId,
+        s3Endpoint: s3Endpoint!,
+        s3Region,
+        s3Bucket: s3Bucket!,
+        storageAdapter,
+        s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
+      });
     } catch (error) {
-      console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+      throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
 
-    // Delete original track only if the replacement track was created
-    if (deleteOriginal && uploadedTrackId) {
+    // Add edited track to Mux asset (only when uploadToMux is true)
+    if (uploadToMux) {
       try {
-        await deleteTrackOnMux(assetId, trackId, credentials);
+        const languageCode = sourceTrack.language_code || "en";
+        const suffix = trackNameSuffix ?? "edited";
+        const trackName = `${sourceTrack.name || "Subtitles"} (${suffix})`;
+
+        uploadedTrackId = await createTextTrackOnMux(
+          assetId,
+          languageCode,
+          trackName,
+          presignedUrl,
+          credentials,
+        );
       } catch (error) {
-        console.warn(`Failed to delete original track: ${error instanceof Error ? error.message : "Unknown error"}`);
+        console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+      }
+
+      // Delete original track only if the replacement track was created
+      if (deleteOriginal && uploadedTrackId) {
+        try {
+          await deleteTrackOnMux(assetId, trackId, credentials);
+        } catch (error) {
+          console.warn(`Failed to delete original track: ${error instanceof Error ? error.message : "Unknown error"}`);
+        }
       }
     }
   }

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -64,7 +64,9 @@ export interface EditCaptionsOptions<P extends SupportedProvider = SupportedProv
   deleteOriginalTrack?: boolean;
   /**
    * When true (default) the edited VTT is uploaded to the configured
-   * bucket and attached to the Mux asset.
+   * bucket and attached as a track on the Mux asset.
+   * When false the edited VTT is still uploaded to S3 and a `presignedUrl`
+   * is returned, but no track is created on the Mux asset.
    */
   uploadToMux?: boolean;
   /** Optional override for the S3-compatible endpoint used for uploads. */
@@ -436,9 +438,9 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
 
-  if (uploadToMux && (!s3Endpoint || !s3Bucket || (!storageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
+  if (!s3Endpoint || !s3Bucket || (!storageAdapter && (!s3AccessKeyId || !s3SecretAccessKey))) {
     throw new Error(
-      "Storage configuration is required for uploading to Mux. Provide s3Endpoint and s3Bucket. " +
+      "Storage configuration is required. Provide s3Endpoint and s3Bucket. " +
       "If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options " +
       "or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.",
     );
@@ -541,20 +543,6 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
       } :
     undefined;
 
-  // If not uploading, return early with the edited VTT
-  if (!uploadToMux) {
-    return {
-      assetId,
-      trackId,
-      originalVtt: vttContent,
-      editedVtt,
-      totalReplacementCount,
-      autoCensorProfanity: autoCensorResult,
-      replacements: replacementsResult,
-      usage: usageWithMetadata,
-    };
-  }
-
   // Upload edited VTT to S3-compatible storage
   let presignedUrl: string;
 
@@ -573,31 +561,33 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
     throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
   }
 
-  // Add edited track to Mux asset
+  // Add edited track to Mux asset (only when uploadToMux is true)
   let uploadedTrackId: string | undefined;
 
-  try {
-    const languageCode = sourceTrack.language_code || "en";
-    const suffix = trackNameSuffix ?? "edited";
-    const trackName = `${sourceTrack.name || "Subtitles"} (${suffix})`;
-
-    uploadedTrackId = await createTextTrackOnMux(
-      assetId,
-      languageCode,
-      trackName,
-      presignedUrl,
-      credentials,
-    );
-  } catch (error) {
-    console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
-  }
-
-  // Delete original track only if the replacement track was created
-  if (deleteOriginal && uploadedTrackId) {
+  if (uploadToMux) {
     try {
-      await deleteTrackOnMux(assetId, trackId, credentials);
+      const languageCode = sourceTrack.language_code || "en";
+      const suffix = trackNameSuffix ?? "edited";
+      const trackName = `${sourceTrack.name || "Subtitles"} (${suffix})`;
+
+      uploadedTrackId = await createTextTrackOnMux(
+        assetId,
+        languageCode,
+        trackName,
+        presignedUrl,
+        credentials,
+      );
     } catch (error) {
-      console.warn(`Failed to delete original track: ${error instanceof Error ? error.message : "Unknown error"}`);
+      console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+
+    // Delete original track only if the replacement track was created
+    if (deleteOriginal && uploadedTrackId) {
+      try {
+        await deleteTrackOnMux(assetId, trackId, credentials);
+      } catch (error) {
+        console.warn(`Failed to delete original track: ${error instanceof Error ? error.message : "Unknown error"}`);
+      }
     }
   }
 

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -57,7 +57,9 @@ export interface AudioTranslationOptions extends MuxAIOptions {
   s3Bucket?: string;
   /**
    * When true (default) the dubbed audio file is uploaded to the configured
-   * bucket and attached to the Mux asset.
+   * bucket and attached as a track on the Mux asset.
+   * When false the dubbed audio is still uploaded to S3 and a `presignedUrl`
+   * is returned, but no track is created on the Mux asset.
    */
   uploadToMux?: boolean;
   /** Optional storage adapter override for upload + presign operations. */
@@ -410,8 +412,8 @@ export async function translateAudio(
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
 
-  if (uploadToMux && (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
-    throw new Error("Storage configuration is required for uploading to Mux. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
+  if (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey))) {
+    throw new Error("Storage configuration is required. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
   }
 
   // Fetch asset data and playback ID from Mux
@@ -514,18 +516,6 @@ export async function translateAudio(
 
   console.warn("✅ Dubbing completed successfully!");
 
-  // If uploadToMux is false, just return the dubbing info
-  // Return ISO 639-1 (2-letter) code for consistency with Mux/player expectations
-  if (!uploadToMux) {
-    const targetLanguage = getLanguageCodePair(toLanguageCode);
-    return {
-      assetId,
-      targetLanguageCode: targetLanguage.iso639_1 as SupportedISO639_1,
-      targetLanguage,
-      dubbingId,
-    };
-  }
-
   // Download dubbed audio from ElevenLabs
   console.warn("📥 Downloading dubbed audio from ElevenLabs...");
 
@@ -586,23 +576,25 @@ export async function translateAudio(
     throw new Error(`Failed to upload audio to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
   }
 
-  // Add translated audio track to Mux asset
-  console.warn("📹 Adding dubbed audio track to Mux asset...");
-
+  // Add translated audio track to Mux asset (only when uploadToMux is true)
   let uploadedTrackId: string | undefined;
-  // Mux uses ISO 639-1 (2-letter) codes for track language_code
-  const muxLangCode = toISO639_1(toLanguageCode);
 
-  try {
-    uploadedTrackId = await createAudioTrackOnMux(assetId, muxLangCode, presignedUrl, credentials);
-    const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
-    const trackName = `${languageName} (auto-dubbed)`;
-    console.warn(`✅ Track added to Mux asset with ID: ${uploadedTrackId}`);
-    console.warn(`📋 Track name: "${trackName}"`);
-  } catch (error) {
-    console.warn(`⚠️ Failed to add audio track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
-    console.warn("🔗 You can manually add the track using this presigned URL:");
-    console.warn(presignedUrl);
+  if (uploadToMux) {
+    console.warn("📹 Adding dubbed audio track to Mux asset...");
+    // Mux uses ISO 639-1 (2-letter) codes for track language_code
+    const muxLangCode = toISO639_1(toLanguageCode);
+
+    try {
+      uploadedTrackId = await createAudioTrackOnMux(assetId, muxLangCode, presignedUrl, credentials);
+      const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
+      const trackName = `${languageName} (auto-dubbed)`;
+      console.warn(`✅ Track added to Mux asset with ID: ${uploadedTrackId}`);
+      console.warn(`📋 Track name: "${trackName}"`);
+    } catch (error) {
+      console.warn(`⚠️ Failed to add audio track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+      console.warn("🔗 You can manually add the track using this presigned URL:");
+      console.warn(presignedUrl);
+    }
   }
 
   const targetLanguage = getLanguageCodePair(toLanguageCode);

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -414,7 +414,7 @@ export async function translateAudio(
   const effectiveStorageAdapter = storageAdapter;
 
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = (uploadToS3Option ?? uploadToMux) || uploadToMux; // Default to uploadToMux; uploadToMux: true forces S3 upload
+  const uploadToS3 = uploadToS3Option || uploadToMux; // Defaults to uploadToMux; uploadToMux: true forces S3 upload
 
   // S3 configuration
   const s3Endpoint = options.s3Endpoint ?? env.S3_ENDPOINT;

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -413,7 +413,7 @@ export async function translateAudio(
   const effectiveStorageAdapter = storageAdapter;
 
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = uploadToS3Option !== false || uploadToMux; // Default to true; implied by uploadToMux
+  const uploadToS3 = uploadToS3Option ?? uploadToMux; // Default to uploadToMux; explicit true/false always wins
 
   // S3 configuration
   const s3Endpoint = options.s3Endpoint ?? env.S3_ENDPOINT;

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -56,10 +56,14 @@ export interface AudioTranslationOptions extends MuxAIOptions {
   /** Bucket that will store dubbed audio files. */
   s3Bucket?: string;
   /**
-   * When true (default) the dubbed audio file is uploaded to the configured
-   * bucket and attached as a track on the Mux asset.
-   * When false the dubbed audio is still uploaded to S3 and a `presignedUrl`
-   * is returned, but no track is created on the Mux asset.
+   * When true (default) the dubbed audio is uploaded to the configured
+   * S3-compatible bucket and a `presignedUrl` is returned.
+   */
+  uploadToS3?: boolean;
+  /**
+   * When true (default) the dubbed audio is attached as a track on the
+   * Mux asset. Implies `uploadToS3: true` because a presigned URL is
+   * required for track creation.
    */
   uploadToMux?: boolean;
   /** Optional storage adapter override for upload + presign operations. */
@@ -393,7 +397,8 @@ export async function translateAudio(
     provider = "elevenlabs",
     fromLanguageCode,
     numSpeakers = 0, // 0 = auto-detect
-    uploadToMux = true,
+    uploadToS3: uploadToS3Option,
+    uploadToMux: uploadToMuxOption,
     storageAdapter,
     credentials: providedCredentials,
   } = options;
@@ -405,6 +410,9 @@ export async function translateAudio(
   const credentials = providedCredentials;
   const effectiveStorageAdapter = storageAdapter;
 
+  const uploadToMux = uploadToMuxOption !== false; // Default to true
+  const uploadToS3 = uploadToS3Option !== false || uploadToMux; // Default to true; implied by uploadToMux
+
   // S3 configuration
   const s3Endpoint = options.s3Endpoint ?? env.S3_ENDPOINT;
   const s3Region = options.s3Region ?? env.S3_REGION ?? "auto";
@@ -412,8 +420,8 @@ export async function translateAudio(
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
 
-  if (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey))) {
-    throw new Error("Storage configuration is required. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
+  if (uploadToS3 && (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
+    throw new Error("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
   }
 
   // Fetch asset data and playback ID from Mux
@@ -516,84 +524,85 @@ export async function translateAudio(
 
   console.warn("✅ Dubbing completed successfully!");
 
-  // Download dubbed audio from ElevenLabs
-  console.warn("📥 Downloading dubbed audio from ElevenLabs...");
-
-  let dubbedAudioBuffer: ArrayBuffer;
-
-  try {
-    // Use the language code from the ElevenLabs status response
-    // ElevenLabs returns target_languages array with the exact codes available for download
-    const requestedLangCode = toISO639_3(toLanguageCode);
-
-    // Find the matching language code from ElevenLabs response
-    // First try exact match, then try case-insensitive match
-    let downloadLangCode = targetLanguages.find(
-      lang => lang === requestedLangCode,
-    ) ?? targetLanguages.find(
-      lang => lang.toLowerCase() === requestedLangCode.toLowerCase(),
-    );
-
-    // Fallback to first available target language if no match found
-    if (!downloadLangCode && targetLanguages.length > 0) {
-      downloadLangCode = targetLanguages[0];
-      console.warn(`⚠️ Requested language "${requestedLangCode}" not found in target_languages. Using "${downloadLangCode}" instead.`);
-    }
-
-    // If still no language code, fall back to the original behavior
-    if (!downloadLangCode) {
-      downloadLangCode = requestedLangCode;
-      console.warn(`⚠️ No target_languages available from ElevenLabs status. Using requested language code: ${requestedLangCode}`);
-    }
-
-    dubbedAudioBuffer = await downloadDubbedAudioFromElevenLabs({
-      dubbingId,
-      languageCode: downloadLangCode,
-      credentials,
-    });
-    console.warn("✅ Dubbed audio downloaded successfully!");
-  } catch (error) {
-    throw new Error(`Failed to download dubbed audio: ${error instanceof Error ? error.message : "Unknown error"}`);
-  }
-
-  // Upload to S3-compatible storage
-  console.warn("📤 Uploading dubbed audio to S3-compatible storage...");
-
-  let presignedUrl: string;
-
-  try {
-    presignedUrl = await uploadDubbedAudioToS3({
-      dubbedAudioBuffer,
-      assetId,
-      toLanguageCode,
-      s3Endpoint: s3Endpoint!,
-      s3Region,
-      s3Bucket: s3Bucket!,
-      storageAdapter: effectiveStorageAdapter,
-      s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
-    });
-  } catch (error) {
-    throw new Error(`Failed to upload audio to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
-  }
-
-  // Add translated audio track to Mux asset (only when uploadToMux is true)
+  let presignedUrl: string | undefined;
   let uploadedTrackId: string | undefined;
 
-  if (uploadToMux) {
-    console.warn("📹 Adding dubbed audio track to Mux asset...");
-    // Mux uses ISO 639-1 (2-letter) codes for track language_code
-    const muxLangCode = toISO639_1(toLanguageCode);
+  if (uploadToS3) {
+    // Download dubbed audio from ElevenLabs
+    console.warn("📥 Downloading dubbed audio from ElevenLabs...");
+
+    let dubbedAudioBuffer: ArrayBuffer;
 
     try {
-      uploadedTrackId = await createAudioTrackOnMux(assetId, muxLangCode, presignedUrl, credentials);
-      const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
-      const trackName = `${languageName} (auto-dubbed)`;
-      console.warn(`✅ Track added to Mux asset with ID: ${uploadedTrackId}`);
-      console.warn(`📋 Track name: "${trackName}"`);
+      // Use the language code from the ElevenLabs status response
+      // ElevenLabs returns target_languages array with the exact codes available for download
+      const requestedLangCode = toISO639_3(toLanguageCode);
+
+      // Find the matching language code from ElevenLabs response
+      // First try exact match, then try case-insensitive match
+      let downloadLangCode = targetLanguages.find(
+        lang => lang === requestedLangCode,
+      ) ?? targetLanguages.find(
+        lang => lang.toLowerCase() === requestedLangCode.toLowerCase(),
+      );
+
+      // Fallback to first available target language if no match found
+      if (!downloadLangCode && targetLanguages.length > 0) {
+        downloadLangCode = targetLanguages[0];
+        console.warn(`⚠️ Requested language "${requestedLangCode}" not found in target_languages. Using "${downloadLangCode}" instead.`);
+      }
+
+      // If still no language code, fall back to the original behavior
+      if (!downloadLangCode) {
+        downloadLangCode = requestedLangCode;
+        console.warn(`⚠️ No target_languages available from ElevenLabs status. Using requested language code: ${requestedLangCode}`);
+      }
+
+      dubbedAudioBuffer = await downloadDubbedAudioFromElevenLabs({
+        dubbingId,
+        languageCode: downloadLangCode,
+        credentials,
+      });
+      console.warn("✅ Dubbed audio downloaded successfully!");
     } catch (error) {
-      console.warn(`⚠️ Failed to add audio track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
-      console.warn("🔗 You can manually add the track using this presigned URL:");
-      console.warn(presignedUrl);
+      throw new Error(`Failed to download dubbed audio: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+
+    // Upload to S3-compatible storage
+    console.warn("📤 Uploading dubbed audio to S3-compatible storage...");
+
+    try {
+      presignedUrl = await uploadDubbedAudioToS3({
+        dubbedAudioBuffer,
+        assetId,
+        toLanguageCode,
+        s3Endpoint: s3Endpoint!,
+        s3Region,
+        s3Bucket: s3Bucket!,
+        storageAdapter: effectiveStorageAdapter,
+        s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
+      });
+    } catch (error) {
+      throw new Error(`Failed to upload audio to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+
+    // Add translated audio track to Mux asset (only when uploadToMux is true)
+    if (uploadToMux) {
+      console.warn("📹 Adding dubbed audio track to Mux asset...");
+      // Mux uses ISO 639-1 (2-letter) codes for track language_code
+      const muxLangCode = toISO639_1(toLanguageCode);
+
+      try {
+        uploadedTrackId = await createAudioTrackOnMux(assetId, muxLangCode, presignedUrl, credentials);
+        const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
+        const trackName = `${languageName} (auto-dubbed)`;
+        console.warn(`✅ Track added to Mux asset with ID: ${uploadedTrackId}`);
+        console.warn(`📋 Track name: "${trackName}"`);
+      } catch (error) {
+        console.warn(`⚠️ Failed to add audio track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+        console.warn("🔗 You can manually add the track using this presigned URL:");
+        console.warn(presignedUrl);
+      }
     }
   }
 

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -413,7 +413,7 @@ export async function translateAudio(
   const effectiveStorageAdapter = storageAdapter;
 
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = uploadToS3Option ?? uploadToMux; // Default to uploadToMux; explicit true/false always wins
+  const uploadToS3 = (uploadToS3Option ?? uploadToMux) || uploadToMux; // Default to uploadToMux; uploadToMux: true forces S3 upload
 
   // S3 configuration
   const s3Endpoint = options.s3Endpoint ?? env.S3_ENDPOINT;

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -58,6 +58,8 @@ export interface AudioTranslationOptions extends MuxAIOptions {
   /**
    * When true (default) the dubbed audio is uploaded to the configured
    * S3-compatible bucket and a `presignedUrl` is returned.
+   * Note: even when explicitly set to `false`, S3 upload still occurs if
+   * `uploadToMux` is `true` (since Mux track creation requires a presigned URL).
    */
   uploadToS3?: boolean;
   /**

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -56,10 +56,11 @@ export interface AudioTranslationOptions extends MuxAIOptions {
   /** Bucket that will store dubbed audio files. */
   s3Bucket?: string;
   /**
-   * When true (default) the dubbed audio is uploaded to the configured
+   * When `true` the dubbed audio is uploaded to the configured
    * S3-compatible bucket and a `presignedUrl` is returned.
-   * Note: even when explicitly set to `false`, S3 upload still occurs if
-   * `uploadToMux` is `true` (since Mux track creation requires a presigned URL).
+   * Defaults to the value of `uploadToMux` when omitted.
+   * Ignored (treated as `true`) when `uploadToMux` is `true`,
+   * since Mux track creation requires a presigned URL.
    */
   uploadToS3?: boolean;
   /**

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -87,9 +87,13 @@ export interface TranslationOptions<P extends SupportedProvider = SupportedProvi
   s3Bucket?: string;
   /**
    * When true (default) the translated VTT is uploaded to the configured
-   * bucket and attached as a track on the Mux asset.
-   * When false the translation is still uploaded to S3 and a `presignedUrl`
-   * is returned, but no track is created on the Mux asset.
+   * S3-compatible bucket and a `presignedUrl` is returned.
+   */
+  uploadToS3?: boolean;
+  /**
+   * When true (default) the translated VTT is attached as a track on the
+   * Mux asset. Implies `uploadToS3: true` because a presigned URL is
+   * required for track creation.
    */
   uploadToMux?: boolean;
   /** Optional storage adapter override for upload + presign operations. */
@@ -689,6 +693,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     s3Endpoint: providedS3Endpoint,
     s3Region: providedS3Region,
     s3Bucket: providedS3Bucket,
+    uploadToS3: uploadToS3Option,
     uploadToMux: uploadToMuxOption,
     storageAdapter,
     credentials: providedCredentials,
@@ -704,6 +709,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
   const uploadToMux = uploadToMuxOption !== false; // Default to true
+  const uploadToS3 = uploadToS3Option !== false || uploadToMux; // Default to true; implied by uploadToMux
 
   const modelConfig = resolveLanguageModelConfig({
     ...options,
@@ -711,8 +717,8 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     provider: provider as SupportedProvider,
   });
 
-  if (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey))) {
-    throw new Error("Storage configuration is required. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
+  if (uploadToS3 && (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
+    throw new Error("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
   }
 
   // Fetch asset data and playback ID from Mux
@@ -810,41 +816,42 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   const targetLanguage = getLanguageCodePair(toLanguageCode);
 
   // Upload translated VTT to S3-compatible storage
-  let presignedUrl: string;
-
-  try {
-    presignedUrl = await uploadVttToS3({
-      translatedVtt,
-      assetId,
-      fromLanguageCode,
-      toLanguageCode,
-      s3Endpoint: s3Endpoint!,
-      s3Region,
-      s3Bucket: s3Bucket!,
-      storageAdapter: effectiveStorageAdapter,
-      s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
-    });
-  } catch (error) {
-    throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
-  }
-
-  // Add translated track to Mux asset (only when uploadToMux is true)
+  let presignedUrl: string | undefined;
   let uploadedTrackId: string | undefined;
 
-  if (uploadToMux) {
+  if (uploadToS3) {
     try {
-      const languageName = getLanguageName(toLanguageCode);
-      const trackName = `${languageName} (auto-translated)`;
-
-      uploadedTrackId = await createTextTrackOnMux(
+      presignedUrl = await uploadVttToS3({
+        translatedVtt,
         assetId,
+        fromLanguageCode,
         toLanguageCode,
-        trackName,
-        presignedUrl,
-        credentials,
-      );
+        s3Endpoint: s3Endpoint!,
+        s3Region,
+        s3Bucket: s3Bucket!,
+        storageAdapter: effectiveStorageAdapter,
+        s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
+      });
     } catch (error) {
-      console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+      throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+
+    // Add translated track to Mux asset (only when uploadToMux is true)
+    if (uploadToMux) {
+      try {
+        const languageName = getLanguageName(toLanguageCode);
+        const trackName = `${languageName} (auto-translated)`;
+
+        uploadedTrackId = await createTextTrackOnMux(
+          assetId,
+          toLanguageCode,
+          trackName,
+          presignedUrl,
+          credentials,
+        );
+      } catch (error) {
+        console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+      }
     }
   }
 

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -711,7 +711,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = uploadToS3Option !== false || uploadToMux; // Default to true; implied by uploadToMux
+  const uploadToS3 = uploadToS3Option ?? uploadToMux; // Default to uploadToMux; explicit true/false always wins
 
   const modelConfig = resolveLanguageModelConfig({
     ...options,

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -88,6 +88,8 @@ export interface TranslationOptions<P extends SupportedProvider = SupportedProvi
   /**
    * When true (default) the translated VTT is uploaded to the configured
    * S3-compatible bucket and a `presignedUrl` is returned.
+   * Note: even when explicitly set to `false`, S3 upload still occurs if
+   * `uploadToMux` is `true` (since Mux track creation requires a presigned URL).
    */
   uploadToS3?: boolean;
   /**

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -87,7 +87,9 @@ export interface TranslationOptions<P extends SupportedProvider = SupportedProvi
   s3Bucket?: string;
   /**
    * When true (default) the translated VTT is uploaded to the configured
-   * bucket and attached to the Mux asset.
+   * bucket and attached as a track on the Mux asset.
+   * When false the translation is still uploaded to S3 and a `presignedUrl`
+   * is returned, but no track is created on the Mux asset.
    */
   uploadToMux?: boolean;
   /** Optional storage adapter override for upload + presign operations. */
@@ -709,8 +711,8 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     provider: provider as SupportedProvider,
   });
 
-  if (uploadToMux && (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
-    throw new Error("Storage configuration is required for uploading to Mux. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
+  if (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey))) {
+    throw new Error("Storage configuration is required. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
   }
 
   // Fetch asset data and playback ID from Mux
@@ -807,20 +809,6 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   const sourceLanguage = getLanguageCodePair(fromLanguageCode);
   const targetLanguage = getLanguageCodePair(toLanguageCode);
 
-  // If uploadToMux is false, just return the translation
-  if (!uploadToMux) {
-    return {
-      assetId,
-      sourceLanguageCode: fromLanguageCode as SupportedISO639_1,
-      targetLanguageCode: toLanguageCode as SupportedISO639_1,
-      sourceLanguage,
-      targetLanguage,
-      originalVtt: vttContent,
-      translatedVtt,
-      usage: usageWithMetadata,
-    };
-  }
-
   // Upload translated VTT to S3-compatible storage
   let presignedUrl: string;
 
@@ -840,22 +828,24 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
   }
 
-  // Add translated track to Mux asset
+  // Add translated track to Mux asset (only when uploadToMux is true)
   let uploadedTrackId: string | undefined;
 
-  try {
-    const languageName = getLanguageName(toLanguageCode);
-    const trackName = `${languageName} (auto-translated)`;
+  if (uploadToMux) {
+    try {
+      const languageName = getLanguageName(toLanguageCode);
+      const trackName = `${languageName} (auto-translated)`;
 
-    uploadedTrackId = await createTextTrackOnMux(
-      assetId,
-      toLanguageCode,
-      trackName,
-      presignedUrl,
-      credentials,
-    );
-  } catch (error) {
-    console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+      uploadedTrackId = await createTextTrackOnMux(
+        assetId,
+        toLanguageCode,
+        trackName,
+        presignedUrl,
+        credentials,
+      );
+    } catch (error) {
+      console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
   }
 
   return {

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -711,7 +711,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = uploadToS3Option ?? uploadToMux; // Default to uploadToMux; explicit true/false always wins
+  const uploadToS3 = (uploadToS3Option ?? uploadToMux) || uploadToMux; // Default to uploadToMux; uploadToMux: true forces S3 upload
 
   const modelConfig = resolveLanguageModelConfig({
     ...options,

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -86,10 +86,11 @@ export interface TranslationOptions<P extends SupportedProvider = SupportedProvi
   /** Bucket that will store translated VTT files. */
   s3Bucket?: string;
   /**
-   * When true (default) the translated VTT is uploaded to the configured
+   * When `true` the translated VTT is uploaded to the configured
    * S3-compatible bucket and a `presignedUrl` is returned.
-   * Note: even when explicitly set to `false`, S3 upload still occurs if
-   * `uploadToMux` is `true` (since Mux track creation requires a presigned URL).
+   * Defaults to the value of `uploadToMux` when omitted.
+   * Ignored (treated as `true`) when `uploadToMux` is `true`,
+   * since Mux track creation requires a presigned URL.
    */
   uploadToS3?: boolean;
   /**

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -712,7 +712,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = (uploadToS3Option ?? uploadToMux) || uploadToMux; // Default to uploadToMux; uploadToMux: true forces S3 upload
+  const uploadToS3 = uploadToS3Option || uploadToMux; // Defaults to uploadToMux; uploadToMux: true forces S3 upload
 
   const modelConfig = resolveLanguageModelConfig({
     ...options,

--- a/tests/eval/translate-captions.eval.ts
+++ b/tests/eval/translate-captions.eval.ts
@@ -320,7 +320,8 @@ evalite("Caption Translation", {
     const result = await translateCaptions(assetId, sourceLanguage, targetLanguage, {
       provider,
       model,
-      uploadToMux: false, // Don't upload during evals
+      uploadToS3: false, // Don't upload during evals
+      uploadToMux: false,
     });
     const latencyMs = performance.now() - startTime;
 

--- a/tests/integration/translate-audio.test.ts
+++ b/tests/integration/translate-audio.test.ts
@@ -9,6 +9,7 @@ describe("audio Translation Integration Tests", () => {
   it("should translate audio to French without uploading to Mux", async () => {
     const result = await translateAudio(assetId, "fr", {
       provider: "elevenlabs",
+      uploadToS3: false,
       uploadToMux: false,
     });
 
@@ -30,9 +31,8 @@ describe("audio Translation Integration Tests", () => {
     expect(typeof result.dubbingId).toBe("string");
     expect(result.dubbingId.length).toBeGreaterThan(0);
 
-    // Since uploadToMux is false, no Mux track should be created
+    // Since both uploadToS3 and uploadToMux are false, neither should be present
     expect(result.uploadedTrackId).toBeUndefined();
-    // But presignedUrl should still be present (S3 upload always happens)
-    expect(result.presignedUrl).toBeDefined();
+    expect(result.presignedUrl).toBeUndefined();
   }, 600000); // 10 minute timeout for ElevenLabs processing
 });

--- a/tests/integration/translate-audio.test.ts
+++ b/tests/integration/translate-audio.test.ts
@@ -30,8 +30,9 @@ describe("audio Translation Integration Tests", () => {
     expect(typeof result.dubbingId).toBe("string");
     expect(result.dubbingId.length).toBeGreaterThan(0);
 
-    // Since uploadToMux is false, these should not be present
+    // Since uploadToMux is false, no Mux track should be created
     expect(result.uploadedTrackId).toBeUndefined();
-    expect(result.presignedUrl).toBeUndefined();
+    // But presignedUrl should still be present (S3 upload always happens)
+    expect(result.presignedUrl).toBeDefined();
   }, 600000); // 10 minute timeout for ElevenLabs processing
 });

--- a/tests/integration/translate-audio.test.workflowdevkit.ts
+++ b/tests/integration/translate-audio.test.workflowdevkit.ts
@@ -10,6 +10,7 @@ describe("audio Translation Integration Tests for Workflow DevKit", () => {
   it("should translate audio to French without uploading to Mux", async () => {
     const run = await start(translateAudio, [assetId, "fr", {
       provider: "elevenlabs",
+      uploadToS3: false,
       uploadToMux: false,
     }]);
     expect(run.runId).toMatch(/^wrun_/);
@@ -33,9 +34,8 @@ describe("audio Translation Integration Tests for Workflow DevKit", () => {
     expect(typeof result.dubbingId).toBe("string");
     expect(result.dubbingId.length).toBeGreaterThan(0);
 
-    // Since uploadToMux is false, no Mux track should be created
+    // Since both uploadToS3 and uploadToMux are false, neither should be present
     expect(result.uploadedTrackId).toBeUndefined();
-    // But presignedUrl should still be present (S3 upload always happens)
-    expect(result.presignedUrl).toBeDefined();
+    expect(result.presignedUrl).toBeUndefined();
   }, 300000); // 5 minute timeout for ElevenLabs processing
 });

--- a/tests/integration/translate-audio.test.workflowdevkit.ts
+++ b/tests/integration/translate-audio.test.workflowdevkit.ts
@@ -33,8 +33,9 @@ describe("audio Translation Integration Tests for Workflow DevKit", () => {
     expect(typeof result.dubbingId).toBe("string");
     expect(result.dubbingId.length).toBeGreaterThan(0);
 
-    // Since uploadToMux is false, these should not be present
+    // Since uploadToMux is false, no Mux track should be created
     expect(result.uploadedTrackId).toBeUndefined();
-    expect(result.presignedUrl).toBeUndefined();
+    // But presignedUrl should still be present (S3 upload always happens)
+    expect(result.presignedUrl).toBeDefined();
   }, 300000); // 5 minute timeout for ElevenLabs processing
 });

--- a/tests/integration/translate-captions.test.ts
+++ b/tests/integration/translate-captions.test.ts
@@ -11,6 +11,7 @@ describe("translateCaptions Integration Tests", () => {
   it.each(providers)("should return valid result for %s provider", async (provider) => {
     const result = await translateCaptions(testAssetId, "en", "fr", {
       provider,
+      uploadToS3: false,
       uploadToMux: false,
     });
 

--- a/tests/integration/translate-captions.test.workflowdevkit.ts
+++ b/tests/integration/translate-captions.test.workflowdevkit.ts
@@ -56,8 +56,9 @@ describe("Caption Translation Integration Tests for Workflow DevKit", () => {
     expect(result.usage?.inputTokens).toBeGreaterThan(0);
     expect(result.usage?.outputTokens).toBeGreaterThan(0);
 
-    // Since uploadToMux is false, these should not be present
+    // Since uploadToMux is false, no Mux track should be created
     expect(result.uploadedTrackId).toBeUndefined();
-    expect(result.presignedUrl).toBeUndefined();
+    // But presignedUrl should still be present (S3 upload always happens)
+    expect(result.presignedUrl).toBeDefined();
   }, 120000); // 2 minute timeout for AI processing
 });

--- a/tests/integration/translate-captions.test.workflowdevkit.ts
+++ b/tests/integration/translate-captions.test.workflowdevkit.ts
@@ -12,6 +12,7 @@ describe("Caption Translation Integration Tests for Workflow DevKit", () => {
   it.each(providers)("should translate captions to French with %s provider without uploading to Mux", async (provider) => {
     const run = await start(translateCaptions, [assetId, "en", "fr", {
       provider,
+      uploadToS3: false,
       uploadToMux: false,
     }]);
     expect(run.runId).toMatch(/^wrun_/);
@@ -56,9 +57,8 @@ describe("Caption Translation Integration Tests for Workflow DevKit", () => {
     expect(result.usage?.inputTokens).toBeGreaterThan(0);
     expect(result.usage?.outputTokens).toBeGreaterThan(0);
 
-    // Since uploadToMux is false, no Mux track should be created
+    // Since both uploadToS3 and uploadToMux are false, neither should be present
     expect(result.uploadedTrackId).toBeUndefined();
-    // But presignedUrl should still be present (S3 upload always happens)
-    expect(result.presignedUrl).toBeDefined();
+    expect(result.presignedUrl).toBeUndefined();
   }, 120000); // 2 minute timeout for AI processing
 });


### PR DESCRIPTION
# Overview

Add a new `uploadToS3` flag alongside the existing `uploadToMux` flag in `translate-captions`, `translate-audio`, and `edit-captions`. The two flags are independent: `uploadToS3` controls whether the result is uploaded to S3 (and a `presignedUrl` returned), while `uploadToMux` controls whether a track is attached to the Mux asset. Both default to `true` for backwards compatibility. `uploadToMux: true` implies `uploadToS3: true` since Mux track creation requires a presigned URL.

# What was changed

- **`translate-captions.ts`**, **`translate-audio.ts`**, **`edit-captions.ts`** — Added `uploadToS3?: boolean` to each options interface. S3 validation and upload are now gated behind `uploadToS3`. Mux track creation is nested inside the `uploadToS3` block and further gated by `uploadToMux`. Both default to `true`.
- **Integration tests** and **eval** — Updated to pass `uploadToS3: false` alongside `uploadToMux: false` to preserve the original intent of skipping all uploads.

# Suggested review order

1. [translate-captions.ts](src/workflows/translate-captions.ts) — Core pattern (options interface + flag logic + conditional blocks)
2. [translate-audio.ts](src/workflows/translate-audio.ts) — Same pattern; ElevenLabs download also gated behind `uploadToS3`
3. [edit-captions.ts](src/workflows/edit-captions.ts) — Same pattern; `deleteOriginalTrack` nested under `uploadToMux`
4. Test/eval files — Flag additions and assertion updates


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes control flow around uploading/downloading and Mux track creation; mis-set defaults or falsy handling could skip uploads or Mux attachment unexpectedly. Backwards compatibility is intended via defaults, but the new `uploadToS3`/`uploadToMux` interaction needs careful review.
> 
> **Overview**
> Introduces a new `uploadToS3?: boolean` option in `translate-captions`, `translate-audio`, and `edit-captions` to **separate S3 upload + `presignedUrl` generation** from **Mux track attachment**.
> 
> Refactors each workflow so **S3 config validation and upload (and in `translateAudio`, the ElevenLabs dubbed-audio download) only run when `uploadToS3` is enabled**, while **Mux track creation (and `editCaptions` original-track deletion) is nested under `uploadToMux`**; `uploadToMux: true` effectively forces S3 upload for presigned URL requirements.
> 
> Updates eval/integration tests to pass `uploadToS3: false` alongside `uploadToMux: false` and adjusts assertions to ensure neither `presignedUrl` nor `uploadedTrackId` is returned when both are disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce58653c9420acf005ba51dd08187f18ae2e43b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->