### PR TITLE
feat!: Major changes in track selection and fallback behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ if (result.exceedsThreshold) {
 ```ts
 import { generateChapters } from "@mux/ai/workflows";
 
-const result = await generateChapters("your-asset-id", "en", {
+const result = await generateChapters("your-asset-id", {
   provider: "anthropic"
 });
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -16,6 +16,7 @@ Analyzes a Mux video or audio asset and returns AI-generated metadata.
 - `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
 - `tone?: 'neutral' | 'playful' | 'professional'` - Analysis tone (default: 'neutral')
 - `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
+- `languageCode?: string` - Language code for transcript track selection (e.g., 'en', 'fr'). When omitted, prefers English if available.
 - `includeTranscript?: boolean` - Include transcript in analysis (default: true)
 - `cleanTranscript?: boolean` - Remove VTT timestamps and formatting from transcript (default: true)
 - `imageSubmissionMode?: 'url' | 'base64'` - How to submit storyboard to AI providers (default: 'url')
@@ -169,6 +170,7 @@ Answer questions about video content by analyzing storyboard frames and optional
 
 - `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
 - `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
+- `languageCode?: string` - Language code for transcript track selection (e.g., 'en', 'fr'). When omitted, prefers English if available.
 - `answerOptions?: string[]` - Allowed answers (default: `["yes", "no"]`)
 - `includeTranscript?: boolean` - Include video transcript in analysis (default: true)
 - `cleanTranscript?: boolean` - Remove VTT timestamps and formatting from transcript (default: true)
@@ -317,14 +319,14 @@ const result = await generateEngagementInsights("asset-id", {
 - A/B testing video variations
 - Providing engagement feedback to content creators
 
-## `translateCaptions(assetId, fromLanguageCode, toLanguageCode, options?)`
+## `translateCaptions(assetId, trackId, toLanguageCode, options?)`
 
-Translates existing captions from one language to another and optionally adds them as a new track to the Mux asset.
+Translates existing captions from one language to another and optionally adds them as a new track to the Mux asset. The source language is inferred from the track's metadata.
 
 **Parameters:**
 
 - `assetId` (string) - Mux asset ID (video or audio-only)
-- `fromLanguageCode` (string) - Source language code (e.g., 'en', 'es', 'fr')
+- `trackId` (string) - ID of the source caption track to translate
 - `toLanguageCode` (string) - Target language code (e.g., 'es', 'fr', 'de')
 - `options` - Configuration options
 
@@ -349,9 +351,10 @@ Translates existing captions from one language to another and optionally adds th
 **Returns:**
 
 ```typescript
-interface TranslateCaptionsResult {
+interface TranslationResult {
   assetId: string;
-  sourceLanguageCode: string;
+  trackId: string; // Source track ID
+  sourceLanguageCode: string; // Inferred from track metadata
   targetLanguageCode: string;
   sourceLanguage: LanguageCodePair; // { iso639_1: string; iso639_3: string }
   targetLanguage: LanguageCodePair; // { iso639_1: string; iso639_3: string }
@@ -433,18 +436,18 @@ interface EditCaptionsResult {
 }
 ```
 
-## `generateChapters(assetId, languageCode, options?)`
+## `generateChapters(assetId, options?)`
 
 Generates AI-powered chapter markers by analyzing video or audio transcripts. Creates logical chapter breaks based on topic changes and content transitions.
 
 **Parameters:**
 
 - `assetId` (string) - Mux asset ID (video or audio-only)
-- `languageCode` (string) - Language code for captions (e.g., 'en', 'es', 'fr')
 - `options` (optional) - Configuration options
 
 **Options:**
 
+- `languageCode?: string` - Language code for captions (e.g., 'en', 'es', 'fr'). When omitted, prefers English if available.
 - `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
 - `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `promptOverrides?: object` - Override specific sections of the chaptering prompt
@@ -460,7 +463,7 @@ Generates AI-powered chapter markers by analyzing video or audio transcripts. Cr
 ```typescript
 {
   assetId: string;
-  languageCode: string;
+  languageCode?: string; // Resolved from input or track metadata
   chapters: Array<{
     startTime: number; // Chapter start time in seconds
     title: string; // Descriptive chapter title
@@ -471,7 +474,8 @@ Generates AI-powered chapter markers by analyzing video or audio transcripts. Cr
 
 **Requirements:**
 
-- Asset must have a ready caption/transcript track in the specified language
+- Asset must have a ready caption/transcript track
+- When `languageCode` is omitted, prefers an English track if available
 - Uses existing auto-generated or uploaded captions/transcripts
 
 **Example Output:**
@@ -551,7 +555,7 @@ Generate vector embeddings for transcript chunks from video or audio assets for 
   - `maxTokens?: number` - Maximum tokens per chunk (default: 500)
   - `overlap?: number` - Token overlap between chunks (for type: 'token', default: 100)
   - `overlapCues?: number` - VTT cue overlap between chunks (for type: 'vtt', default: 2)
-- `languageCode?: string` - Language code for transcript (default: first available track)
+- `languageCode?: string` - Language code for transcript track selection. When omitted, prefers English if available.
 - `batchSize?: number` - Maximum number of chunks to process concurrently (default: 5)
 
 **Returns:**

--- a/docs/AUDIO-ONLY.md
+++ b/docs/AUDIO-ONLY.md
@@ -36,7 +36,7 @@ Chapters are generated from the transcript with timestamps. If the asset has a s
 ```typescript
 import { generateChapters } from "@mux/ai/workflows";
 
-const result = await generateChapters("your-audio-only-asset-id", "en", {
+const result = await generateChapters("your-audio-only-asset-id", {
   provider: "openai",
 });
 ```
@@ -56,12 +56,12 @@ const result = await generateEmbeddings("your-audio-only-asset-id", {
 
 ### Caption Translation (`translateCaptions`)
 
-Translate a transcript VTT to another language and optionally upload back to Mux. Audio-only assets can use the single available text track.
+Translate a transcript VTT to another language and optionally upload back to Mux.
 
 ```typescript
 import { translateCaptions } from "@mux/ai/workflows";
 
-const result = await translateCaptions("your-audio-only-asset-id", "en", "es", {
+const result = await translateCaptions("your-audio-only-asset-id", "your-track-id", "es", {
   provider: "google",
 });
 ```

--- a/docs/PROMPT-CUSTOMIZATION.md
+++ b/docs/PROMPT-CUSTOMIZATION.md
@@ -102,7 +102,7 @@ const result = await getSummaryAndTags(assetId, {
 ### Chapter Title Style
 
 ```ts
-const result = await generateChapters(assetId, "en", {
+const result = await generateChapters(assetId, {
   provider: "openai",
   promptOverrides: {
     titleGuidelines: "Use short, punchy titles under 6 words. Start with an action verb.",

--- a/docs/STORAGE-ADAPTERS.md
+++ b/docs/STORAGE-ADAPTERS.md
@@ -25,7 +25,7 @@ import {
   workflows,
 } from "@mux/ai";
 
-await workflows.translateCaptions(assetId, "en", "es", {
+await workflows.translateCaptions(assetId, "your-track-id", "es", {
   provider: "openai",
   s3Endpoint: "https://s3.amazonaws.com",
   s3Bucket: "my-bucket",
@@ -72,7 +72,7 @@ const adapter: StorageAdapter = {
 ```typescript
 import { workflows } from "@mux/ai";
 
-await workflows.translateCaptions(assetId, "en", "es", {
+await workflows.translateCaptions(assetId, "your-track-id", "es", {
   provider: "openai",
   s3Endpoint: "https://s3.amazonaws.com",
   s3Bucket: "my-bucket",

--- a/docs/WORKFLOW-ENCRYPTION.md
+++ b/docs/WORKFLOW-ENCRYPTION.md
@@ -85,7 +85,7 @@ Use `createWorkflowStorageClient(...)` when you need a workflow-compatible adapt
 ```ts
 import { createWorkflowStorageClient, workflows } from "@mux/ai";
 
-await workflows.translateCaptions(assetId, "en", "es", {
+await workflows.translateCaptions(assetId, "your-track-id", "es", {
   provider: "openai",
   s3Endpoint: "https://s3.amazonaws.com",
   s3Bucket: "my-bucket",

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -321,7 +321,7 @@ Generate AI-powered chapter markers from video or audio transcripts.
 ```typescript
 import { generateChapters } from "@mux/ai/workflows";
 
-const result = await generateChapters("your-mux-asset-id", "en", {
+const result = await generateChapters("your-mux-asset-id", {
   provider: "openai"
 });
 
@@ -334,7 +334,8 @@ player.addChapters(result.chapters);
 
 ### Requirements
 
-- Asset must have a ready caption/transcript track in the specified language
+- Asset must have a ready caption/transcript track
+- When `languageCode` is omitted, prefers an English track if available
 - Uses existing auto-generated or uploaded captions/transcripts
 
 ## Embeddings
@@ -401,11 +402,11 @@ Translate existing captions to different languages and add as new tracks (video 
 ```typescript
 import { translateCaptions } from "@mux/ai/workflows";
 
-// Translate English to Spanish and upload to Mux
+// Translate a caption track to Spanish and upload to Mux
 const result = await translateCaptions(
   "your-mux-asset-id",
-  "en", // from language
-  "es", // to language
+  "your-track-id", // source caption track ID
+  "es", // target language
   {
     provider: "google",
     model: "gemini-3-flash-preview"
@@ -421,7 +422,7 @@ By default, `translateCaptions` uses VTT-aware chunking for longer assets. It pr
 
 ```typescript
 // Override chunking behavior for large assets
-const result = await translateCaptions("your-mux-asset-id", "en", "es", {
+const result = await translateCaptions("your-mux-asset-id", "your-track-id", "es", {
   provider: "anthropic",
   chunking: {
     enabled: true,
@@ -464,7 +465,7 @@ S3_SECRET_ACCESS_KEY=your-secret-key
 `s3Endpoint`, `s3Region` and `s3Bucket` can also be used to override the environment varialbes
 
 ```typescript
-const result = await translateCaptions(assetId, "en", "es", {
+const result = await translateCaptions(assetId, "your-track-id", "es", {
   provider: "anthropic",
   s3Endpoint: "https://your-endpoint.com",
   s3Region: "auto",
@@ -685,17 +686,17 @@ Works with any workflow:
 import { generateChapters } from "@mux/ai/workflows";
 
 // OpenAI (default: gpt-5.1)
-const openaiChapters = await generateChapters(assetId, "en", {
+const openaiChapters = await generateChapters(assetId, {
   provider: "openai"
 });
 
 // Anthropic (default: claude-sonnet-4-5)
-const anthropicChapters = await generateChapters(assetId, "en", {
+const anthropicChapters = await generateChapters(assetId, {
   provider: "anthropic"
 });
 
 // Google (default: gemini-3-flash-preview)
-const googleChapters = await generateChapters(assetId, "en", {
+const googleChapters = await generateChapters(assetId, {
   provider: "google"
 });
 ```

--- a/examples/chapters/basic-example.ts
+++ b/examples/chapters/basic-example.ts
@@ -36,8 +36,9 @@ program
     try {
       const start = Date.now();
 
-      const result = await generateChapters(assetId, options.language, {
+      const result = await generateChapters(assetId, {
         provider: options.provider,
+        languageCode: options.language,
         outputLanguageCode: options.outputLanguage,
         promptOverrides: {
           titleGuidelines: "Use concise titles under 6 words.",

--- a/examples/chapters/provider-comparison.ts
+++ b/examples/chapters/provider-comparison.ts
@@ -30,7 +30,7 @@ program
       for (const config of providers) {
         console.log(`Testing ${config.name} chapter generation...`);
         const start = Date.now();
-        const result = await generateChapters(assetId, options.language, { provider: config.provider });
+        const result = await generateChapters(assetId, { provider: config.provider, languageCode: options.language });
         const duration = Date.now() - start;
 
         console.log("📊 Results:");

--- a/examples/translate-captions/aws-sdk-storage-adapter-example.ts
+++ b/examples/translate-captions/aws-sdk-storage-adapter-example.ts
@@ -70,7 +70,7 @@ program
   .name("translate-captions-aws-sdk")
   .description("Translate captions using AWS SDK v3 via storageAdapter")
   .argument("<asset-id>", "Mux asset ID to translate")
-  .option("-f, --from <language>", "Source language code", "en")
+  .requiredOption("--track <trackId>", "Source text track ID")
   .option("-t, --to <language>", "Target language code", "es")
   .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "anthropic")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
@@ -78,7 +78,7 @@ program
   .option("--s3-region <region>", "S3 region", process.env.S3_REGION ?? "us-east-1")
   .option("--s3-bucket <name>", "S3 bucket", process.env.S3_BUCKET)
   .action(async (assetId: string, options: {
-    from: string;
+    track: string;
     to: string;
     provider: Provider;
     model?: string;
@@ -100,14 +100,15 @@ program
     const storageAdapter = createAwsSdkStorageAdapter();
 
     console.log(`Asset ID: ${assetId}`);
-    console.log(`Translation: ${options.from} -> ${options.to}`);
+    console.log(`Track ID: ${options.track}`);
+    console.log(`Target language: ${options.to}`);
     console.log(`Provider: ${options.provider} (${model})`);
     console.log(`S3 endpoint: ${options.s3Endpoint}`);
     console.log(`S3 region: ${options.s3Region}`);
     console.log(`S3 bucket: ${options.s3Bucket}\n`);
 
     try {
-      const result = await translateCaptions(assetId, options.from, options.to, {
+      const result = await translateCaptions(assetId, options.track, options.to, {
         provider: options.provider,
         model,
         s3Endpoint: options.s3Endpoint,

--- a/examples/translate-captions/basic-example.ts
+++ b/examples/translate-captions/basic-example.ts
@@ -18,13 +18,13 @@ program
   .name("translate-captions")
   .description("Translate captions for a Mux video asset")
   .argument("<asset-id>", "Mux asset ID to translate")
-  .option("-f, --from <language>", "Source language code", "en")
+  .requiredOption("--track <trackId>", "Source text track ID")
   .option("-t, --to <language>", "Target language code", "es")
   .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "anthropic")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("--no-upload", "Skip uploading translated captions to Mux (returns presigned URL only)")
   .action(async (assetId: string, options: {
-    from: string;
+    track: string;
     to: string;
     provider: Provider;
     model?: string;
@@ -32,42 +32,44 @@ program
   }) => {
     // Validate provider
     if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+      console.error("Unsupported provider. Choose from: openai, anthropic, google");
       process.exit(1);
     }
 
     const model = options.model || DEFAULT_MODELS[options.provider];
 
     console.log(`Asset ID: ${assetId}`);
-    console.log(`Translation: ${options.from} -> ${options.to}`);
+    console.log(`Track ID: ${options.track}`);
+    console.log(`Target language: ${options.to}`);
     console.log(`Provider: ${options.provider} (${model})`);
     console.log(`Upload to Mux: ${options.upload}\n`);
 
     try {
-      console.log("🌍 Starting translation...\n");
+      console.log("Starting translation...\n");
 
-      const result = await translateCaptions(assetId, options.from, options.to, {
+      const result = await translateCaptions(assetId, options.track, options.to, {
         provider: options.provider,
         model,
         uploadToMux: options.upload,
       });
 
-      console.log("\n📊 Translation Results:");
+      console.log("\nTranslation Results:");
       console.log(`Source Language: ${result.sourceLanguageCode}`);
       console.log(`Target Language: ${result.targetLanguageCode}`);
       console.log(`Asset ID: ${result.assetId}`);
+      console.log(`Track ID: ${result.trackId}`);
 
       if (result.uploadedTrackId) {
-        console.log(`🎬 Mux Track ID: ${result.uploadedTrackId}`);
+        console.log(`Mux Track ID: ${result.uploadedTrackId}`);
       }
 
       if (result.presignedUrl) {
-        console.log(`🔗 Presigned URL: ${result.presignedUrl.substring(0, 80)}...`);
+        console.log(`Presigned URL: ${result.presignedUrl.substring(0, 80)}...`);
       }
 
-      console.log("\n✅ VTT translation completed successfully!");
+      console.log("\nVTT translation completed successfully!");
     } catch (error) {
-      console.error("❌ Error:", error instanceof Error ? error.message : error);
+      console.error("Error:", error instanceof Error ? error.message : error);
       process.exit(1);
     }
   });

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -1,3 +1,4 @@
+import { isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
 import { signUrl } from "@mux/ai/lib/url-signing";
 import type { AssetTextTrack, MuxAsset, WorkflowCredentialsInput } from "@mux/ai/types";
 
@@ -47,11 +48,20 @@ export function findCaptionTrack(asset: MuxAsset, languageCode?: string): AssetT
     return englishTrack ?? tracks[0];
   }
 
-  return tracks.find(
+  const languageMatch = tracks.find(
     track =>
       track.text_type === "subtitles" &&
       track.language_code === languageCode,
   );
+  if (languageMatch)
+    return languageMatch;
+
+  // Audio-only assets may have a single track that isn't "subtitles" — fall back to it
+  if (isAudioOnlyAsset(asset) && tracks.length === 1) {
+    return tracks[0];
+  }
+
+  return undefined;
 }
 
 function normalizeLineEndings(value: string): string {

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -41,7 +41,10 @@ export function findCaptionTrack(asset: MuxAsset, languageCode?: string): AssetT
     return undefined;
 
   if (!languageCode) {
-    return tracks[0];
+    const englishTrack = tracks.find(
+      track => track.text_type === "subtitles" && track.language_code === "en",
+    );
+    return englishTrack ?? tracks[0];
   }
 
   return tracks.find(

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -44,6 +44,8 @@ export interface AskQuestionsOptions extends MuxAIOptions {
   provider?: SupportedProvider;
   /** Provider-specific chat model identifier. */
   model?: ModelIdByProvider[SupportedProvider];
+  /** BCP 47 language code of the caption track to use (e.g. "en", "fr"). When omitted, prefers English if available. */
+  languageCode?: string;
   /** Allowed answers for each question (defaults to ["yes", "no"]). */
   answerOptions?: string[];
   /** Fetch transcript alongside storyboard (defaults to true). */
@@ -368,6 +370,7 @@ export async function askQuestions(
   const {
     provider = "openai",
     model,
+    languageCode,
     answerOptions,
     includeTranscript = true,
     cleanTranscript = true,
@@ -413,6 +416,7 @@ export async function askQuestions(
   const transcriptText =
     includeTranscript ?
         (await fetchTranscriptForAsset(assetData, playbackId, {
+          languageCode,
           cleanTranscript,
           shouldSign: policy === "signed",
         })).transcriptText :

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -62,7 +62,7 @@ export type ChaptersPromptSections =
  *
  * @example
  * ```typescript
- * const result = await generateChapters(assetId, "en", {
+ * const result = await generateChapters(assetId, {
  *   promptOverrides: {
  *     titleGuidelines: "Use short, punchy titles under 6 words.",
  *   },

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -74,6 +74,8 @@ export type ChaptersPromptOverrides = PromptOverrides<ChaptersPromptSections>;
 
 /** Configuration accepted by `generateChapters`. */
 export interface ChaptersOptions extends MuxAIOptions {
+  /** BCP 47 language code of the caption track to use (e.g. "en", "fr"). When omitted, prefers English if available. */
+  languageCode?: string;
   /** AI provider used to interpret the transcript (defaults to 'openai'). */
   provider?: SupportedProvider;
   /** Provider-specific model identifier. */
@@ -289,11 +291,11 @@ function buildUserPrompt({
 
 export async function generateChapters(
   assetId: string,
-  languageCode: string,
   options: ChaptersOptions = {},
 ): Promise<ChaptersResult> {
   "use workflow";
   const {
+    languageCode,
     provider = "openai",
     model,
     promptOverrides,
@@ -345,7 +347,7 @@ export async function generateChapters(
       .filter(Boolean)
       .join(", ");
     throw new Error(
-      `No caption track found for language '${languageCode}'. Available languages: ${availableLanguages || "none"}`,
+      `No caption track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
     );
   }
 
@@ -418,7 +420,7 @@ export async function generateChapters(
 
   return {
     assetId,
-    languageCode,
+    languageCode: languageCode ?? transcriptResult.track?.language_code ?? "unknown",
     chapters: validChapters,
     usage: usageWithMetadata,
   };

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -17,7 +17,6 @@ import { resolveMuxSigningContext } from "@mux/ai/lib/workflow-credentials";
 import {
   extractTimestampedTranscript,
   fetchTranscriptForAsset,
-  getReadyTextTracks,
 } from "@mux/ai/primitives/transcripts";
 import type { MuxAIOptions, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
 
@@ -324,32 +323,13 @@ export async function generateChapters(
     );
   }
 
-  const readyTextTracks = getReadyTextTracks(assetData);
-  let transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
+  const transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
     languageCode,
     cleanTranscript: false, // keep timestamps for chapter segmentation
     shouldSign: policy === "signed",
     credentials,
+    required: true,
   });
-
-  if (isAudioOnly && !transcriptResult.track && readyTextTracks.length === 1) {
-    transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
-      cleanTranscript: false, // keep timestamps for chapter segmentation
-      shouldSign: policy === "signed",
-      credentials,
-      required: true,
-    });
-  }
-
-  if (!transcriptResult.track || !transcriptResult.transcriptText) {
-    const availableLanguages = readyTextTracks
-      .map(t => t.language_code)
-      .filter(Boolean)
-      .join(", ");
-    throw new Error(
-      `No caption track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
-    );
-  }
 
   const timestampedTranscript = extractTimestampedTranscript(transcriptResult.transcriptText);
   if (!timestampedTranscript) {

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -40,7 +40,7 @@ export type ChaptersType = z.infer<typeof chaptersSchema>;
 /** Structured return payload from `generateChapters`. */
 export interface ChaptersResult {
   assetId: string;
-  languageCode: string;
+  languageCode?: string;
   chapters: Chapter[];
   /** Token usage from the AI provider (for efficiency/cost analysis). */
   usage?: TokenUsage;
@@ -400,7 +400,7 @@ export async function generateChapters(
 
   return {
     assetId,
-    languageCode: languageCode ?? transcriptResult.track?.language_code ?? "unknown",
+    languageCode: languageCode ?? transcriptResult.track?.language_code,
     chapters: validChapters,
     usage: usageWithMetadata,
   };

--- a/src/workflows/embeddings.ts
+++ b/src/workflows/embeddings.ts
@@ -3,14 +3,13 @@ import { embed } from "ai";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
-  isAudioOnlyAsset,
 } from "@mux/ai/lib/mux-assets";
 import type { EmbeddingModelIdByProvider, SupportedEmbeddingProvider } from "@mux/ai/lib/providers";
 import { createEmbeddingModelFromConfig, resolveEmbeddingModelConfig } from "@mux/ai/lib/providers";
 import { withRetry } from "@mux/ai/lib/retry";
 import { resolveMuxSigningContext } from "@mux/ai/lib/workflow-credentials";
 import { chunkText, chunkVTTCues } from "@mux/ai/primitives/text-chunking";
-import { fetchTranscriptForAsset, getReadyTextTracks, parseVTTCues } from "@mux/ai/primitives/transcripts";
+import { fetchTranscriptForAsset, parseVTTCues } from "@mux/ai/primitives/transcripts";
 import type {
   ChunkEmbedding,
   ChunkingStrategy,
@@ -162,7 +161,6 @@ async function generateEmbeddingsInternal(
   // Fetch asset and playback ID
   const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
-  const isAudioOnly = isAudioOnlyAsset(assetData);
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
@@ -174,43 +172,16 @@ async function generateEmbeddingsInternal(
   }
 
   // Fetch transcript (raw VTT for VTT strategy, cleaned text otherwise)
-  const readyTextTracks = getReadyTextTracks(assetData);
   const useVttChunking = chunkingStrategy.type === "vtt";
-  let transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
+  const transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
     languageCode,
     cleanTranscript: !useVttChunking,
     shouldSign: policy === "signed",
     credentials,
+    required: true,
   });
 
-  if (isAudioOnly && !transcriptResult.track && readyTextTracks.length === 1) {
-    transcriptResult = await fetchTranscriptForAsset(assetData, playbackId, {
-      cleanTranscript: !useVttChunking,
-      shouldSign: policy === "signed",
-      credentials,
-    });
-  }
-
-  if (!transcriptResult.track || !transcriptResult.transcriptText) {
-    const availableLanguages = readyTextTracks
-      .map(t => t.language_code)
-      .filter(Boolean)
-      .join(", ");
-    if (isAudioOnly) {
-      throw new Error(
-        `No transcript track found${languageCode ? ` for language '${languageCode}'` : ""}. ` +
-        `Audio-only assets require a transcript. Available languages: ${availableLanguages || "none"}`,
-      );
-    }
-    throw new Error(
-      `No caption track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
-    );
-  }
-
   const transcriptText = transcriptResult.transcriptText;
-  if (!transcriptText.trim()) {
-    throw new Error("Transcript is empty");
-  }
 
   // Chunk the transcript
   const chunks = useVttChunking ?

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -13,7 +13,7 @@ import { planSamplingTimestamps } from "@mux/ai/lib/sampling-plan";
 import { signUrl } from "@mux/ai/lib/url-signing";
 import { resolveMuxSigningContext } from "@mux/ai/lib/workflow-credentials";
 import { getThumbnailUrls } from "@mux/ai/primitives/thumbnails";
-import { fetchTranscriptForAsset, getReadyTextTracks } from "@mux/ai/primitives/transcripts";
+import { fetchTranscriptForAsset } from "@mux/ai/primitives/transcripts";
 import type {
   ImageSubmissionMode,
   MuxAIOptions,
@@ -545,25 +545,13 @@ export async function getModerationScores(
 
   if (isAudioOnly) {
     mode = "transcript";
-    const readyTextTracks = getReadyTextTracks(asset);
-    let transcriptResult = await fetchTranscriptForAsset(asset, playbackId, {
+    const transcriptResult = await fetchTranscriptForAsset(asset, playbackId, {
       languageCode,
       cleanTranscript: true,
       shouldSign: policy === "signed",
       credentials,
       required: true,
     });
-
-    // Audio-only assets may have a single ready text track that isn't "subtitles" (e.g. transcripts).
-    // If a language-specific subtitle wasn't found but there's exactly one track, fall back to it.
-    if (!transcriptResult.track && readyTextTracks.length === 1) {
-      transcriptResult = await fetchTranscriptForAsset(asset, playbackId, {
-        cleanTranscript: true,
-        shouldSign: policy === "signed",
-        credentials,
-        required: true,
-      });
-    }
 
     if (provider === "openai") {
       thumbnailScores = await requestOpenAITranscriptModeration(

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -108,6 +108,8 @@ export interface SummarizationOptions extends MuxAIOptions {
   provider?: SupportedProvider;
   /** Provider-specific chat model identifier. */
   model?: ModelIdByProvider[SupportedProvider];
+  /** BCP 47 language code of the caption track to use (e.g. "en", "fr"). When omitted, prefers English if available. */
+  languageCode?: string;
   /** Prompt tone shim applied to the system instruction (defaults to 'neutral'). */
   tone?: ToneType;
   /** Fetch the transcript and send it alongside the storyboard (defaults to true). */
@@ -593,6 +595,7 @@ export async function getSummaryAndTags(
   const {
     provider = "openai",
     model,
+    languageCode,
     tone = "neutral",
     includeTranscript = true,
     cleanTranscript = true,
@@ -647,6 +650,7 @@ export async function getSummaryAndTags(
   const transcriptResult =
     includeTranscript ?
         await fetchTranscriptForAsset(assetData, playbackId, {
+          languageCode,
           cleanTranscript,
           shouldSign: policy === "signed",
           credentials: workflowCredentials,

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -15,7 +15,6 @@ import type { LanguageCodePair, SupportedISO639_1 } from "@mux/ai/lib/language-c
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
-  isAudioOnlyAsset,
 } from "@mux/ai/lib/mux-assets";
 import { createTextTrackOnMux, fetchVttFromMux } from "@mux/ai/lib/mux-tracks";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
@@ -51,6 +50,7 @@ import type {
 /** Output returned from `translateCaptions`. */
 export interface TranslationResult {
   assetId: string;
+  trackId: string;
   /** Source language code (ISO 639-1 two-letter format). */
   sourceLanguageCode: SupportedISO639_1;
   /** Target language code (ISO 639-1 two-letter format). */
@@ -676,7 +676,7 @@ async function uploadVttToS3({
 
 export async function translateCaptions<P extends SupportedProvider = SupportedProvider>(
   assetId: string,
-  fromLanguageCode: string,
+  trackId: string,
   toLanguageCode: string,
   options: TranslationOptions<P>,
 ): Promise<TranslationResult> {
@@ -716,7 +716,6 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   // Fetch asset data and playback ID from Mux
   const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
-  const isAudioOnly = isAudioOnlyAsset(assetData);
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
@@ -727,44 +726,30 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     );
   }
 
-  // Find text track with the source language
+  // Validate track exists
   const readyTextTracks = getReadyTextTracks(assetData);
-  if (!readyTextTracks.length) {
-    throw new Error("No ready text tracks found for this asset");
-  }
-
-  let sourceTextTrack = readyTextTracks.find(track =>
-    track.text_type === "subtitles" &&
-    track.language_code === fromLanguageCode,
-  );
-
-  if (!sourceTextTrack && isAudioOnly && readyTextTracks.length === 1) {
-    sourceTextTrack = readyTextTracks[0];
-  }
-
+  const sourceTextTrack = readyTextTracks.find(t => t.id === trackId);
   if (!sourceTextTrack) {
-    const availableLanguages = readyTextTracks
-      .map(t => t.language_code)
+    const availableTrackIds = readyTextTracks
+      .map(t => t.id)
       .filter(Boolean)
       .join(", ");
-    if (isAudioOnly) {
-      throw new Error(
-        `No transcript track found with language code '${fromLanguageCode}' for this asset. ` +
-        `Audio-only assets require a transcript. Available languages: ${availableLanguages || "none"}`,
-      );
-    }
     throw new Error(
-      `No ready text track found with language code '${fromLanguageCode}' for this asset. ` +
-      `Available languages: ${availableLanguages || "none"}`,
+      `Track '${trackId}' not found or not ready on asset '${assetId}'. ` +
+      `Available track IDs: ${availableTrackIds || "none"}`,
     );
   }
 
-  if (!sourceTextTrack.id) {
-    throw new Error("Transcript track is missing an id");
+  const fromLanguageCode = sourceTextTrack.language_code;
+  if (!fromLanguageCode) {
+    throw new Error(
+      `Track '${trackId}' is missing language metadata (language_code). ` +
+      `Cannot determine source language for translation.`,
+    );
   }
 
   // Fetch the VTT file content (signed if needed)
-  const vttUrl = await buildTranscriptUrl(playbackId, sourceTextTrack.id, policy === "signed", credentials);
+  const vttUrl = await buildTranscriptUrl(playbackId, trackId, policy === "signed", credentials);
 
   let vttContent: string;
   try {
@@ -811,6 +796,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   if (!uploadToMux) {
     return {
       assetId,
+      trackId,
       sourceLanguageCode: fromLanguageCode as SupportedISO639_1,
       targetLanguageCode: toLanguageCode as SupportedISO639_1,
       sourceLanguage,
@@ -860,6 +846,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
 
   return {
     assetId,
+    trackId,
     sourceLanguageCode: fromLanguageCode as SupportedISO639_1,
     targetLanguageCode: toLanguageCode as SupportedISO639_1,
     sourceLanguage,

--- a/tests/eval/chapters-translation.eval.ts
+++ b/tests/eval/chapters-translation.eval.ts
@@ -115,9 +115,10 @@ evalite("Chapters Translation", {
   data,
   task: async ({ assetId, provider, model, languageCode, variant, outputLanguageCode }): Promise<EvalOutput> => {
     const startTime = performance.now();
-    const result = await generateChapters(assetId, languageCode, {
+    const result = await generateChapters(assetId, {
       provider,
       model,
+      languageCode,
       outputLanguageCode,
     });
     const latencyMs = performance.now() - startTime;

--- a/tests/eval/chapters.eval.ts
+++ b/tests/eval/chapters.eval.ts
@@ -243,7 +243,7 @@ evalite("Chapters", {
   data,
   task: async ({ assetId, provider, model, languageCode, promptOverrides }): Promise<EvalOutput> => {
     const startTime = performance.now();
-    const result = await generateChapters(assetId, languageCode, { provider, model, promptOverrides });
+    const result = await generateChapters(assetId, { provider, model, promptOverrides, languageCode });
     const latencyMs = performance.now() - startTime;
 
     console.warn(

--- a/tests/eval/translate-captions.eval.ts
+++ b/tests/eval/translate-captions.eval.ts
@@ -6,8 +6,10 @@ import { reportTrace } from "evalite/traces";
 import { z } from "zod";
 
 import { isValidISO639_1, isValidISO639_3, toISO639_1, toISO639_3 } from "../../src/lib/language-codes";
+import { getPlaybackIdForAsset } from "../../src/lib/mux-assets";
 import { calculateModelCost, EVAL_MODEL_CONFIGS } from "../../src/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "../../src/lib/providers";
+import { getReadyTextTracks } from "../../src/primitives/transcripts";
 import type { TokenUsage } from "../../src/types";
 import { translateCaptions } from "../../src/workflows";
 import type { TranslationResult } from "../../src/workflows";
@@ -316,8 +318,14 @@ async function scoreTranslationFaithfulness({
 evalite("Caption Translation", {
   data,
   task: async ({ assetId, provider, model, sourceLanguage, targetLanguage }): Promise<EvalOutput> => {
+    const { asset } = await getPlaybackIdForAsset(assetId);
+    const tracks = getReadyTextTracks(asset);
+    const sourceTrack = tracks.find(t => t.language_code === sourceLanguage);
+    if (!sourceTrack?.id)
+      throw new Error(`No ${sourceLanguage} track for ${assetId}`);
+
     const startTime = performance.now();
-    const result = await translateCaptions(assetId, sourceLanguage, targetLanguage, {
+    const result = await translateCaptions(assetId, sourceTrack.id, targetLanguage, {
       provider,
       model,
       uploadToMux: false, // Don't upload during evals

--- a/tests/integration/chapters.test.ts
+++ b/tests/integration/chapters.test.ts
@@ -10,7 +10,7 @@ describe("chapters Integration Tests", () => {
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should return valid result for %s provider", async (provider) => {
-    const result = await generateChapters(assetId, languageCode, { provider });
+    const result = await generateChapters(assetId, { provider, languageCode });
 
     expect(result).toBeDefined();
     expect(result).toHaveProperty("assetId", assetId);
@@ -21,8 +21,9 @@ describe("chapters Integration Tests", () => {
 
   describe("language parameter", () => {
     it("should accept an explicit language code for chapter titles", async () => {
-      const result = await generateChapters(assetId, languageCode, {
+      const result = await generateChapters(assetId, {
         provider: "openai",
+        languageCode,
         outputLanguageCode: "es",
       });
 
@@ -32,8 +33,9 @@ describe("chapters Integration Tests", () => {
     });
 
     it("should accept outputLanguageCode: 'auto' without error", async () => {
-      const result = await generateChapters(assetId, languageCode, {
+      const result = await generateChapters(assetId, {
         provider: "openai",
+        languageCode,
         outputLanguageCode: "auto",
       });
 

--- a/tests/integration/chapters.test.ts
+++ b/tests/integration/chapters.test.ts
@@ -6,15 +6,14 @@ import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("chapters Integration Tests", () => {
   const assetId = muxTestAssets.assetId;
-  const languageCode = "en";
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should return valid result for %s provider", async (provider) => {
-    const result = await generateChapters(assetId, { provider, languageCode });
+    const result = await generateChapters(assetId, { provider });
 
     expect(result).toBeDefined();
     expect(result).toHaveProperty("assetId", assetId);
-    expect(result).toHaveProperty("languageCode", languageCode);
+    expect(result).toHaveProperty("languageCode", "en");
     expect(result).toHaveProperty("chapters");
     expect(Array.isArray(result.chapters)).toBe(true);
   });
@@ -23,7 +22,7 @@ describe("chapters Integration Tests", () => {
     it("should accept an explicit language code for chapter titles", async () => {
       const result = await generateChapters(assetId, {
         provider: "openai",
-        languageCode,
+        languageCode: "en",
         outputLanguageCode: "es",
       });
 
@@ -35,7 +34,7 @@ describe("chapters Integration Tests", () => {
     it("should accept outputLanguageCode: 'auto' without error", async () => {
       const result = await generateChapters(assetId, {
         provider: "openai",
-        languageCode,
+        languageCode: "en",
         outputLanguageCode: "auto",
       });
 

--- a/tests/integration/chapters.test.workflowdevkit.ts
+++ b/tests/integration/chapters.test.workflowdevkit.ts
@@ -10,7 +10,7 @@ describe("Chapters Integration Tests for Workflow DevKit", () => {
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should generate chapters with %s provider", async (provider) => {
-    const run = await start(generateChapters, [assetId, { provider, languageCode: "en" }]);
+    const run = await start(generateChapters, [assetId, { provider }]);
     expect(run.runId).toMatch(/^wrun_/);
 
     const result = await run.returnValue;

--- a/tests/integration/chapters.test.workflowdevkit.ts
+++ b/tests/integration/chapters.test.workflowdevkit.ts
@@ -10,7 +10,7 @@ describe("Chapters Integration Tests for Workflow DevKit", () => {
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
   it.each(providers)("should generate chapters with %s provider", async (provider) => {
-    const run = await start(generateChapters, [assetId, "en", { provider }]);
+    const run = await start(generateChapters, [assetId, { provider, languageCode: "en" }]);
     expect(run.runId).toMatch(/^wrun_/);
 
     const result = await run.returnValue;

--- a/tests/integration/signed-playback.test.ts
+++ b/tests/integration/signed-playback.test.ts
@@ -286,8 +286,9 @@ describe("signed Playback Integration Tests", () => {
 
     describe("generateChapters", () => {
       it.skipIf(!canRunSignedTests)("should generate chapters for signed asset", async () => {
-        const result = await generateChapters(signedAssetId, "en", {
+        const result = await generateChapters(signedAssetId, {
           provider: "anthropic",
+          languageCode: "en",
         });
 
         expect(result).toBeDefined();

--- a/tests/integration/translate-captions.test.ts
+++ b/tests/integration/translate-captions.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
+import { getPlaybackIdForAsset } from "../../src/lib/mux-assets";
 import type { SupportedProvider } from "../../src/lib/providers";
+import { getReadyTextTracks } from "../../src/primitives/transcripts";
 import { translateCaptions } from "../../src/workflows";
 import { muxTestAssets } from "../helpers/mux-test-assets";
 
@@ -8,14 +10,26 @@ describe("translateCaptions Integration Tests", () => {
   const testAssetId = muxTestAssets.assetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
+  let englishTrackId: string;
+
+  beforeAll(async () => {
+    const { asset } = await getPlaybackIdForAsset(testAssetId);
+    const tracks = getReadyTextTracks(asset);
+    const englishTrack = tracks.find(t => t.language_code === "en");
+    if (!englishTrack?.id)
+      throw new Error("Test asset missing English track");
+    englishTrackId = englishTrack.id;
+  });
+
   it.each(providers)("should return valid result for %s provider", async (provider) => {
-    const result = await translateCaptions(testAssetId, "en", "fr", {
+    const result = await translateCaptions(testAssetId, englishTrackId, "fr", {
       provider,
       uploadToMux: false,
     });
 
     expect(result).toBeDefined();
     expect(result).toHaveProperty("assetId", testAssetId);
+    expect(result).toHaveProperty("trackId", englishTrackId);
     expect(result).toHaveProperty("sourceLanguageCode", "en");
     expect(result).toHaveProperty("targetLanguageCode", "fr");
     expect(result).toHaveProperty("originalVtt");

--- a/tests/integration/translate-captions.test.workflowdevkit.ts
+++ b/tests/integration/translate-captions.test.workflowdevkit.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { start } from "workflow/api";
 
+import { getPlaybackIdForAsset } from "../../src/lib/mux-assets";
 import type { SupportedProvider } from "../../src/lib/providers";
+import { getReadyTextTracks } from "../../src/primitives/transcripts";
 import { translateCaptions } from "../../src/workflows";
 import { muxTestAssets } from "../helpers/mux-test-assets";
 
@@ -9,8 +11,19 @@ describe("Caption Translation Integration Tests for Workflow DevKit", () => {
   const assetId = muxTestAssets.assetId;
   const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
 
+  let englishTrackId: string;
+
+  beforeAll(async () => {
+    const { asset } = await getPlaybackIdForAsset(assetId);
+    const tracks = getReadyTextTracks(asset);
+    const englishTrack = tracks.find(t => t.language_code === "en");
+    if (!englishTrack?.id)
+      throw new Error("Test asset missing English track");
+    englishTrackId = englishTrack.id;
+  });
+
   it.each(providers)("should translate captions to French with %s provider without uploading to Mux", async (provider) => {
-    const run = await start(translateCaptions, [assetId, "en", "fr", {
+    const run = await start(translateCaptions, [assetId, englishTrackId, "fr", {
       provider,
       uploadToMux: false,
     }]);
@@ -23,6 +36,7 @@ describe("Caption Translation Integration Tests for Workflow DevKit", () => {
 
     // Verify structure
     expect(result).toHaveProperty("assetId");
+    expect(result).toHaveProperty("trackId");
     expect(result).toHaveProperty("sourceLanguageCode");
     expect(result).toHaveProperty("targetLanguageCode");
     expect(result).toHaveProperty("sourceLanguage");
@@ -33,6 +47,7 @@ describe("Caption Translation Integration Tests for Workflow DevKit", () => {
 
     // Verify asset ID matches
     expect(result.assetId).toBe(assetId);
+    expect(result.trackId).toBe(englishTrackId);
 
     // Verify language codes
     expect(result.sourceLanguageCode).toBe("en");


### PR DESCRIPTION
## Summary

Standardises how workflows select caption tracks. Addresses inconsistencies found during an audit: some workflows used language codes, some used track IDs, some took neither, and the default fallback just grabbed the first available track with no language preference.

**Breaking changes:**

- **`translateCaptions`** now requires a `trackId` instead of `fromLanguageCode`. Source language is inferred from the track's metadata. Mirrors the `editCaptions` pattern.
- **`generateChapters`** signature changes from `(assetId, languageCode, options?)` to `(assetId, options?)`. `languageCode` moves into `ChaptersOptions` and becomes optional.

**Non-breaking additions:**

- `findCaptionTrack` now prefers an English subtitle track when no language is specified, instead of blindly returning `tracks[0]`. All workflows using `fetchTranscriptForAsset` benefit automatically.
- `askQuestions` and `getSummaryAndTags` gain an optional `languageCode` option for explicit track selection.

## Suggested review order

1. `src/primitives/transcripts.ts` — the "prefer English" fallback in `findCaptionTrack`
2. `src/workflows/translate-captions.ts` — signature change and track-by-ID lookup
3. `src/workflows/chapters.ts` — `languageCode` moved to options
4. `src/workflows/ask-questions.ts` and `src/workflows/summarization.ts` — new `languageCode` option
5. Updated callers: tests, evals, and examples

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces breaking workflow API changes (`translateCaptions` now takes a `trackId`; `generateChapters` moves `languageCode` into options) and changes transcript track fallback behavior, which can affect downstream integrations and which captions/transcripts are used at runtime.
> 
> **Overview**
> **Standardizes transcript/caption track selection across workflows** by updating `findCaptionTrack` to *prefer English subtitles* when no `languageCode` is provided, and to fall back to the single available text track for audio-only assets.
> 
> **Breaking API updates:** `translateCaptions` now requires a source `trackId` (infers source language from track metadata and returns `trackId` in `TranslationResult`), and `generateChapters` changes to `(assetId, options?)` with optional `languageCode` in `ChaptersOptions` (and `ChaptersResult.languageCode` becomes optional/resolved).
> 
> Adds optional `languageCode` to `askQuestions` and `getSummaryAndTags` for explicit transcript selection, simplifies transcript-required handling in `generateChapters`/`generateEmbeddings`/audio-only moderation by relying on `fetchTranscriptForAsset(required: true)`, and updates docs/examples/tests/evals to match the new signatures and track-ID-based translation flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0b4c22dc2fc5be26c206c8b01f7ae21be43bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->