### PR TITLE
feat!: New moderation sampling behaviour

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -66,7 +66,7 @@ Analyzes a Mux asset for inappropriate content using OpenAI's Moderation API or 
 - `thresholds?: { sexual?: number; violence?: number }` - Custom thresholds (default: {sexual: 0.7, violence: 0.8})
 - `thumbnailInterval?: number` - Seconds between thumbnails for long videos (default: 10)
 - `thumbnailWidth?: number` - Thumbnail width in pixels (default: 640)
-- `maxSamples?: number` - Maximum number of thumbnails to sample. When set, samples are evenly distributed with first and last frames pinned. (default: unlimited)
+- `maxSamples?: number` - Maximum number of thumbnails to sample. Acts as a cap: if `thumbnailInterval` produces fewer samples than this limit the interval is respected; otherwise samples are evenly distributed with first and last frames pinned. (default: unlimited)
 - `maxConcurrent?: number` - Maximum concurrent API requests (default: 5)
 - `imageSubmissionMode?: 'url' | 'base64'` - How to submit images to AI providers (default: 'url')
 - `imageDownloadOptions?: object` - Options for image download when using base64 mode

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -91,7 +91,7 @@ export interface ModerationOptions extends MuxAIOptions {
   thumbnailInterval?: number;
   /** Width of storyboard thumbnails in pixels (defaults to 640). */
   thumbnailWidth?: number;
-  /** Maximum number of thumbnails to sample (defaults to unlimited). When set, samples are evenly distributed with first and last frames pinned. */
+  /** Maximum number of thumbnails to sample (defaults to unlimited). Acts as a cap: if `thumbnailInterval` produces fewer samples than this limit the interval is respected; otherwise samples are evenly distributed with first and last frames pinned. */
   maxSamples?: number;
   /** Max concurrent moderation requests (defaults to 5). */
   maxConcurrent?: number;
@@ -578,33 +578,36 @@ export async function getModerationScores(
       throw new Error(`Unsupported moderation provider: ${provider}`);
     }
   } else {
-    const thumbnailUrls = maxSamples === undefined ?
-        // Generate thumbnail URLs (signed if needed) using existing interval-based logic.
-        await getThumbnailUrls(playbackId, duration, {
-          interval: thumbnailInterval,
-          width: thumbnailWidth,
-          shouldSign: policy === "signed",
-          credentials,
-        }) :
-        // In maxSamples mode, sample valid timestamps over the trimmed usable span.
-        // Use proportional trims (≈ duration/6, capped at 5s) to stay well inside the
-        // renderable range — Mux can't always serve thumbnails at the very edges.
-        await getThumbnailUrlsFromTimestamps(
-          playbackId,
-          planSamplingTimestamps({
-            duration_sec: duration,
-            max_candidates: maxSamples,
-            trim_start_sec: duration > 2 ? Math.min(5, Math.max(1, duration / 6)) : 0,
-            trim_end_sec: duration > 2 ? Math.min(5, Math.max(1, duration / 6)) : 0,
-            fps: videoTrackFps,
-            base_cadence_hz: thumbnailInterval > 0 ? 1 / thumbnailInterval : undefined,
-          }),
-          {
-            width: thumbnailWidth,
-            shouldSign: policy === "signed",
-            credentials,
-          },
-        );
+    // Always start with interval-based thumbnails.
+    const intervalBasedUrls = await getThumbnailUrls(playbackId, duration, {
+      interval: thumbnailInterval,
+      width: thumbnailWidth,
+      shouldSign: policy === "signed",
+      credentials,
+    });
+
+    // maxSamples acts as a true cap: if the interval already fits within the
+    // budget we keep those results. Only when the interval produces more
+    // thumbnails than allowed do we switch to the intelligent sampling plan.
+    const thumbnailUrls =
+      maxSamples === undefined || intervalBasedUrls.length <= maxSamples ?
+        intervalBasedUrls :
+          await getThumbnailUrlsFromTimestamps(
+            playbackId,
+            planSamplingTimestamps({
+              duration_sec: duration,
+              max_candidates: maxSamples,
+              trim_start_sec: duration > 2 ? Math.min(5, Math.max(1, duration / 6)) : 0,
+              trim_end_sec: duration > 2 ? Math.min(5, Math.max(1, duration / 6)) : 0,
+              fps: videoTrackFps,
+              base_cadence_hz: thumbnailInterval > 0 ? 1 / thumbnailInterval : undefined,
+            }),
+            {
+              width: thumbnailWidth,
+              shouldSign: policy === "signed",
+              credentials,
+            },
+          );
     thumbnailCount = thumbnailUrls.length;
 
     if (provider === "openai") {

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -578,20 +578,15 @@ export async function getModerationScores(
       throw new Error(`Unsupported moderation provider: ${provider}`);
     }
   } else {
-    // Always start with interval-based thumbnails.
-    const intervalBasedUrls = await getThumbnailUrls(playbackId, duration, {
-      interval: thumbnailInterval,
-      width: thumbnailWidth,
-      shouldSign: policy === "signed",
-      credentials,
-    });
+    // Cheaply estimate how many thumbnails the interval would produce so we
+    // can skip generating (and potentially JWT-signing) URLs we'd discard.
+    const estimatedIntervalCount = duration <= 50 ? 5 : Math.ceil(duration / thumbnailInterval);
 
     // maxSamples acts as a true cap: if the interval already fits within the
-    // budget we keep those results. Only when the interval produces more
-    // thumbnails than allowed do we switch to the intelligent sampling plan.
+    // budget we use the interval-based path. Only when the interval would
+    // produce more thumbnails than allowed do we switch to the sampling plan.
     const thumbnailUrls =
-      maxSamples === undefined || intervalBasedUrls.length <= maxSamples ?
-        intervalBasedUrls :
+      maxSamples !== undefined && estimatedIntervalCount > maxSamples ?
           await getThumbnailUrlsFromTimestamps(
             playbackId,
             planSamplingTimestamps({
@@ -607,7 +602,13 @@ export async function getModerationScores(
               shouldSign: policy === "signed",
               credentials,
             },
-          );
+          ) :
+          await getThumbnailUrls(playbackId, duration, {
+            interval: thumbnailInterval,
+            width: thumbnailWidth,
+            shouldSign: policy === "signed",
+            credentials,
+          });
     thumbnailCount = thumbnailUrls.length;
 
     if (provider === "openai") {

--- a/tests/integration/moderation.test.ts
+++ b/tests/integration/moderation.test.ts
@@ -235,7 +235,7 @@ describe("moderation Integration Tests", () => {
       expect(resultWithLargeMax.thumbnailScores.length).toBeGreaterThan(0);
     });
 
-    it("should combine maxSamples with custom thumbnail interval", async () => {
+    it("should cap thumbnails when interval produces more than maxSamples", async () => {
       const result = await getModerationScores(safeAsset, {
         provider: "openai",
         model: "omni-moderation-latest",
@@ -244,8 +244,22 @@ describe("moderation Integration Tests", () => {
       });
 
       expect(result).toBeDefined();
-      // maxSamples should override the interval-based count
+      // interval at 5s produces more than 3 thumbnails, so maxSamples caps the count
       expect(result.thumbnailScores.length).toBe(3);
+    });
+
+    it("should respect interval when it fits within maxSamples", async () => {
+      const result = await getModerationScores(safeAsset, {
+        provider: "openai",
+        model: "omni-moderation-latest",
+        thumbnailInterval: 10,
+        maxSamples: 1000,
+      });
+
+      expect(result).toBeDefined();
+      // interval at 10s produces far fewer than 1000 thumbnails, so interval is respected
+      expect(result.thumbnailScores.length).toBeGreaterThan(0);
+      expect(result.thumbnailScores.length).toBeLessThan(1000);
     });
   });
 });


### PR DESCRIPTION
## Summary

- `maxSamples` is now a true cap rather than a mode switch. Previously, setting `maxSamples` bypassed interval-based thumbnail generation entirely in favour of `planSamplingTimestamps`. Now the interval-based path always runs first, and the sampling plan only kicks in when the interval would produce more thumbnails than `maxSamples` allows.
- If `thumbnailInterval` already fits within `maxSamples`, the interval is respected as-is.
- Updated JSDoc, API docs, and integration tests to reflect the new semantics.

## Example

```typescript
// Before: maxSamples overrode the interval entirely, using planSamplingTimestamps
// After: interval produces 12 thumbnails (0, 5, 10, ..., 55), exceeds 3, so sampling plan caps it
getModerationScores(assetId, { thumbnailInterval: 5, maxSamples: 3 });

// Before: maxSamples overrode the interval entirely
// After: interval produces 6 thumbnails, fits under 100, so interval is respected
getModerationScores(assetId, { thumbnailInterval: 10, maxSamples: 100 });
```

## Suggested review order

1. `src/workflows/moderation.ts` — core logic change (~lines 580-610)
2. `docs/API.md` — updated `maxSamples` description
3. `tests/integration/moderation.test.ts` — renamed + new test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core thumbnail selection behavior for moderation, which can alter the number/timing of frames reviewed and potentially affect classification outcomes on existing integrations.
> 
> **Overview**
> Updates `getModerationScores` so `maxSamples` is no longer a mode switch: it now *caps* thumbnail count only when the `thumbnailInterval` path would exceed the limit, otherwise the interval-based thumbnails are used.
> 
> Adds an interval-count estimate to avoid generating/signing URLs that would be discarded, and updates `docs/API.md`, JSDoc, and integration tests to reflect the new `maxSamples` semantics (including a new test for “interval fits within maxSamples”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4659002569e5caa2d00e04186b27ceab9e14e81a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->