### PR TITLE
chore: bump to 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates the package version in `package.json` and `package-lock.json` with no functional code changes.
> 
> **Overview**
> Bumps the `@mux/ai` package version from `0.13.1` to `0.14.0` in both `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc21b95b7b9a3e43f845b9f0116a31ef1b8c6957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->