### PR TITLE
chore: fix breaking publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,9 +23,6 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
-      - name: Update npm to latest
-        run: npm install -g npm@latest
-
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Running into issues publishing our NPM packages: https://github.com/muxinc/ai/actions/runs/24156016515/job/70496358237

GitHub told me to remove this line

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI change limited to the release publish workflow; it only affects which npm version is used during install/build/test/publish.
> 
> **Overview**
> Stops force-upgrading npm to the latest version in `.github/workflows/publish.yml`, relying on the `actions/setup-node` provided npm instead to avoid publish breakages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54af35722e9ea8feaa925409053c7995db4c6e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->