### PR TITLE
chore: revert

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
+      - name: Update npm to latest
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
NPM publishing is a nightmare. Revert https://github.com/muxinc/ai/pull/161

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low code risk, but this can affect release pipeline stability if the latest npm introduces breaking changes or different lockfile/install behavior.
> 
> **Overview**
> Ensures the `publish.yml` workflow upgrades npm (`npm install -g npm@latest`) immediately after `setup-node`, before running `npm ci`/build/tests, so releases use the most recent npm during packaging and publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7ce48eeb0b056a6fe39a667cee91a2c9665ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->