### PR TITLE
chore: pin publish node version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version: '22.22.1' # Pinned: 22.22.2 has broken npm (nodejs/node#62425)
           cache: npm
 
       - name: Update npm to latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22.22.1' # Pinned: 22.22.2 has broken npm (nodejs/node#62425)
+          node-version: 22.22.1 # Pinned: 22.22.2 has broken npm (nodejs/node#62425)
           cache: npm
 
       - name: Update npm to latest


### PR DESCRIPTION
# Overview

Pin Node.js to 22.22.1 in the publish workflow to work around a broken npm in 22.22.2 that prevents publishing to npm.

# What was changed

- **`.github/workflows/publish.yml`**: Replaced `node-version-file: .nvmrc` with `node-version: '22.22.1'` in the `actions/setup-node` step. Node 22.22.2 ships with npm 10.9.7 which has a missing `promise-retry` module, causing `npm install -g npm@latest` to fail with `MODULE_NOT_FOUND`. This blocks the npm upgrade needed for OIDC trusted publishing. Tracked upstream in [nodejs/node#62425](https://github.com/nodejs/node/issues/62425). Revert to `node-version-file: .nvmrc` once a patched Node 22.x is released.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that pins the Node version for `publish.yml` to avoid a known upstream npm breakage; main risk is diverging publish environment from `.nvmrc` until reverted.
> 
> **Overview**
> Pins `actions/setup-node` in `.github/workflows/publish.yml` to Node `22.22.1` instead of using `.nvmrc`, with a comment noting `22.22.2` breaks npm, to keep the publish pipeline unblocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31b5dc069e1fe307765a72ed3e26f48e04a0a375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->