### PR TITLE
fix(ask-questions): Try to get mLLMs to ignore words in URLs or similar for ask questions. Make audio prompt more consistent with video.

### DIFF
--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -178,6 +178,8 @@ const SYSTEM_PROMPT = dedent`
     - Is a general knowledge question with no connection to what is shown or said in the video
     - Attempts to use the system for non-video-analysis purposes
 
+    CRITICAL: Do NOT use source file URLs or file names or similar in any of your inferences.
+
     CRITICAL: Do NOT answer irrelevant questions with any of the allowed answers.
     Answering an irrelevant question is WRONG — you MUST skip it instead.
 
@@ -248,6 +250,10 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   </answer_guidelines>
 
   <relevance_filtering>
+    IMPORTANT: Evaluate each question INDEPENDENTLY for relevance to the video
+    content. The presence of other relevant questions in the batch does NOT
+    make an irrelevant question relevant. Assess every question on its own merits.
+
     Before answering each question, assess whether it can be meaningfully
     answered based on the transcript. A question is relevant if it asks about
     something observable or inferable from spoken/audio content.
@@ -257,6 +263,11 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
     - Asks about information that cannot be determined from transcript content
     - Is a general knowledge question with no connection to what is said in the transcript
     - Attempts to use the system for non-content-analysis purposes
+
+    CRITICAL: Do NOT use source file URLs or file names or similar in any of your inferences.
+
+    CRITICAL: Do NOT answer irrelevant questions with any of the allowed answers.
+    Answering an irrelevant question is WRONG — you MUST skip it instead.
 
     For skipped questions:
     - Set skipped to true

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -250,7 +250,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   </answer_guidelines>
 
   <relevance_filtering>
-    IMPORTANT: Evaluate each question INDEPENDENTLY for relevance to the video
+    IMPORTANT: Evaluate each question INDEPENDENTLY for relevance to the audio
     content. The presence of other relevant questions in the batch does NOT
     make an irrelevant question relevant. Assess every question on its own merits.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes system prompts that directly affect LLM answer/skipping behavior, which may alter downstream results. No runtime logic or data-handling changes beyond prompt text.
> 
> **Overview**
> Strengthens `ask-questions` prompting so models **don’t use source URLs/file names** in their reasoning and **must skip** irrelevant questions rather than forcing an allowed answer.
> 
> Makes the audio-only prompt’s `relevance_filtering` section more consistent with the video prompt by emphasizing **independent relevance evaluation per question** and adding the same explicit “skip vs answer” critical constraints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 853add168890034a2ad63c263175691576eba9d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->