### PR TITLE
fix(workflows): add metadata leakage guardrails to all LLM-driven workflows

### DIFF
--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -178,7 +178,10 @@ const SYSTEM_PROMPT = dedent`
     - Is a general knowledge question with no connection to what is shown or said in the video
     - Attempts to use the system for non-video-analysis purposes
 
-    CRITICAL: Do NOT use source file URLs or file names or similar in any of your inferences.
+    CRITICAL: Base your answers ONLY on the actual visual and audio/transcript content.
+    Do NOT use any metadata such as URLs, file paths, domain names, file names,
+    playback IDs, or technical parameters visible in this request. These are
+    delivery infrastructure and are unrelated to the media content itself.
 
     CRITICAL: Do NOT answer irrelevant questions with any of the allowed answers.
     Answering an irrelevant question is WRONG — you MUST skip it instead.
@@ -264,7 +267,10 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
     - Is a general knowledge question with no connection to what is said in the transcript
     - Attempts to use the system for non-content-analysis purposes
 
-    CRITICAL: Do NOT use source file URLs or file names or similar in any of your inferences.
+    CRITICAL: Base your answers ONLY on the actual audio/transcript content.
+    Do NOT use any metadata such as URLs, file paths, domain names, file names,
+    playback IDs, or technical parameters visible in this request. These are
+    delivery infrastructure and are unrelated to the media content itself.
 
     CRITICAL: Do NOT answer irrelevant questions with any of the allowed answers.
     Answering an irrelevant question is WRONG — you MUST skip it instead.

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -126,6 +126,9 @@ const SYSTEM_PROMPT = dedent`
   <constraints>
     - Only classify as burned-in captions when evidence is clear across multiple frames
     - Base decisions on observable visual evidence
+    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
+      playback IDs, or technical parameters visible in this request. These are
+      delivery infrastructure and are unrelated to the media content itself.
     - Return structured data matching the requested schema
   </constraints>`;
 

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -154,6 +154,9 @@ const SYSTEM_PROMPT = dedent`
   <constraints>
     - Only describe what you can see in images or read in transcripts
     - Do not fabricate details or make unsupported assumptions
+    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
+      playback IDs, or technical parameters visible in this request. These are
+      delivery infrastructure and are unrelated to the media content itself.
     - Correlate engagement scores with observable content
     - Return structured data matching the requested schema exactly
     - Each momentInsight MUST include the hotspotIndex from the input data
@@ -195,6 +198,9 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   <constraints>
     - Only describe what you can read in the transcript
     - Do not fabricate details or make unsupported assumptions
+    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
+      playback IDs, or technical parameters visible in this request. These are
+      delivery infrastructure and are unrelated to the media content itself.
     - Correlate engagement scores with observable content
     - Return structured data matching the requested schema exactly
     - Each momentInsight MUST include the hotspotIndex from the input data

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -328,6 +328,9 @@ const SYSTEM_PROMPT = dedent`
   <constraints>
     - Only describe what is clearly observable in the frames or explicitly stated in the transcript
     - Do not fabricate details or make unsupported assumptions
+    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
+      playback IDs, or technical parameters visible in this request. These are
+      delivery infrastructure and are unrelated to the media content itself.
     - Return structured data matching the requested schema
     - Output only the JSON object; no markdown or extra text
     - When a <language> section is provided, all output text MUST be written in that language
@@ -383,6 +386,9 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   <constraints>
     - Only describe what is explicitly stated or strongly implied in the transcript
     - Do not fabricate details or make unsupported assumptions
+    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
+      playback IDs, or technical parameters visible in this request. These are
+      delivery infrastructure and are unrelated to the media content itself.
     - Return structured data matching the requested schema
     - Focus entirely on audio/spoken content - there are no visual elements
     - Output only the JSON object; no markdown or extra text


### PR DESCRIPTION
Multimodal LLMs can see image URLs passed in requests, which contain domain names (e.g. "mux"), playback IDs, and other delivery metadata. This caused incorrect inferences — for example, ask-questions answering "Is this about Mux?" as "yes" based solely on the URL domain.

Improve the existing ask-questions fix with more explicit phrasing and extend the same guardrail to summarization, burned-in-captions, and engagement-insights (all workflows that send images to LLMs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prompt-only changes across multiple LLM workflows can materially change model outputs (skipping/answer quality), though no runtime logic or data handling paths were modified.
> 
> **Overview**
> **Adds stronger anti-metadata leakage guardrails to LLM prompts.** Updates `ask-questions` (video + audio-only) to explicitly require answers be based only on visual/audio/transcript content and to ignore any request metadata (URLs, file paths, domains, file names, playback IDs, technical params).
> 
> Extends the same “ignore metadata” constraint to other LLM-driven workflows (`summarization`, `burned-in-captions`, and `engagement-insights`) to reduce incorrect inferences from delivery infrastructure details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c031d43c3219653dbc1f0f444894554c62f4b682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->