### PR TITLE
feat: add MuxAiError for customer-safe error surfacing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 import { version } from "../package.json";
 
+// Error types
+export { MuxAiError } from "./lib/mux-ai-error";
+
 // Workflow credential utilities
 export { setWorkflowCredentialsProvider } from "./lib/workflow-credentials";
 export type { WorkflowCredentialsProvider } from "./lib/workflow-credentials";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { version } from "../package.json";
 
 // Error types
-export { MuxAiError } from "./lib/mux-ai-error";
+export { MuxAiError, wrapError } from "./lib/mux-ai-error";
+export type { MuxAiErrorType } from "./lib/mux-ai-error";
 
 // Workflow credential utilities
 export { setWorkflowCredentialsProvider } from "./lib/workflow-credentials";

--- a/src/lib/mux-ai-error.ts
+++ b/src/lib/mux-ai-error.ts
@@ -1,5 +1,7 @@
+export type MuxAiErrorType = "validation_error" | "processing_error" | "timeout_error";
+
 /**
- * An error whose message is safe to surface .
+ * An error whose message is safe to surface verbatim to the customer.
  *
  * Uses a structural brand (`__robots_error = true`) so that downstream
  * consumers can identify customer-safe errors via duck typing — no
@@ -7,16 +9,16 @@
  * this brand (unexpected SDK failures, upstream provider errors, etc.)
  * should be treated as internal and obfuscated.
  *
- * Own properties (`publicMessage`, `publicType`, `retryable`, `fatal`)
- * survive JSON serialization across workflow step boundaries, unlike
- * inherited `Error.message`.
+ * Own properties (`publicMessage`, `publicType`, `retryable`) survive
+ * JSON serialization across workflow step boundaries, unlike inherited
+ * `Error.message`.
  */
 export class MuxAiError extends Error {
   /** Structural brand for duck-type identification. */
   readonly __robots_error = true;
 
   /** Error category shown in the API response. */
-  readonly publicType: string;
+  readonly publicType: MuxAiErrorType;
 
   /** Customer-facing message. Must be safe to show verbatim. */
   readonly publicMessage: string;
@@ -24,11 +26,8 @@ export class MuxAiError extends Error {
   /** Whether the customer should retry the job. */
   readonly retryable: boolean;
 
-  /** Tells the workflow runtime to skip step-level retries. */
-  readonly fatal = true;
-
   constructor(message: string, opts?: {
-    type?: string;
+    type?: MuxAiErrorType;
     retryable?: boolean;
   }) {
     super(message);
@@ -37,4 +36,19 @@ export class MuxAiError extends Error {
     this.publicMessage = message;
     this.retryable = opts?.retryable ?? false;
   }
+}
+
+/**
+ * Re-throws {@link MuxAiError} instances to preserve the structural brand,
+ * wraps everything else in a plain `Error` with a contextual message.
+ *
+ * Use this in catch blocks that re-throw so a customer-safe error from a
+ * callee isn't accidentally converted into an internal error.
+ */
+export function wrapError(error: unknown, message: string): never {
+  if (error instanceof MuxAiError) {
+    throw error;
+  }
+  const detail = error instanceof Error ? error.message : "Unknown error";
+  throw new Error(`${message}: ${detail}`);
 }

--- a/src/lib/mux-ai-error.ts
+++ b/src/lib/mux-ai-error.ts
@@ -1,0 +1,40 @@
+/**
+ * An error whose message is safe to surface .
+ *
+ * Uses a structural brand (`__robots_error = true`) so that downstream
+ * consumers can identify customer-safe errors via duck typing — no
+ * shared dependency required. Errors from @mux/ai that DON'T carry
+ * this brand (unexpected SDK failures, upstream provider errors, etc.)
+ * should be treated as internal and obfuscated.
+ *
+ * Own properties (`publicMessage`, `publicType`, `retryable`, `fatal`)
+ * survive JSON serialization across workflow step boundaries, unlike
+ * inherited `Error.message`.
+ */
+export class MuxAiError extends Error {
+  /** Structural brand for duck-type identification. */
+  readonly __robots_error = true;
+
+  /** Error category shown in the API response. */
+  readonly publicType: string;
+
+  /** Customer-facing message. Must be safe to show verbatim. */
+  readonly publicMessage: string;
+
+  /** Whether the customer should retry the job. */
+  readonly retryable: boolean;
+
+  /** Tells the workflow runtime to skip step-level retries. */
+  readonly fatal = true;
+
+  constructor(message: string, opts?: {
+    type?: string;
+    retryable?: boolean;
+  }) {
+    super(message);
+    this.name = "MuxAiError";
+    this.publicType = opts?.type ?? "processing_error";
+    this.publicMessage = message;
+    this.retryable = opts?.retryable ?? false;
+  }
+}

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -1,4 +1,5 @@
 import { getMuxClientFromEnv } from "@mux/ai/lib/client-factory";
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import type { MuxAsset, PlaybackAsset, PlaybackPolicy, WorkflowCredentialsInput, WorkflowMuxClient } from "@mux/ai/types";
 
 /**
@@ -22,9 +23,10 @@ function getPlaybackId(asset: MuxAsset): { id: string; policy: PlaybackPolicy } 
     return { id: signedPlaybackId.id, policy: "signed" };
   }
 
-  throw new Error(
+  throw new MuxAiError(
     "No public or signed playback ID found for this asset. " +
     "A public or signed playback ID is required. DRM playback IDs are not currently supported.",
+    { type: "validation_error" },
   );
 }
 

--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -24,8 +24,7 @@ function getPlaybackId(asset: MuxAsset): { id: string; policy: PlaybackPolicy } 
   }
 
   throw new MuxAiError(
-    "No public or signed playback ID found for this asset. " +
-    "A public or signed playback ID is required. DRM playback IDs are not currently supported.",
+    "No public or signed playback ID found for this asset. DRM playback IDs are not currently supported.",
     { type: "validation_error" },
   );
 }

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -275,6 +275,6 @@ export async function waitForShotsForAsset(
 
   throw new MuxAiError(
     `Timed out waiting for shots for asset '${assetId}' after ${normalizedMaxAttempts} attempts. Last status: ${lastStatus ?? "unknown"}`,
-    { retryable: true },
+    { type: "timeout_error", retryable: true },
   );
 }

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -1,4 +1,5 @@
 import { getMuxClientFromEnv } from "@mux/ai/lib/client-factory";
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import type { WorkflowCredentialsInput } from "@mux/ai/types";
 
 export interface Shot {
@@ -264,7 +265,7 @@ export async function waitForShotsForAsset(
     }
 
     if (result.status === "errored") {
-      throw new Error(`Shots generation errored for asset '${assetId}'`);
+      throw new MuxAiError(`Shots generation errored for asset '${assetId}'`);
     }
 
     if (attempt < normalizedMaxAttempts - 1) {
@@ -272,7 +273,8 @@ export async function waitForShotsForAsset(
     }
   }
 
-  throw new Error(
+  throw new MuxAiError(
     `Timed out waiting for shots for asset '${assetId}' after ${normalizedMaxAttempts} attempts. Last status: ${lastStatus ?? "unknown"}`,
+    { retryable: true },
   );
 }

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -265,7 +265,7 @@ export async function waitForShotsForAsset(
     }
 
     if (result.status === "errored") {
-      throw new MuxAiError(`Shots generation errored for asset '${assetId}'`);
+      throw new MuxAiError(`Shot generation failed for asset ${assetId}.`);
     }
 
     if (attempt < normalizedMaxAttempts - 1) {
@@ -274,7 +274,7 @@ export async function waitForShotsForAsset(
   }
 
   throw new MuxAiError(
-    `Timed out waiting for shots for asset '${assetId}' after ${normalizedMaxAttempts} attempts. Last status: ${lastStatus ?? "unknown"}`,
+    `Timed out waiting for shots for asset ${assetId}. Last status: ${lastStatus ?? "unknown"}.`,
     { type: "timeout_error", retryable: true },
   );
 }

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -1,3 +1,4 @@
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import { isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
 import { signUrl } from "@mux/ai/lib/url-signing";
 import type { AssetTextTrack, MuxAsset, WorkflowCredentialsInput } from "@mux/ai/types";
@@ -494,7 +495,7 @@ export async function fetchTranscriptForAsset(
         .map(t => t.language_code)
         .filter(Boolean)
         .join(", ");
-      throw new Error(
+      throw new MuxAiError(
         `No transcript track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
       );
     }
@@ -503,7 +504,7 @@ export async function fetchTranscriptForAsset(
 
   if (!track.id) {
     if (required) {
-      throw new Error("Transcript track is missing an id");
+      throw new MuxAiError("Transcript track is missing an id");
     }
     return { transcriptText: "", track };
   }
@@ -523,7 +524,7 @@ export async function fetchTranscriptForAsset(
     const transcriptText = cleanTranscript ? extractTextFromVTT(rawVtt) : rawVtt;
 
     if (required && !transcriptText.trim()) {
-      throw new Error("Transcript is empty");
+      throw new MuxAiError("Transcript is empty");
     }
 
     return { transcriptText, transcriptUrl, track };

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -497,6 +497,7 @@ export async function fetchTranscriptForAsset(
         .join(", ");
       throw new MuxAiError(
         `No transcript track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
+        { type: "validation_error" },
       );
     }
     return { transcriptText: "" };
@@ -504,7 +505,7 @@ export async function fetchTranscriptForAsset(
 
   if (!track.id) {
     if (required) {
-      throw new MuxAiError("Transcript track is missing an id");
+      throw new MuxAiError("Transcript track is missing an id", { type: "validation_error" });
     }
     return { transcriptText: "", track };
   }
@@ -524,11 +525,14 @@ export async function fetchTranscriptForAsset(
     const transcriptText = cleanTranscript ? extractTextFromVTT(rawVtt) : rawVtt;
 
     if (required && !transcriptText.trim()) {
-      throw new MuxAiError("Transcript is empty");
+      throw new MuxAiError("Transcript is empty", { type: "validation_error" });
     }
 
     return { transcriptText, transcriptUrl, track };
   } catch (error) {
+    if (error instanceof MuxAiError) {
+      throw error;
+    }
     if (required) {
       throw new Error(
         `Failed to fetch transcript: ${error instanceof Error ? error.message : "Unknown error"}`,

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -1,4 +1,4 @@
-import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
+import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import { isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
 import { signUrl } from "@mux/ai/lib/url-signing";
 import type { AssetTextTrack, MuxAsset, WorkflowCredentialsInput } from "@mux/ai/types";
@@ -530,13 +530,8 @@ export async function fetchTranscriptForAsset(
 
     return { transcriptText, transcriptUrl, track };
   } catch (error) {
-    if (error instanceof MuxAiError) {
-      throw error;
-    }
     if (required) {
-      throw new Error(
-        `Failed to fetch transcript: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      wrapError(error, "Failed to fetch transcript");
     }
     console.warn("Failed to fetch transcript:", error);
     return { transcriptText: "", transcriptUrl, track };

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -496,7 +496,7 @@ export async function fetchTranscriptForAsset(
         .filter(Boolean)
         .join(", ");
       throw new MuxAiError(
-        `No transcript track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
+        `No caption track found${languageCode ? ` for language ${languageCode}` : ""}. Available languages: ${availableLanguages || "none"}.`,
         { type: "validation_error" },
       );
     }
@@ -505,7 +505,7 @@ export async function fetchTranscriptForAsset(
 
   if (!track.id) {
     if (required) {
-      throw new MuxAiError("Transcript track is missing an id", { type: "validation_error" });
+      throw new MuxAiError("Transcript track is missing an id.", { type: "validation_error" });
     }
     return { transcriptText: "", track };
   }
@@ -525,7 +525,7 @@ export async function fetchTranscriptForAsset(
     const transcriptText = cleanTranscript ? extractTextFromVTT(rawVtt) : rawVtt;
 
     if (required && !transcriptText.trim()) {
-      throw new MuxAiError("Transcript is empty", { type: "validation_error" });
+      throw new MuxAiError("Transcript is empty.", { type: "validation_error" });
     }
 
     return { transcriptText, transcriptUrl, track };

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
 import { createPromptBuilder, createTranscriptSection, renderSection } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
@@ -475,14 +476,15 @@ export async function askQuestions(
 
   // Validate questions array is non-empty
   if (!questions || questions.length === 0) {
-    throw new Error("At least one question must be provided");
+    throw new MuxAiError("At least one question must be provided", { type: "validation_error" });
   }
 
   // Validate each question has valid text
   questions.forEach((q, idx) => {
     if (!q.question || typeof q.question !== "string" || !q.question.trim()) {
-      throw new Error(
+      throw new MuxAiError(
         `Question at index ${idx} is invalid: must have non-empty 'question' field`,
+        { type: "validation_error" },
       );
     }
   });
@@ -509,7 +511,7 @@ export async function askQuestions(
   );
 
   if (!normalizedAnswerOptions.length) {
-    throw new Error("answerOptions must include at least one non-empty value");
+    throw new MuxAiError("answerOptions must include at least one non-empty value", { type: "validation_error" });
   }
 
   const allowedAnswers = normalizedAnswerOptions as [string, ...string[]];
@@ -526,17 +528,19 @@ export async function askQuestions(
   const isAudioOnly = isAudioOnlyAsset(assetData);
 
   if (isAudioOnly && !includeTranscript) {
-    throw new Error(
+    throw new MuxAiError(
       "Audio-only assets require a transcript. Set includeTranscript: true and ensure the asset has a ready text track (captions/subtitles).",
+      { type: "validation_error" },
     );
   }
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
   if (policy === "signed" && !signingContext) {
-    throw new Error(
+    throw new MuxAiError(
       "Signed playback ID requires signing credentials. " +
       "Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables.",
+      { type: "validation_error" },
     );
   }
 
@@ -621,12 +625,12 @@ export async function askQuestions(
   }
 
   if (!analysisResponse.result?.answers) {
-    throw new Error(`Failed to get answers for asset ${assetId}`);
+    throw new MuxAiError(`Failed to get answers for asset ${assetId}`);
   }
 
   // Validate we got answers for all questions
   if (analysisResponse.result.answers.length !== questions.length) {
-    throw new Error(
+    throw new MuxAiError(
       `Expected ${questions.length} answers but received ${analysisResponse.result.answers.length}`,
     );
   }

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
-import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
+import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
 import { createPromptBuilder, createTranscriptSection, renderSection } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
@@ -617,11 +617,7 @@ export async function askQuestions(
     }
   } catch (error: unknown) {
     const contentType = isAudioOnly ? "audio" : "video";
-    throw new Error(
-      `Failed to analyze ${contentType} questions with ${provider}: ${
-        error instanceof Error ? error.message : "Unknown error"
-      }`,
-    );
+    wrapError(error, `Failed to analyze ${contentType} questions with ${provider}`);
   }
 
   if (!analysisResponse.result?.answers) {

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -476,14 +476,14 @@ export async function askQuestions(
 
   // Validate questions array is non-empty
   if (!questions || questions.length === 0) {
-    throw new MuxAiError("At least one question must be provided", { type: "validation_error" });
+    throw new MuxAiError("At least one question must be provided.", { type: "validation_error" });
   }
 
   // Validate each question has valid text
   questions.forEach((q, idx) => {
     if (!q.question || typeof q.question !== "string" || !q.question.trim()) {
       throw new MuxAiError(
-        `Question at index ${idx} is invalid: must have non-empty 'question' field`,
+        `Question at index ${idx} is invalid: must have a non-empty question field.`,
         { type: "validation_error" },
       );
     }
@@ -511,7 +511,7 @@ export async function askQuestions(
   );
 
   if (!normalizedAnswerOptions.length) {
-    throw new MuxAiError("answerOptions must include at least one non-empty value", { type: "validation_error" });
+    throw new MuxAiError("answerOptions must include at least one non-empty value.", { type: "validation_error" });
   }
 
   const allowedAnswers = normalizedAnswerOptions as [string, ...string[]];
@@ -621,13 +621,13 @@ export async function askQuestions(
   }
 
   if (!analysisResponse.result?.answers) {
-    throw new MuxAiError(`Failed to get answers for asset ${assetId}`);
+    throw new MuxAiError(`Failed to generate answers for asset ${assetId}.`);
   }
 
   // Validate we got answers for all questions
   if (analysisResponse.result.answers.length !== questions.length) {
     throw new MuxAiError(
-      `Expected ${questions.length} answers but received ${analysisResponse.result.answers.length}`,
+      `Failed to generate answers for all questions for asset ${assetId}.`,
     );
   }
 

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -341,12 +341,13 @@ export async function generateChapters(
       .join(", ");
     throw new MuxAiError(
       `No caption track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
+      { type: "validation_error" },
     );
   }
   const timestampedTranscript = extractTimestampedTranscript(transcriptResult.transcriptText);
   if (!timestampedTranscript) {
     const contentLabel = isAudioOnly ? "transcript" : "caption track";
-    throw new MuxAiError(`No usable content found in ${contentLabel}`);
+    throw new MuxAiError(`No usable content found in ${contentLabel}`, { type: "validation_error" });
   }
 
   // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -3,6 +3,7 @@ import dedent from "dedent";
 import { z } from "zod";
 
 import { getLanguageName } from "@mux/ai/lib/language-codes";
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -318,9 +319,10 @@ export async function generateChapters(
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
   if (policy === "signed" && !signingContext) {
-    throw new Error(
+    throw new MuxAiError(
       "Signed playback ID requires signing credentials. " +
       "Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables.",
+      { type: "validation_error" },
     );
   }
 
@@ -337,14 +339,14 @@ export async function generateChapters(
       .map(t => t.language_code)
       .filter(Boolean)
       .join(", ");
-    throw new Error(
+    throw new MuxAiError(
       `No caption track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
     );
   }
   const timestampedTranscript = extractTimestampedTranscript(transcriptResult.transcriptText);
   if (!timestampedTranscript) {
     const contentLabel = isAudioOnly ? "transcript" : "caption track";
-    throw new Error(`No usable content found in ${contentLabel}`);
+    throw new MuxAiError(`No usable content found in ${contentLabel}`);
   }
 
   // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track
@@ -382,7 +384,7 @@ export async function generateChapters(
   }
 
   if (!chaptersData || !chaptersData.chapters) {
-    throw new Error("No chapters generated from AI response");
+    throw new MuxAiError("No chapters generated from AI response");
   }
 
   // Validate and sort chapters
@@ -392,7 +394,7 @@ export async function generateChapters(
     .sort((a, b) => a.startTime - b.startTime);
 
   if (validChapters.length === 0) {
-    throw new Error("No valid chapters found in AI response");
+    throw new MuxAiError("No valid chapters found in AI response");
   }
 
   // Ensure first chapter starts at 0

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -340,14 +340,14 @@ export async function generateChapters(
       .filter(Boolean)
       .join(", ");
     throw new MuxAiError(
-      `No caption track found${languageCode ? ` for language '${languageCode}'` : ""}. Available languages: ${availableLanguages || "none"}`,
+      `No caption track found${languageCode ? ` for language ${languageCode}` : ""}. Available languages: ${availableLanguages || "none"}.`,
       { type: "validation_error" },
     );
   }
   const timestampedTranscript = extractTimestampedTranscript(transcriptResult.transcriptText);
   if (!timestampedTranscript) {
     const contentLabel = isAudioOnly ? "transcript" : "caption track";
-    throw new MuxAiError(`No usable content found in ${contentLabel}`, { type: "validation_error" });
+    throw new MuxAiError(`No usable content found in ${contentLabel}.`, { type: "validation_error" });
   }
 
   // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track
@@ -383,7 +383,7 @@ export async function generateChapters(
   }
 
   if (!chaptersData || !chaptersData.chapters) {
-    throw new MuxAiError("No chapters generated from AI response");
+    throw new MuxAiError(`Failed to generate chapters for asset ${assetId}.`);
   }
 
   // Validate and sort chapters
@@ -393,7 +393,7 @@ export async function generateChapters(
     .sort((a, b) => a.startTime - b.startTime);
 
   if (validChapters.length === 0) {
-    throw new MuxAiError("No valid chapters found in AI response");
+    throw new MuxAiError(`Failed to generate valid chapters for asset ${assetId}.`);
   }
 
   // Ensure first chapter starts at 0

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -3,7 +3,7 @@ import dedent from "dedent";
 import { z } from "zod";
 
 import { getLanguageName } from "@mux/ai/lib/language-codes";
-import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
+import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -379,9 +379,7 @@ export async function generateChapters(
       credentials,
     });
   } catch (error) {
-    throw new Error(
-      `Failed to generate chapters with ${provider}: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
+    wrapError(error, `Failed to generate chapters with ${provider}`);
   }
 
   if (!chaptersData || !chaptersData.chapters) {

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -3,7 +3,7 @@ import dedent from "dedent";
 import { z } from "zod";
 
 import env from "@mux/ai/env";
-import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
+import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -493,7 +493,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
   try {
     vttContent = await fetchVttFromMux(vttUrl);
   } catch (error) {
-    throw new Error(`Failed to fetch VTT content: ${error instanceof Error ? error.message : "Unknown error"}`);
+    wrapError(error, "Failed to fetch VTT content");
   }
 
   let editedVtt = vttContent;
@@ -527,7 +527,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
       detectedProfanity = result.profanity;
       usage = result.usage;
     } catch (error) {
-      throw new Error(`Failed to detect profanity with ${modelConfig.provider}: ${error instanceof Error ? error.message : "Unknown error"}`);
+      wrapError(error, `Failed to detect profanity with ${modelConfig.provider}`);
     }
 
     const finalProfanity = applyOverrideLists(detectedProfanity, alwaysCensor, neverCensor);
@@ -573,7 +573,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
         s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
       });
     } catch (error) {
-      throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
+      wrapError(error, "Failed to upload VTT to S3");
     }
 
     // Add edited track to Mux asset (only when uploadToMux is true)

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -3,6 +3,7 @@ import dedent from "dedent";
 import { z } from "zod";
 
 import env from "@mux/ai/env";
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -429,11 +430,11 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
   const hasAutoCensor = !!autoCensorOption;
   const hasReplacements = !!replacementsOption && replacementsOption.length > 0;
   if (!hasAutoCensor && !hasReplacements) {
-    throw new Error("At least one of autoCensorProfanity or replacements must be provided.");
+    throw new MuxAiError("At least one of autoCensorProfanity or replacements must be provided.", { type: "validation_error" });
   }
 
   if (autoCensorOption && !provider) {
-    throw new Error("provider is required when using autoCensorProfanity.");
+    throw new MuxAiError("provider is required when using autoCensorProfanity.", { type: "validation_error" });
   }
 
   const deleteOriginal = deleteOriginalTrack !== false;
@@ -448,10 +449,11 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
 
   if (uploadToS3 && (!s3Endpoint || !s3Bucket || (!storageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
-    throw new Error(
+    throw new MuxAiError(
       "Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. " +
       "If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options " +
       "or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.",
+      { type: "validation_error" },
     );
   }
 
@@ -462,9 +464,10 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
   if (policy === "signed" && !signingContext) {
-    throw new Error(
+    throw new MuxAiError(
       "Signed playback ID requires signing credentials. " +
       "Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables.",
+      { type: "validation_error" },
     );
   }
 
@@ -476,9 +479,10 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
       .map(t => t.id)
       .filter(Boolean)
       .join(", ");
-    throw new Error(
+    throw new MuxAiError(
       `Track '${trackId}' not found or not ready on asset '${assetId}'. ` +
       `Available track IDs: ${availableTrackIds || "none"}`,
+      { type: "validation_error" },
     );
   }
 
@@ -503,7 +507,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
 
     const plainText = extractTextFromVTT(vttContent);
     if (!plainText.trim()) {
-      throw new Error("Track transcript is empty; nothing to censor.");
+      throw new MuxAiError("Track transcript is empty; nothing to censor.");
     }
 
     const modelConfig = resolveLanguageModelConfig({

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -480,8 +480,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
       .filter(Boolean)
       .join(", ");
     throw new MuxAiError(
-      `Track '${trackId}' not found or not ready on asset '${assetId}'. ` +
-      `Available track IDs: ${availableTrackIds || "none"}`,
+      `Track ${trackId} not found or not ready on asset ${assetId}. Available track IDs: ${availableTrackIds || "none"}.`,
       { type: "validation_error" },
     );
   }

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -507,7 +507,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
 
     const plainText = extractTextFromVTT(vttContent);
     if (!plainText.trim()) {
-      throw new MuxAiError("Track transcript is empty; nothing to censor.");
+      throw new MuxAiError("Track transcript is empty; nothing to censor.", { type: "validation_error" });
     }
 
     const modelConfig = resolveLanguageModelConfig({

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -2,6 +2,7 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -534,7 +535,7 @@ export async function generateEngagementInsights(
   } = options;
 
   if (!Number.isInteger(hotspotLimit) || hotspotLimit < 1 || hotspotLimit > 10) {
-    throw new Error("hotspotLimit must be an integer between 1 and 10");
+    throw new MuxAiError("hotspotLimit must be an integer between 1 and 10", { type: "validation_error" });
   }
 
   const modelConfig = resolveLanguageModelConfig({
@@ -548,16 +549,17 @@ export async function generateEngagementInsights(
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(asset);
 
   if (!assetDurationSeconds) {
-    throw new Error(`Asset ${assetId} has no valid duration`);
+    throw new MuxAiError(`Asset ${assetId} has no valid duration`, { type: "validation_error" });
   }
 
   const audioOnly = isAudioOnlyAsset(asset);
 
   const signingContext = await resolveMuxSigningContext(credentials);
   if (policy === "signed" && !signingContext) {
-    throw new Error(
+    throw new MuxAiError(
       "Signed playback ID requires signing credentials. " +
       "Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables.",
+      { type: "validation_error" },
     );
   }
 
@@ -700,7 +702,7 @@ export async function generateEngagementInsights(
   );
 
   if (!aiInsights.momentInsights || aiInsights.momentInsights.length === 0) {
-    throw new Error("Failed to generate insights from AI response");
+    throw new MuxAiError("Failed to generate insights from AI response");
   }
 
   // Step 6: Transform — re-associate AI output with hotspots by hotspotIndex
@@ -727,7 +729,7 @@ export async function generateEngagementInsights(
   }
 
   if (momentInsights.length === 0) {
-    throw new Error(
+    throw new MuxAiError(
       "AI returned insights but none matched valid hotspot indices. " +
       "This may indicate a prompt or model issue.",
     );

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -535,7 +535,7 @@ export async function generateEngagementInsights(
   } = options;
 
   if (!Number.isInteger(hotspotLimit) || hotspotLimit < 1 || hotspotLimit > 10) {
-    throw new MuxAiError("hotspotLimit must be an integer between 1 and 10", { type: "validation_error" });
+    throw new MuxAiError("hotspotLimit must be an integer between 1 and 10.", { type: "validation_error" });
   }
 
   const modelConfig = resolveLanguageModelConfig({
@@ -549,7 +549,7 @@ export async function generateEngagementInsights(
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(asset);
 
   if (!assetDurationSeconds) {
-    throw new MuxAiError(`Asset ${assetId} has no valid duration`, { type: "validation_error" });
+    throw new MuxAiError(`Asset ${assetId} has no valid duration.`, { type: "validation_error" });
   }
 
   const audioOnly = isAudioOnlyAsset(asset);
@@ -702,7 +702,7 @@ export async function generateEngagementInsights(
   );
 
   if (!aiInsights.momentInsights || aiInsights.momentInsights.length === 0) {
-    throw new MuxAiError("Failed to generate insights from AI response");
+    throw new MuxAiError(`Failed to generate insights for asset ${assetId}.`);
   }
 
   // Step 6: Transform — re-associate AI output with hotspots by hotspotIndex
@@ -730,8 +730,7 @@ export async function generateEngagementInsights(
 
   if (momentInsights.length === 0) {
     throw new MuxAiError(
-      "AI returned insights but none matched valid hotspot indices. " +
-      "This may indicate a prompt or model issue.",
+      `Failed to generate valid insights for asset ${assetId}.`,
     );
   }
 

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -613,7 +613,7 @@ export async function getSummaryAndTags(
   // Validate tone parameter
   if (!VALID_TONES.includes(tone)) {
     throw new MuxAiError(
-      `Invalid tone "${tone}". Valid tones are: ${VALID_TONES.join(", ")}`,
+      `Invalid tone "${tone}". Valid tones are: ${VALID_TONES.join(", ")}.`,
       { type: "validation_error" },
     );
   }

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
 import { getLanguageName } from "@mux/ai/lib/language-codes";
-import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
+import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -728,15 +728,12 @@ export async function getSummaryAndTags(
     }
   } catch (error: unknown) {
     const contentType = isAudioOnly ? "audio" : "video";
-    throw new Error(
-      `Failed to analyze ${contentType} content with ${provider}: ${
-        error instanceof Error ? error.message : "Unknown error"
-      }`,
-    );
+    wrapError(error, `Failed to analyze ${contentType} content with ${provider}`);
   }
 
   if (!analysisResponse.result) {
-    throw new MuxAiError(`Failed to analyze video content for asset ${assetId}`);
+    const contentType = isAudioOnly ? "audio" : "video";
+    throw new MuxAiError(`Failed to analyze ${contentType} content for asset ${assetId}`);
   }
 
   if (!analysisResponse.result.title) {

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
 import { getLanguageName } from "@mux/ai/lib/language-codes";
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -611,8 +612,9 @@ export async function getSummaryAndTags(
 
   // Validate tone parameter
   if (!VALID_TONES.includes(tone)) {
-    throw new Error(
+    throw new MuxAiError(
       `Invalid tone "${tone}". Valid tones are: ${VALID_TONES.join(", ")}`,
+      { type: "validation_error" },
     );
   }
 
@@ -633,17 +635,19 @@ export async function getSummaryAndTags(
 
   // Audio-only assets require transcripts since there's no visual content
   if (isAudioOnly && !includeTranscript) {
-    throw new Error(
+    throw new MuxAiError(
       "Audio-only assets require a transcript. Set includeTranscript: true and ensure the asset has a ready text track (captions/subtitles).",
+      { type: "validation_error" },
     );
   }
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(workflowCredentials);
   if (policy === "signed" && !signingContext) {
-    throw new Error(
+    throw new MuxAiError(
       "Signed playback ID requires signing credentials. " +
       "Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables.",
+      { type: "validation_error" },
     );
   }
 
@@ -732,15 +736,15 @@ export async function getSummaryAndTags(
   }
 
   if (!analysisResponse.result) {
-    throw new Error(`Failed to analyze video content for asset ${assetId}`);
+    throw new MuxAiError(`Failed to analyze video content for asset ${assetId}`);
   }
 
   if (!analysisResponse.result.title) {
-    throw new Error(`Failed to generate title for asset ${assetId}`);
+    throw new MuxAiError(`Failed to generate title for asset ${assetId}`);
   }
 
   if (!analysisResponse.result.description) {
-    throw new Error(`Failed to generate description for asset ${assetId}`);
+    throw new MuxAiError(`Failed to generate description for asset ${assetId}`);
   }
 
   return {

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -733,15 +733,15 @@ export async function getSummaryAndTags(
 
   if (!analysisResponse.result) {
     const contentType = isAudioOnly ? "audio" : "video";
-    throw new MuxAiError(`Failed to analyze ${contentType} content for asset ${assetId}`);
+    throw new MuxAiError(`Failed to analyze ${contentType} content for asset ${assetId}.`);
   }
 
   if (!analysisResponse.result.title) {
-    throw new MuxAiError(`Failed to generate title for asset ${assetId}`);
+    throw new MuxAiError(`Failed to generate title for asset ${assetId}.`);
   }
 
   if (!analysisResponse.result.description) {
-    throw new MuxAiError(`Failed to generate description for asset ${assetId}`);
+    throw new MuxAiError(`Failed to generate description for asset ${assetId}.`);
   }
 
   return {

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -408,7 +408,7 @@ export async function translateAudio(
   } = options;
 
   if (provider !== "elevenlabs") {
-    throw new MuxAiError("Only ElevenLabs provider is currently supported for audio translation", { type: "validation_error" });
+    throw new MuxAiError("Only ElevenLabs provider is currently supported for audio translation.", { type: "validation_error" });
   }
 
   const credentials = providedCredentials;

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -2,6 +2,7 @@ import env from "@mux/ai/env";
 import { getApiKeyFromEnv } from "@mux/ai/lib/client-factory";
 import { getLanguageCodePair, toISO639_1, toISO639_3 } from "@mux/ai/lib/language-codes";
 import type { LanguageCodePair, SupportedISO639_1 } from "@mux/ai/lib/language-codes";
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
 import {
   createPresignedGetUrlWithStorageAdapter,
@@ -185,14 +186,15 @@ async function waitForAudioStaticRendition({
     );
 
     if (currentStatus === "errored") {
-      throw new Error(
+      throw new MuxAiError(
         "Mux failed to create the static rendition for this asset. Please check the asset in the Mux dashboard.",
       );
     }
   }
 
-  throw new Error(
+  throw new MuxAiError(
     "Timed out waiting for the static rendition to become ready. Please try again in a moment.",
+    { retryable: true },
   );
 }
 
@@ -407,7 +409,7 @@ export async function translateAudio(
   } = options;
 
   if (provider !== "elevenlabs") {
-    throw new Error("Only ElevenLabs provider is currently supported for audio translation");
+    throw new MuxAiError("Only ElevenLabs provider is currently supported for audio translation", { type: "validation_error" });
   }
 
   const credentials = providedCredentials;
@@ -424,7 +426,7 @@ export async function translateAudio(
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
 
   if (uploadToS3 && (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
-    throw new Error("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
+    throw new MuxAiError("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.", { type: "validation_error" });
   }
 
   // Fetch asset data and playback ID from Mux
@@ -446,7 +448,7 @@ export async function translateAudio(
   const audioRendition = getReadyAudioStaticRendition(currentAsset);
 
   if (!audioRendition) {
-    throw new Error(
+    throw new MuxAiError(
       "Unable to obtain an audio-only static rendition for this asset. Please verify static renditions are enabled in Mux.",
     );
   }
@@ -522,7 +524,7 @@ export async function translateAudio(
   }
 
   if (dubbingStatus !== "dubbed") {
-    throw new Error(`Dubbing job timed out or failed. Final status: ${dubbingStatus}`);
+    throw new MuxAiError(`Dubbing job timed out or failed. Final status: ${dubbingStatus}`, { retryable: true });
   }
 
   console.warn("✅ Dubbing completed successfully!");

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -524,7 +524,7 @@ export async function translateAudio(
   }
 
   if (dubbingStatus !== "dubbed") {
-    throw new MuxAiError(`Dubbing job timed out or failed. Final status: ${dubbingStatus}`, { type: "timeout_error", retryable: true });
+    throw new MuxAiError("Audio translation timed out or failed. Please try again.", { type: "timeout_error", retryable: true });
   }
 
   console.warn("✅ Dubbing completed successfully!");

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -450,6 +450,7 @@ export async function translateAudio(
   if (!audioRendition) {
     throw new MuxAiError(
       "Unable to obtain an audio-only static rendition for this asset. Please verify static renditions are enabled in Mux.",
+      { type: "validation_error" },
     );
   }
 

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -2,7 +2,7 @@ import env from "@mux/ai/env";
 import { getApiKeyFromEnv } from "@mux/ai/lib/client-factory";
 import { getLanguageCodePair, toISO639_1, toISO639_3 } from "@mux/ai/lib/language-codes";
 import type { LanguageCodePair, SupportedISO639_1 } from "@mux/ai/lib/language-codes";
-import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
+import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
 import {
   createPresignedGetUrlWithStorageAdapter,
@@ -139,8 +139,7 @@ async function requestStaticRenditionCreation(
       return;
     }
 
-    const message = error instanceof Error ? error.message : "Unknown error";
-    throw new Error(`Failed to request static rendition from Mux: ${message}`);
+    wrapError(error, "Failed to request static rendition from Mux");
   }
 }
 
@@ -194,7 +193,7 @@ async function waitForAudioStaticRendition({
 
   throw new MuxAiError(
     "Timed out waiting for the static rendition to become ready. Please try again in a moment.",
-    { retryable: true },
+    { type: "timeout_error", retryable: true },
   );
 }
 
@@ -467,7 +466,7 @@ export async function translateAudio(
   try {
     audioBuffer = await fetchAudioFromMux(audioUrl);
   } catch (error) {
-    throw new Error(`Failed to fetch audio from Mux: ${error instanceof Error ? error.message : "Unknown error"}`);
+    wrapError(error, "Failed to fetch audio from Mux");
   }
 
   // Create dubbing job in ElevenLabs
@@ -493,7 +492,7 @@ export async function translateAudio(
     });
     console.warn(`✅ Dubbing job created with ID: ${dubbingId}`);
   } catch (error) {
-    throw new Error(`Failed to create ElevenLabs dubbing job: ${error instanceof Error ? error.message : "Unknown error"}`);
+    wrapError(error, "Failed to create ElevenLabs dubbing job");
   }
 
   // Poll for completion
@@ -520,12 +519,12 @@ export async function translateAudio(
         throw new Error("ElevenLabs dubbing job failed");
       }
     } catch (error) {
-      throw new Error(`Failed to check dubbing status: ${error instanceof Error ? error.message : "Unknown error"}`);
+      wrapError(error, "Failed to check dubbing status");
     }
   }
 
   if (dubbingStatus !== "dubbed") {
-    throw new MuxAiError(`Dubbing job timed out or failed. Final status: ${dubbingStatus}`, { retryable: true });
+    throw new MuxAiError(`Dubbing job timed out or failed. Final status: ${dubbingStatus}`, { type: "timeout_error", retryable: true });
   }
 
   console.warn("✅ Dubbing completed successfully!");
@@ -571,7 +570,7 @@ export async function translateAudio(
       });
       console.warn("✅ Dubbed audio downloaded successfully!");
     } catch (error) {
-      throw new Error(`Failed to download dubbed audio: ${error instanceof Error ? error.message : "Unknown error"}`);
+      wrapError(error, "Failed to download dubbed audio");
     }
 
     // Upload to S3-compatible storage
@@ -589,7 +588,7 @@ export async function translateAudio(
         s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
       });
     } catch (error) {
-      throw new Error(`Failed to upload audio to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
+      wrapError(error, "Failed to upload audio to S3");
     }
 
     // Add translated audio track to Mux asset (only when uploadToMux is true)

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -746,8 +746,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
       .filter(Boolean)
       .join(", ");
     throw new MuxAiError(
-      `Track '${trackId}' not found or not ready on asset '${assetId}'. ` +
-      `Available track IDs: ${availableTrackIds || "none"}`,
+      `Track ${trackId} not found or not ready on asset ${assetId}. Available track IDs: ${availableTrackIds || "none"}.`,
       { type: "validation_error" },
     );
   }
@@ -755,8 +754,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   const fromLanguageCode = sourceTextTrack.language_code;
   if (!fromLanguageCode) {
     throw new MuxAiError(
-      `Track '${trackId}' is missing language metadata (language_code). ` +
-      `Cannot determine source language for translation.`,
+      `Track ${trackId} is missing language metadata. Cannot determine source language for translation.`,
       { type: "validation_error" },
     );
   }

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import env from "@mux/ai/env";
 import { getLanguageCodePair, getLanguageName } from "@mux/ai/lib/language-codes";
 import type { LanguageCodePair, SupportedISO639_1 } from "@mux/ai/lib/language-codes";
+import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -721,7 +722,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   });
 
   if (uploadToS3 && (!s3Endpoint || !s3Bucket || (!effectiveStorageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
-    throw new Error("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.");
+    throw new MuxAiError("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.", { type: "validation_error" });
   }
 
   // Fetch asset data and playback ID from Mux
@@ -731,9 +732,10 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
   if (policy === "signed" && !signingContext) {
-    throw new Error(
+    throw new MuxAiError(
       "Signed playback ID requires signing credentials. " +
       "Set MUX_SIGNING_KEY and MUX_PRIVATE_KEY environment variables.",
+      { type: "validation_error" },
     );
   }
 
@@ -745,17 +747,19 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
       .map(t => t.id)
       .filter(Boolean)
       .join(", ");
-    throw new Error(
+    throw new MuxAiError(
       `Track '${trackId}' not found or not ready on asset '${assetId}'. ` +
       `Available track IDs: ${availableTrackIds || "none"}`,
+      { type: "validation_error" },
     );
   }
 
   const fromLanguageCode = sourceTextTrack.language_code;
   if (!fromLanguageCode) {
-    throw new Error(
+    throw new MuxAiError(
       `Track '${trackId}' is missing language metadata (language_code). ` +
       `Cannot determine source language for translation.`,
+      { type: "validation_error" },
     );
   }
 

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import env from "@mux/ai/env";
 import { getLanguageCodePair, getLanguageName } from "@mux/ai/lib/language-codes";
 import type { LanguageCodePair, SupportedISO639_1 } from "@mux/ai/lib/language-codes";
-import { MuxAiError } from "@mux/ai/lib/mux-ai-error";
+import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
@@ -539,9 +539,7 @@ async function translateChunkWithFallback({
     };
   } catch (error) {
     if (!shouldSplitChunkTranslationError(error) || chunk.cueCount <= 1) {
-      throw new Error(
-        `Chunk ${chunk.id} failed for ${Math.round(chunk.startTime)}s-${Math.round(chunk.endTime)}s: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      wrapError(error, `Chunk ${chunk.id} failed for ${Math.round(chunk.startTime)}s-${Math.round(chunk.endTime)}s`);
     }
 
     const [leftChunk, rightChunk] = splitTranslationChunkAtMidpoint(chunk);
@@ -770,7 +768,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
   try {
     vttContent = await fetchVttFromMux(vttUrl);
   } catch (error) {
-    throw new Error(`Failed to fetch VTT content: ${error instanceof Error ? error.message : "Unknown error"}`);
+    wrapError(error, "Failed to fetch VTT content");
   }
 
   // Translate VTT content using configured provider via ai-sdk
@@ -791,7 +789,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     translatedVtt = result.translatedVtt;
     usage = result.usage;
   } catch (error) {
-    throw new Error(`Failed to translate VTT with ${modelConfig.provider}: ${error instanceof Error ? error.message : "Unknown error"}`);
+    wrapError(error, `Failed to translate VTT with ${modelConfig.provider}`);
   }
 
   const usageWithMetadata = usage ?
@@ -825,7 +823,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
         s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
       });
     } catch (error) {
-      throw new Error(`Failed to upload VTT to S3: ${error instanceof Error ? error.message : "Unknown error"}`);
+      wrapError(error, "Failed to upload VTT to S3");
     }
 
     // Add translated track to Mux asset (only when uploadToMux is true)


### PR DESCRIPTION
# Overview

Adds `MuxAiError` so `@mux/ai` can mark errors as customer-safe. Downstream consumers identify these via a structural brand (`__robots_error`) using duck typing -- no shared dependency. Errors that don't carry the brand are treated as internal and obfuscated before reaching customers.

# What was changed

**New file: `src/lib/mux-ai-error.ts`**
- `MuxAiError` class with `__robots_error` structural brand, `publicMessage`, `publicType`, and `retryable` as own properties (survive JSON serialization across workflow step boundaries).
- `MuxAiErrorType` union: `"validation_error" | "processing_error" | "timeout_error"`.
- `wrapError(error, message)` helper -- re-throws `MuxAiError` as-is, wraps anything else as plain `Error`. Prevents catch blocks from accidentally stripping the brand.

**`src/index.ts`** -- exports `MuxAiError`, `MuxAiErrorType`, `wrapError`.

**Across 7 workflow files + 3 lib/primitive files:**
- ~40 error sites converted from `throw new Error(...)` to `throw new MuxAiError(...)` where the message is customer-safe.
- Each error classified as `validation_error` (bad input, missing config, asset state), `processing_error` (AI/generation failures), or `timeout_error` (retryable timeouts).
- Internal errors (provider failures, network issues, crypto) left as plain `Error`.
- Catch blocks that re-throw now use `wrapError()` instead of `throw new Error(... error.message ...)`.
- Error messages audited for consistency: trailing periods, no quoted IDs, aligned phrasing (`"Failed to X for asset Y."`), no internal jargon in customer-facing messages, unified track terminology.

# Suggested review order

1. `src/lib/mux-ai-error.ts` -- the class, type, and `wrapError` helper (the entire contract).
2. `src/lib/mux-assets.ts` -- simplest conversion, one error site.
3. `src/primitives/transcripts.ts` -- shows `wrapError` replacing the manual `instanceof MuxAiError` guard in a catch block.
4. `src/primitives/shots.ts` -- shows `timeout_error` + `retryable: true` usage.
5. Any workflow file (they all follow the same pattern) -- `ask-questions.ts` or `summarization.ts` are representative.
6. `src/index.ts` -- exports only.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error types and messages surfaced from multiple workflows/primitives, which can affect downstream error handling and retry behavior. Logic is largely unchanged but error classification (`validation_error`/`timeout_error`) must be validated in real integrations.
> 
> **Overview**
> Adds a new `MuxAiError` (with a structural `__robots_error` brand) plus `MuxAiErrorType` and `wrapError`, and exports them from `src/index.ts` for downstream consumers.
> 
> Updates workflows and helpers (e.g. `ask-questions`, `summarization`, `chapters`, `translate-*`, `edit-captions`, `engagement-insights`, plus `shots`, `transcripts`, `mux-assets`) to replace many generic `Error` throws with `MuxAiError` for **customer-safe, categorized** failures (notably input/config validation and retryable timeouts), and switches several rethrowing catch blocks to `wrapError` to avoid stripping the customer-safe brand.
> 
> Bumps package version to `0.15.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006bebb2b098c6e2cf217029802b591457c1c206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->