### PR TITLE
chore: update unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -284,7 +284,7 @@ describe("waitForShotsForAsset", () => {
       maxAttempts: 3,
     });
     const expectation = expect(promise).rejects.toThrow(
-      "Timed out waiting for shots for asset 'test-asset-123' after 3 attempts. Last status: pending",
+      "Timed out waiting for shots for asset test-asset-123. Last status: pending.",
     );
 
     await vi.runAllTimersAsync();
@@ -302,7 +302,7 @@ describe("waitForShotsForAsset", () => {
       maxAttempts: 3,
     });
     const expectation = expect(promise).rejects.toThrow(
-      "Shots generation errored for asset 'test-asset-123'",
+      "Shot generation failed for asset test-asset-123.",
     );
 
     await vi.runAllTimersAsync();


### PR DESCRIPTION
Somehow, these tests passed on the branch itself but are only failing in the `publish` npm step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only bumps the package version and updates unit test expectations for `waitForShotsForAsset` error message strings; no runtime logic changes are included in the diff.
> 
> **Overview**
> Bumps the library version from `0.15.0` to `0.15.1` (including `package-lock.json`).
> 
> Updates `tests/unit/shots.test.ts` to assert the new, normalized error messages thrown by `waitForShotsForAsset` for timeout and terminal `errored` states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27880f5ed6607f894d363ed14fd823afaafab094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->