### PR TITLE
feat!: Move custom answers into per-question

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -171,7 +171,8 @@ Answer questions about asset content by analyzing storyboard frames and optional
 - `assetId` (string) - Mux asset ID (video or audio-only)
 - `questions` (array) - Array of question objects
   - Each question object must have a `question` field (string)
-  - Example: `[{ question: "Does this video contain cooking?" }]`
+  - Each question may optionally include `answerOptions?: string[]` (defaults to `["yes", "no"]`)
+  - Example: `[{ question: "Does this video contain cooking?", answerOptions: ["yes", "no", "unsure"] }]`
 - `options` (optional) - Configuration options
 
 **Options:**
@@ -179,7 +180,6 @@ Answer questions about asset content by analyzing storyboard frames and optional
 - `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
 - `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `languageCode?: string` - Language code for transcript track selection (e.g., 'en', 'fr'). When omitted, prefers English if available.
-- `answerOptions?: string[]` - Allowed answers (default: `["yes", "no"]`)
 - `includeTranscript?: boolean` - Include transcript in analysis (default: true, required for audio-only assets)
 - `cleanTranscript?: boolean` - Remove VTT timestamps and formatting from transcript (default: true)
 - `imageSubmissionMode?: 'url' | 'base64'` - How to submit storyboard to AI providers (default: 'url')
@@ -233,10 +233,11 @@ const result = await askQuestions("asset-id", questions, {
   includeTranscript: false
 });
 
-// Custom answer options
-const triState = await askQuestions("asset-id", questions, {
-  answerOptions: ["yes", "no", "unsure"]
-});
+// Per-question answer options
+const triState = await askQuestions("asset-id", [
+  { question: "Does this contain cooking?", answerOptions: ["yes", "no", "unsure"] },
+  { question: "How is the production quality?", answerOptions: ["low", "medium", "high"] },
+]);
 ```
 
 **Tips for Effective Questions:**

--- a/docs/API.md
+++ b/docs/API.md
@@ -172,7 +172,7 @@ Answer questions about asset content by analyzing storyboard frames and optional
 - `questions` (array) - Array of question objects
   - Each question object must have a `question` field (string)
   - Each question may optionally include `answerOptions?: string[]` (defaults to `["yes", "no"]`)
-  - Example: `[{ question: "Does this video contain cooking?", answerOptions: ["yes", "no", "unsure"] }]`
+  - Example: `[{ question: "What is the production quality?", answerOptions: ["amateur", "semi-pro", "professional"] }]`
 - `options` (optional) - Configuration options
 
 **Options:**
@@ -233,10 +233,12 @@ const result = await askQuestions("asset-id", questions, {
   includeTranscript: false
 });
 
-// Per-question answer options
-const triState = await askQuestions("asset-id", [
-  { question: "Does this contain cooking?", answerOptions: ["yes", "no", "unsure"] },
-  { question: "How is the production quality?", answerOptions: ["low", "medium", "high"] },
+// Per-question answer options — mix yes/no with classification scales
+const result = await askQuestions("asset-id", [
+  { question: "Does this contain cooking?" }, // defaults to yes/no
+  { question: "What is the production quality?", answerOptions: ["amateur", "semi-pro", "professional"] },
+  { question: "What is the primary content type?", answerOptions: ["tutorial", "entertainment", "news", "advertisement"] },
+  { question: "What is the overall sentiment?", answerOptions: ["positive", "neutral", "negative"] },
 ]);
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -235,7 +235,7 @@ const result = await askQuestions("asset-id", questions, {
 
 // Per-question answer options — mix yes/no with classification scales
 const result = await askQuestions("asset-id", [
-  { question: "Does this contain cooking?" }, // defaults to yes/no
+  { question: "Does this contain cooking?" }, // answer options default to yes/no
   { question: "What is the production quality?", answerOptions: ["amateur", "semi-pro", "professional"] },
   { question: "What is the primary content type?", answerOptions: ["tutorial", "entertainment", "news", "advertisement"] },
   { question: "What is the overall sentiment?", answerOptions: ["positive", "neutral", "negative"] },

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -136,7 +136,7 @@ console.log(result.detectedLanguage); // Language if captions detected
 
 ## Ask Questions
 
-Answer questions about asset content by analyzing storyboard frames and optional transcripts. For audio-only assets, this workflow analyzes transcript text only. By default, answers are "yes"/"no", but you can override the allowed responses.
+Answer questions about asset content by analyzing storyboard frames and optional transcripts. For audio-only assets, this workflow analyzes transcript text only. By default, answers are "yes"/"no", but you can specify different allowed answers per question.
 
 ```typescript
 import { askQuestions } from "@mux/ai/workflows";
@@ -181,13 +181,24 @@ result.answers.forEach(answer => {
 - **Accessibility Audits:** "Are there visual text elements?", "Does this rely only on audio?"
 - **Metadata Validation:** "Does the content match the title?", "Is this in English?"
 
+### Per-question Answer Options
+
+Each question can specify its own allowed answers. Questions without `answerOptions` default to `["yes", "no"]`:
+
+```typescript
+const result = await askQuestions(assetId, [
+  { question: "Does this video contain people?" }, // defaults to yes/no
+  { question: "Is this suitable for children?", answerOptions: ["yes", "no", "unsure"] },
+  { question: "How is the production quality?", answerOptions: ["low", "medium", "high"] },
+]);
+```
+
 ### Configuration Options
 
 ```typescript
 const result = await askQuestions(assetId, questions, {
   provider: "openai", // "openai", "anthropic", or "google" (default: "openai")
   model: "gpt-5.1", // Override default model
-  answerOptions: ["yes", "no", "unsure"], // Override allowed answers
   includeTranscript: true, // Include transcript (default: true)
   cleanTranscript: true, // Remove timestamps/markup (default: true)
   imageSubmissionMode: "url", // "url" or "base64" (default: "url")

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -187,7 +187,7 @@ Each question can specify its own allowed answers, so classification scales and 
 
 ```typescript
 const result = await askQuestions(assetId, [
-  { question: "Does this video contain people?" }, // defaults to yes/no
+  { question: "Does this video contain people?" }, // answer options default to yes/no
   { question: "What is the primary content type?", answerOptions: ["tutorial", "entertainment", "news", "advertisement"] },
   { question: "What is the production quality?", answerOptions: ["amateur", "semi-pro", "professional"] },
   { question: "What is the primary spoken language?", answerOptions: ["english", "spanish", "french", "other"] },

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -183,13 +183,14 @@ result.answers.forEach(answer => {
 
 ### Per-question Answer Options
 
-Each question can specify its own allowed answers. Questions without `answerOptions` default to `["yes", "no"]`:
+Each question can specify its own allowed answers, so classification scales and enumerations can sit alongside simple yes/no checks in a single call. Questions without `answerOptions` default to `["yes", "no"]`:
 
 ```typescript
 const result = await askQuestions(assetId, [
   { question: "Does this video contain people?" }, // defaults to yes/no
-  { question: "Is this suitable for children?", answerOptions: ["yes", "no", "unsure"] },
-  { question: "How is the production quality?", answerOptions: ["low", "medium", "high"] },
+  { question: "What is the primary content type?", answerOptions: ["tutorial", "entertainment", "news", "advertisement"] },
+  { question: "What is the production quality?", answerOptions: ["amateur", "semi-pro", "professional"] },
+  { question: "What is the primary spoken language?", answerOptions: ["english", "spanish", "french", "other"] },
 ]);
 ```
 

--- a/examples/ask-questions/README.md
+++ b/examples/ask-questions/README.md
@@ -18,7 +18,7 @@ npm install
 
 ### Per-question Answer Options (CLI syntax)
 
-Each question defaults to yes/no. To specify custom allowed answers for a question, append a pipe character followed by a comma-separated list of options:
+Each question's answer options default to yes/no. To specify custom allowed answers for a question, append a pipe character followed by a comma-separated list of options:
 
 ```
 "Question text|option1,option2,option3"
@@ -29,7 +29,7 @@ The pipe must be inside the quoted string so the shell doesn't treat it as a com
 ```bash
 "What is the production quality?|amateur,semi-pro,professional"
 "What is the sentiment?|positive,neutral,negative"
-"Does this contain cooking?"   # no pipe → defaults to yes/no
+"Does this contain cooking?"   # no pipe → answer options default to yes/no
 ```
 
 ### Basic Example
@@ -146,7 +146,7 @@ You can ask multiple questions in a single call for efficiency. Each question ca
 import { askQuestions } from "@mux/ai/workflows";
 
 const result = await askQuestions("asset-id", [
-  { question: "Does this video contain cooking?" }, // defaults to yes/no
+  { question: "Does this video contain cooking?" }, // answer options default to yes/no
   {
     question: "What is the primary content type?",
     answerOptions: ["tutorial", "entertainment", "news", "advertisement"],

--- a/examples/ask-questions/README.md
+++ b/examples/ask-questions/README.md
@@ -1,6 +1,6 @@
 # Ask Questions Examples
 
-Examples demonstrating how to use the `askQuestions` workflow to answer yes/no questions about asset content.
+Examples demonstrating how to use the `askQuestions` workflow to answer questions about asset content. Each question can specify its own allowed answers (defaulting to `["yes", "no"]`), so simple binary checks and richer classification scales can be mixed in a single call.
 
 ## Setup
 
@@ -16,9 +16,25 @@ npm install
 
 ## Examples
 
+### Per-question Answer Options (CLI syntax)
+
+Each question defaults to yes/no. To specify custom allowed answers for a question, append a pipe character followed by a comma-separated list of options:
+
+```
+"Question text|option1,option2,option3"
+```
+
+The pipe must be inside the quoted string so the shell doesn't treat it as a command pipeline. For example:
+
+```bash
+"What is the production quality?|amateur,semi-pro,professional"
+"What is the sentiment?|positive,neutral,negative"
+"Does this contain cooking?"   # no pipe → defaults to yes/no
+```
+
 ### Basic Example
 
-Ask a single yes/no question about a video:
+Ask a single question about a video:
 
 ```bash
 # From the examples/ask-questions directory
@@ -36,8 +52,11 @@ npm run example:ask-questions -- <asset-id> "Does this video contain cooking?"
 #### Examples
 
 ```bash
-# Ask if a video contains cooking
+# Yes/no question (default)
 npm run basic abc123 "Does this video contain cooking?"
+
+# Custom allowed answers via pipe syntax
+npm run basic abc123 "What is the production quality?|amateur,semi-pro,professional"
 
 # Ask if people are visible, without using transcript
 npm run basic abc123 "Are there people visible in this video?" --no-transcript
@@ -48,7 +67,7 @@ npm run basic abc123 "Is this video shot outdoors?" --model gpt-4o
 
 ### Multiple Questions Example
 
-Ask multiple yes/no questions about a video in a single call (more efficient):
+Ask multiple questions about a video in a single call (more efficient). Questions can mix yes/no checks with custom answer sets using the pipe syntax:
 
 ```bash
 # From the examples/ask-questions directory
@@ -80,8 +99,14 @@ If no asset ID is provided, the script uses `MUX_TEST_ASSET_ID_AUDIO_ONLY`.
 #### Examples
 
 ```bash
-# Ask multiple questions at once
+# Ask multiple yes/no questions at once
 npm run multiple abc123 "Does this contain cooking?" "Are there people visible?" "Is this outdoors?"
+
+# Mix yes/no with per-question answer sets
+npm run multiple abc123 \
+  "Does this contain cooking?" \
+  "What is the production quality?|amateur,semi-pro,professional" \
+  "What is the sentiment?|positive,neutral,negative"
 
 # Multiple questions without transcript
 npm run multiple abc123 "Is this a tutorial?" "Is it shot indoors?" --no-transcript
@@ -102,27 +127,34 @@ The `askQuestions` workflow:
 2. **Generates storyboard** - Creates a grid of frames showing the video timeline (video assets only)
 3. **Fetches transcript** - Optionally includes the video's transcript/captions
 4. **Analyzes content** - Sends storyboard+transcript (video) or transcript-only (audio-only) to the AI model
-5. **Returns structured answers** - Provides yes/no answer, confidence score (0-1), and reasoning
+5. **Returns structured answers** - Provides an answer drawn from the question's allowed options, a confidence score (0-1), and reasoning
 
 ## Answer Format
 
 Each answer includes:
-- **answer**: "yes" or "no"
+- **answer**: One of the question's allowed `answerOptions` (or `null` when skipped as irrelevant)
 - **confidence**: Float between 0 and 1 (e.g., 0.95 = 95% confident)
 - **reasoning**: Explanation citing specific visual or audio evidence
 - **question**: The original question
+- **skipped**: True when the question wasn't answerable from the asset content
 
 ## Multiple Questions
 
-You can ask multiple questions in a single call for efficiency. See the [Multiple Questions Example](#multiple-questions-example) above for a command-line demonstration, or use the API directly:
+You can ask multiple questions in a single call for efficiency. Each question can carry its own `answerOptions`:
 
 ```typescript
 import { askQuestions } from "@mux/ai/workflows";
 
 const result = await askQuestions("asset-id", [
-  { question: "Does this video contain cooking?" },
-  { question: "Are there people visible?" },
-  { question: "Is this shot indoors?" },
+  { question: "Does this video contain cooking?" }, // defaults to yes/no
+  {
+    question: "What is the primary content type?",
+    answerOptions: ["tutorial", "entertainment", "news", "advertisement"],
+  },
+  {
+    question: "What is the production quality?",
+    answerOptions: ["amateur", "semi-pro", "professional"],
+  },
 ]);
 
 result.answers.forEach(answer => {

--- a/examples/ask-questions/audio-only-example.ts
+++ b/examples/ask-questions/audio-only-example.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { askQuestions } from "@mux/ai/workflows";
 
 import env from "../env";
+import { parseQuestionArg } from "./parse-question";
 
 type Provider = "openai" | "anthropic" | "google";
 
@@ -18,23 +19,25 @@ const program = new Command();
 
 program
   .name("ask-questions-audio-only")
-  .description("Ask a yes/no question about an audio-only Mux asset")
+  .description("Ask a question about an audio-only Mux asset")
   .argument(
     "[asset-id]",
     "Mux asset ID to analyze (defaults to MUX_TEST_ASSET_ID_AUDIO_ONLY)",
   )
   .argument(
     "[question]",
-    `Question to ask (defaults to "${DEFAULT_QUESTION}")`,
+    `Question to ask (defaults to "${DEFAULT_QUESTION}"). Defaults to yes/no; ` +
+    "append a pipe + comma-separated options for custom allowed answers, e.g. " +
+    "\"What is the speaker's tone?|calm,excited,angry\"",
   )
   .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
-  .action(async (assetId: string | undefined, question: string | undefined, options: {
+  .action(async (assetId: string | undefined, questionArg: string | undefined, options: {
     provider: Provider;
     model?: string;
   }) => {
     const resolvedAssetId = assetId ?? env.MUX_TEST_ASSET_ID_AUDIO_ONLY;
-    const resolvedQuestion = question?.trim() || DEFAULT_QUESTION;
+    const parsedQuestion = parseQuestionArg(questionArg?.trim() || DEFAULT_QUESTION);
 
     if (!resolvedAssetId) {
       console.error(
@@ -52,12 +55,13 @@ program
 
     console.log("Asset ID:", resolvedAssetId);
     console.log("Asset Type: audio-only");
-    console.log("Question:", resolvedQuestion);
+    console.log("Question:", parsedQuestion.question);
+    console.log(`Allowed answers: ${(parsedQuestion.answerOptions ?? ["yes", "no"]).join(", ")}`);
     console.log(`Provider: ${options.provider} (${model})`);
     console.log("Include Transcript: true\n");
 
     try {
-      const result = await askQuestions(resolvedAssetId, [{ question: resolvedQuestion }], {
+      const result = await askQuestions(resolvedAssetId, [parsedQuestion], {
         provider: options.provider,
         model,
         includeTranscript: true,

--- a/examples/ask-questions/audio-only-example.ts
+++ b/examples/ask-questions/audio-only-example.ts
@@ -26,7 +26,7 @@ program
   )
   .argument(
     "[question]",
-    `Question to ask (defaults to "${DEFAULT_QUESTION}"). Defaults to yes/no; ` +
+    `Question to ask (defaults to "${DEFAULT_QUESTION}"). Answer options default to yes/no; ` +
     "append a pipe + comma-separated options for custom allowed answers, e.g. " +
     "\"What is the speaker's tone?|calm,excited,angry\"",
   )

--- a/examples/ask-questions/basic-example.ts
+++ b/examples/ask-questions/basic-example.ts
@@ -12,7 +12,7 @@ program
   .argument("<asset-id>", "Mux asset ID to analyze")
   .argument(
     "<question>",
-    "Question to ask. Defaults to yes/no. To use custom allowed answers, " +
+    "Question to ask. Answer options default to yes/no. To use custom allowed answers, " +
     "append a pipe followed by comma-separated options, e.g. " +
     "\"What is the quality?|amateur,semi-pro,professional\"",
   )

--- a/examples/ask-questions/basic-example.ts
+++ b/examples/ask-questions/basic-example.ts
@@ -2,23 +2,33 @@ import { Command } from "commander";
 
 import { askQuestions } from "@mux/ai/workflows";
 
+import { parseQuestionArg } from "./parse-question";
+
 const program = new Command();
 
 program
   .name("ask-questions")
-  .description("Ask yes/no questions about a Mux asset")
+  .description("Ask a question about a Mux asset")
   .argument("<asset-id>", "Mux asset ID to analyze")
-  .argument("<question>", "Yes/no question to ask about the asset")
+  .argument(
+    "<question>",
+    "Question to ask. Defaults to yes/no. To use custom allowed answers, " +
+    "append a pipe followed by comma-separated options, e.g. " +
+    "\"What is the quality?|amateur,semi-pro,professional\"",
+  )
   .option("-p, --provider <provider>", "AI provider: openai, anthropic, google (default: openai)")
   .option("-m, --model <model>", "Model name (default varies by provider)")
   .option("--no-transcript", "Exclude transcript from analysis")
-  .action(async (assetId: string, question: string, options: {
+  .action(async (assetId: string, questionArg: string, options: {
     provider?: string;
     model?: string;
     transcript: boolean;
   }) => {
+    const parsedQuestion = parseQuestionArg(questionArg);
+
     console.log("Asset ID:", assetId);
-    console.log("Question:", question);
+    console.log("Question:", parsedQuestion.question);
+    console.log(`Allowed answers: ${(parsedQuestion.answerOptions ?? ["yes", "no"]).join(", ")}`);
     console.log(`Provider: ${options.provider || "openai (default)"}`);
     console.log(`Model: ${options.model || "default"}`);
     console.log(`Include Transcript: ${options.transcript}\n`);
@@ -26,7 +36,7 @@ program
     try {
       // Uses the default prompt built into the library
       // Credentials are automatically read from environment variables
-      const result = await askQuestions(assetId, [{ question }], {
+      const result = await askQuestions(assetId, [parsedQuestion], {
         provider: options.provider as any,
         model: options.model,
         includeTranscript: options.transcript,

--- a/examples/ask-questions/multiple-questions-example.ts
+++ b/examples/ask-questions/multiple-questions-example.ts
@@ -2,29 +2,39 @@ import { Command } from "commander";
 
 import { askQuestions } from "@mux/ai/workflows";
 
+import { parseQuestionArg } from "./parse-question";
+
 const program = new Command();
 
 program
   .name("ask-multiple-questions")
-  .description("Ask multiple yes/no questions about a Mux asset")
+  .description("Ask multiple questions about a Mux asset")
   .argument("<asset-id>", "Mux asset ID to analyze")
-  .argument("<questions...>", "Yes/no questions to ask about the asset (space-separated)")
+  .argument(
+    "<questions...>",
+    "Questions to ask (space-separated). Each defaults to yes/no. " +
+    "To use custom allowed answers for a question, append a pipe followed by " +
+    "comma-separated options, e.g. \"What is the quality?|amateur,semi-pro,professional\"",
+  )
   .option("-p, --provider <provider>", "AI provider: openai, anthropic, google (default: openai)")
   .option("-m, --model <model>", "Model name (default varies by provider)")
   .option("--no-transcript", "Exclude transcript from analysis")
-  .action(async (assetId: string, questions: string[], options: {
+  .action(async (assetId: string, questionArgs: string[], options: {
     provider?: string;
     model?: string;
     transcript: boolean;
   }) => {
+    const questionObjects = questionArgs.map(parseQuestionArg);
+
     console.log("Asset ID:", assetId);
-    console.log(`Questions (${questions.length}):`, questions);
+    console.log(`Questions (${questionObjects.length}):`);
+    questionObjects.forEach((q, idx) => {
+      const answers = (q.answerOptions ?? ["yes", "no"]).join(", ");
+      console.log(`  ${idx + 1}. ${q.question} [${answers}]`);
+    });
     console.log(`Provider: ${options.provider || "openai (default)"}`);
     console.log(`Model: ${options.model || "default"}`);
     console.log(`Include Transcript: ${options.transcript}\n`);
-
-    // Convert string array to Question objects
-    const questionObjects = questions.map(q => ({ question: q }));
 
     try {
       // Uses the default prompt built into the library
@@ -60,12 +70,17 @@ program
       }
 
       // Summary statistics
-      const yesCount = result.answers.filter(a => a.answer === "yes").length;
-      const noCount = result.answers.filter(a => a.answer === "no").length;
+      const answerCounts = result.answers.reduce<Record<string, number>>((acc, a) => {
+        const key = a.answer ?? "(skipped)";
+        acc[key] = (acc[key] ?? 0) + 1;
+        return acc;
+      }, {});
       const avgConfidence = result.answers.reduce((sum, a) => sum + a.confidence, 0) / result.answers.length;
 
       console.log("\n📊 Summary:");
-      console.log(`  Yes: ${yesCount}, No: ${noCount}`);
+      for (const [answer, count] of Object.entries(answerCounts)) {
+        console.log(`  ${answer}: ${count}`);
+      }
       console.log(`  Average Confidence: ${(avgConfidence * 100).toFixed(1)}%`);
     } catch (error) {
       console.error("❌ Error:", error instanceof Error ? error.message : error);

--- a/examples/ask-questions/multiple-questions-example.ts
+++ b/examples/ask-questions/multiple-questions-example.ts
@@ -12,7 +12,7 @@ program
   .argument("<asset-id>", "Mux asset ID to analyze")
   .argument(
     "<questions...>",
-    "Questions to ask (space-separated). Each defaults to yes/no. " +
+    "Questions to ask (space-separated). Answer options default to yes/no. " +
     "To use custom allowed answers for a question, append a pipe followed by " +
     "comma-separated options, e.g. \"What is the quality?|amateur,semi-pro,professional\"",
   )

--- a/examples/ask-questions/parse-question.ts
+++ b/examples/ask-questions/parse-question.ts
@@ -4,7 +4,7 @@ import type { Question } from "@mux/ai/workflows";
  * Parse a CLI question string with optional pipe-delimited answer options.
  *
  * Syntax:
- *   "Question text"                                → defaults to yes/no
+ *   "Question text"                                → answer options default to yes/no
  *   "Question text|option1,option2,option3"        → custom allowed answers
  *
  * Examples:

--- a/examples/ask-questions/parse-question.ts
+++ b/examples/ask-questions/parse-question.ts
@@ -1,0 +1,46 @@
+import type { Question } from "@mux/ai/workflows";
+
+/**
+ * Parse a CLI question string with optional pipe-delimited answer options.
+ *
+ * Syntax:
+ *   "Question text"                                → defaults to yes/no
+ *   "Question text|option1,option2,option3"        → custom allowed answers
+ *
+ * Examples:
+ *   "Is this about glasses?"
+ *   "What is the production quality?|amateur,semi-pro,professional"
+ *   "What is the sentiment?|positive,neutral,negative"
+ *
+ * Shell note: the pipe character must be quoted so the shell doesn't
+ * interpret it as a command pipeline.
+ */
+export function parseQuestionArg(input: string): Question {
+  const pipeIdx = input.indexOf("|");
+  if (pipeIdx === -1) {
+    const question = input.trim();
+    if (!question) {
+      throw new Error("Empty question text.");
+    }
+    return { question };
+  }
+
+  const question = input.slice(0, pipeIdx).trim();
+  const answerOptions = input
+    .slice(pipeIdx + 1)
+    .split(",")
+    .map(o => o.trim())
+    .filter(Boolean);
+
+  if (!question) {
+    throw new Error(`Empty question text in "${input}".`);
+  }
+  if (!answerOptions.length) {
+    throw new Error(
+      `Pipe found but no answer options in "${input}". ` +
+      "Expected format: \"Question text|option1,option2,...\".",
+    );
+  }
+
+  return { question, answerOptions };
+}

--- a/src/lib/prompt-builder.ts
+++ b/src/lib/prompt-builder.ts
@@ -81,7 +81,7 @@ export function renderSection(section: PromptSection): string {
     value
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;/");
+      .replace(/>/g, "&gt;");
 
   const escapeXmlAttribute = (value: string): string =>
     escapeXmlText(value).replace(/"/g, "&quot;");

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -6,7 +6,7 @@ import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
 import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
-import { createPromptBuilder, createTranscriptSection, renderSection } from "@mux/ai/lib/prompt-builder";
+import { createTranscriptSection, renderSection } from "@mux/ai/lib/prompt-builder";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
 import { withRetry } from "@mux/ai/lib/retry";
@@ -152,8 +152,8 @@ const SYSTEM_PROMPT = dedent`
   </task>
 
   <answer_guidelines>
-    - Each question specifies its own allowed answers in brackets after the question text
-    - Choose only from the options listed for that specific question
+    - Each question is presented as its own <question> block with a <text> element (the question) and an <allowed_answers> element (the permitted response values)
+    - Choose only from the values listed in that question's <allowed_answers> element
     - Choose the affirmative option only if you have clear evidence supporting it
     - Choose the negative/contradicting option if evidence contradicts or if insufficient evidence exists
     - Confidence should reflect the clarity and strength of evidence:
@@ -243,8 +243,8 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   </task>
 
   <answer_guidelines>
-    - Each question specifies its own allowed answers in brackets after the question text
-    - Choose only from the options listed for that specific question
+    - Each question is presented as its own <question> block with a <text> element (the question) and an <allowed_answers> element (the permitted response values)
+    - Choose only from the values listed in that question's <allowed_answers> element
     - Choose the affirmative option only if you have clear evidence supporting it
     - Choose the negative/contradicting option if evidence contradicts or if insufficient evidence exists
     - Confidence should reflect the clarity and strength of evidence:
@@ -308,18 +308,6 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
     - Be specific and evidence-based
   </language_guidelines>`;
 
-type AskQuestionsPromptSections = "questions";
-
-const askQuestionsPromptBuilder = createPromptBuilder<AskQuestionsPromptSections>({
-  template: {
-    questions: {
-      tag: "questions",
-      content: "Please answer the following questions about this content:",
-    },
-  },
-  sectionOrder: ["questions"],
-});
-
 type NormalizedQuestion = Question & { answerOptions: [string, ...string[]] };
 
 interface UserPromptContext {
@@ -335,34 +323,41 @@ function buildUserPrompt({
   isCleanTranscript = true,
   isAudioOnly = false,
 }: UserPromptContext): string {
-  const questionsList = questions
+  const contentDescriptor = isAudioOnly ?
+    "audio content using transcript evidence" :
+    "content";
+
+  const taskSection = renderSection({
+    tag: "task",
+    content: dedent`
+      Answer each question in the <questions> block below about the ${contentDescriptor}.
+      Use only the values listed inside each question's own <allowed_answers> element.
+      Return one answer per question, in the order the questions appear.
+      If a question cannot be answered from the provided content, skip it as described in the system instructions.`,
+  });
+
+  const questionBlocks = questions
     .map((q, idx) => {
-      const answerList = q.answerOptions.map(a => `"${a}"`).join(", ");
-      return `${idx + 1}. ${q.question} [Allowed answers: ${answerList}]`;
+      const textTag = renderSection({ tag: "text", content: q.question });
+      const answersTag = renderSection({
+        tag: "allowed_answers",
+        content: q.answerOptions.map(a => `"${a}"`).join(", "),
+      });
+      return `<question number="${idx + 1}">\n${textTag}\n${answersTag}\n</question>`;
     })
-    .join("\n");
+    .join("\n\n");
 
-  const questionsIntro = isAudioOnly ?
-    "Please answer the following questions about this audio content using transcript evidence:" :
-    "Please answer the following questions about this content:";
+  const questionsSection = `<questions>\n${questionBlocks}\n</questions>`;
 
-  const questionsContent = dedent`
-    ${questionsIntro}
-
-    ${questionsList}
-
-    Each question lists its own allowed answers in brackets. Select from those options only, or skip if the question is not answerable from the content.`;
-
-  const questionsSection = askQuestionsPromptBuilder.build({ questions: questionsContent });
-
-  if (!transcriptText) {
-    return questionsSection;
+  const sections: string[] = [];
+  if (transcriptText) {
+    const format = isCleanTranscript ? "plain text" : "WebVTT";
+    sections.push(renderSection(createTranscriptSection(transcriptText, format)));
   }
+  sections.push(taskSection);
+  sections.push(questionsSection);
 
-  const format = isCleanTranscript ? "plain text" : "WebVTT";
-  const transcriptSection = renderSection(createTranscriptSection(transcriptText, format));
-
-  return `${transcriptSection}\n\n${questionsSection}`;
+  return sections.join("\n\n");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -327,14 +327,12 @@ function buildUserPrompt({
     "audio content using transcript evidence" :
     "content";
 
-  const taskSection = renderSection({
-    tag: "task",
-    content: dedent`
-      Answer each question in the <questions> block below about the ${contentDescriptor}.
-      Use only the values listed inside each question's own <allowed_answers> element.
-      Return one answer per question, in the order the questions appear.
-      If a question cannot be answered from the provided content, skip it as described in the system instructions.`,
-  });
+  const taskContent = dedent`
+    Answer each question in the <questions> block below about the ${contentDescriptor}.
+    Use only the values listed inside each question's own <allowed_answers> element.
+    Return one answer per question, in the order the questions appear.
+    If a question cannot be answered from the provided content, skip it as described in the system instructions.`;
+  const taskSection = `<task>\n${taskContent}\n</task>`;
 
   const questionBlocks = questions
     .map((q, idx) => {

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -23,6 +23,8 @@ import type { ImageSubmissionMode, MuxAIOptions, TokenUsage, WorkflowCredentials
 export interface Question {
   /** The question text */
   question: string;
+  /** Allowed answers for this question (defaults to ["yes", "no"]). */
+  answerOptions?: string[];
 }
 
 /** A single answer to a question. */
@@ -47,8 +49,6 @@ export interface AskQuestionsOptions extends MuxAIOptions {
   model?: ModelIdByProvider[SupportedProvider];
   /** BCP 47 language code of the caption track to use (e.g. "en", "fr"). When omitted, prefers English if available. */
   languageCode?: string;
-  /** Allowed answers for each question (defaults to ["yes", "no"]). */
-  answerOptions?: string[];
   /** Fetch transcript alongside storyboard (defaults to true, required for audio-only assets). */
   includeTranscript?: boolean;
   /** Strip timestamps/markup from transcripts (defaults to true). */
@@ -146,12 +146,14 @@ const SYSTEM_PROMPT = dedent`
   <task>
     For each question provided, you must:
     1. Analyze the storyboard frames and transcript (if provided)
-    2. Answer with ONLY the allowed response options - no other values are acceptable
+    2. Answer with ONLY the allowed response options listed for that question - no other values are acceptable
     3. Provide a confidence score between 0 and 1 reflecting your certainty
     4. Explain your reasoning based on observable evidence
   </task>
 
   <answer_guidelines>
+    - Each question specifies its own allowed answers in brackets after the question text
+    - Choose only from the options listed for that specific question
     - Choose the affirmative option only if you have clear evidence supporting it
     - Choose the negative/contradicting option if evidence contradicts or if insufficient evidence exists
     - Confidence should reflect the clarity and strength of evidence:
@@ -199,7 +201,7 @@ const SYSTEM_PROMPT = dedent`
   </relevance_filtering>
 
   <constraints>
-    - You MUST answer every relevant question with one of the allowed response options
+    - You MUST answer every relevant question with one of its own listed allowed response options
     - Skip irrelevant questions as described in relevance_filtering
     - Only describe observable evidence from frames or transcript
     - Do not fabricate details or make unsupported assumptions
@@ -235,12 +237,14 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   <task>
     For each question provided, you must:
     1. Analyze the transcript
-    2. Answer with ONLY the allowed response options - no other values are acceptable
+    2. Answer with ONLY the allowed response options listed for that question - no other values are acceptable
     3. Provide a confidence score between 0 and 1 reflecting your certainty
     4. Explain your reasoning based on observable evidence
   </task>
 
   <answer_guidelines>
+    - Each question specifies its own allowed answers in brackets after the question text
+    - Choose only from the options listed for that specific question
     - Choose the affirmative option only if you have clear evidence supporting it
     - Choose the negative/contradicting option if evidence contradicts or if insufficient evidence exists
     - Confidence should reflect the clarity and strength of evidence:
@@ -288,7 +292,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   </relevance_filtering>
 
   <constraints>
-    - You MUST answer every relevant question with one of the allowed response options
+    - You MUST answer every relevant question with one of its own listed allowed response options
     - Skip irrelevant questions as described in relevance_filtering
     - Only describe observable evidence from transcript content
     - Do not fabricate details or make unsupported assumptions
@@ -316,9 +320,10 @@ const askQuestionsPromptBuilder = createPromptBuilder<AskQuestionsPromptSections
   sectionOrder: ["questions"],
 });
 
+type NormalizedQuestion = Question & { answerOptions: [string, ...string[]] };
+
 interface UserPromptContext {
-  questions: Question[];
-  allowedAnswers: string[];
+  questions: NormalizedQuestion[];
   transcriptText?: string;
   isCleanTranscript?: boolean;
   isAudioOnly?: boolean;
@@ -326,13 +331,15 @@ interface UserPromptContext {
 
 function buildUserPrompt({
   questions,
-  allowedAnswers,
   transcriptText,
   isCleanTranscript = true,
   isAudioOnly = false,
 }: UserPromptContext): string {
   const questionsList = questions
-    .map((q, idx) => `${idx + 1}. ${q.question}`)
+    .map((q, idx) => {
+      const answerList = q.answerOptions.map(a => `"${a}"`).join(", ");
+      return `${idx + 1}. ${q.question} [Allowed answers: ${answerList}]`;
+    })
     .join("\n");
 
   const questionsIntro = isAudioOnly ?
@@ -342,24 +349,20 @@ function buildUserPrompt({
   const questionsContent = dedent`
     ${questionsIntro}
 
-    ${questionsList}`;
+    ${questionsList}
 
-  const answerList = allowedAnswers.map(answer => `"${answer}"`).join(", ");
-  const responseOptions = dedent`
-    <response_options>
-      Allowed answers: ${answerList}
-    </response_options>`;
+    Each question lists its own allowed answers in brackets. Select from those options only, or skip if the question is not answerable from the content.`;
 
   const questionsSection = askQuestionsPromptBuilder.build({ questions: questionsContent });
 
   if (!transcriptText) {
-    return `${questionsSection}\n\n${responseOptions}`;
+    return questionsSection;
   }
 
   const format = isCleanTranscript ? "plain text" : "WebVTT";
   const transcriptSection = renderSection(createTranscriptSection(transcriptText, format));
 
-  return `${transcriptSection}\n\n${questionsSection}\n\n${responseOptions}`;
+  return `${transcriptSection}\n\n${questionsSection}`;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -499,7 +502,6 @@ export async function askQuestions(
     provider = "openai",
     model,
     languageCode,
-    answerOptions,
     includeTranscript = true,
     cleanTranscript = true,
     imageSubmissionMode = "url",
@@ -508,19 +510,26 @@ export async function askQuestions(
     credentials,
   } = options ?? {};
 
-  const normalizedAnswerOptions = Array.from(
-    new Set(
-      (answerOptions?.length ? answerOptions : ["yes", "no"])
-        .map(option => option.trim())
-        .filter(Boolean),
-    ),
-  );
+  const normalizedQuestions: NormalizedQuestion[] = questions.map((q, idx) => {
+    const options = Array.from(
+      new Set(
+        (q.answerOptions?.length ? q.answerOptions : ["yes", "no"])
+          .map(o => o.trim())
+          .filter(Boolean),
+      ),
+    );
+    if (!options.length) {
+      throw new MuxAiError(
+        `Question at index ${idx} has invalid answerOptions: must include at least one non-empty value.`,
+        { type: "validation_error" },
+      );
+    }
+    return { ...q, answerOptions: options as [string, ...string[]] };
+  });
 
-  if (!normalizedAnswerOptions.length) {
-    throw new MuxAiError("answerOptions must include at least one non-empty value.", { type: "validation_error" });
-  }
-
-  const allowedAnswers = normalizedAnswerOptions as [string, ...string[]];
+  const allowedAnswers = Array.from(
+    new Set(normalizedQuestions.flatMap(q => q.answerOptions)),
+  ) as [string, ...string[]];
 
   const modelConfig = resolveLanguageModelConfig({
     ...options,
@@ -562,10 +571,9 @@ export async function askQuestions(
       undefined;
   const transcriptText = transcriptResult?.transcriptText ?? "";
 
-  // Build the user prompt with questions, allowed answers, and optional transcript
+  // Build the user prompt with questions (each with their allowed answers) and optional transcript
   const userPrompt = buildUserPrompt({
-    questions,
-    allowedAnswers,
+    questions: normalizedQuestions,
     transcriptText,
     isCleanTranscript: cleanTranscript,
     isAudioOnly,
@@ -639,8 +647,13 @@ export async function askQuestions(
 
   // Post-process raw LLM output into the public QuestionAnswer shape.
   // Treat as skipped if the model flagged it OR if the answer is the sentinel.
-  const answers: QuestionAnswer[] = analysisResponse.result.answers.map((raw) => {
+  const answers: QuestionAnswer[] = analysisResponse.result.answers.map((raw, idx) => {
     const isSkipped = raw.skipped || raw.answer === SKIP_SENTINEL;
+    if (!isSkipped && !normalizedQuestions[idx].answerOptions.includes(raw.answer)) {
+      throw new MuxAiError(
+        `Answer "${raw.answer}" for question ${idx} is not in allowed options: ${normalizedQuestions[idx].answerOptions.join(", ")}`,
+      );
+    }
     return {
       // Strip numbering prefix (e.g., "1. " or "2. ") from questions
       question: raw.question.replace(/^\d+\.\s*/, ""),

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -81,7 +81,7 @@ export interface AskQuestionsResult {
 
 /** Zod schema for a single answer (matches the public QuestionAnswer interface). */
 export const questionAnswerSchema = z.object({
-  question: z.string(),
+  question: z.string().describe("The full text of the original question"),
   answer: z.string().nullable(),
   confidence: z.number(),
   reasoning: z.string(),
@@ -650,7 +650,7 @@ export async function askQuestions(
       );
     }
     return {
-      // Strip numbering prefix (e.g., "1. " or "2. ") from questions
+      // Strip numbering prefix (e.g. "1. ") if the LLM prepends one
       question: raw.question.replace(/^\d+\.\s*/, ""),
       confidence: isSkipped ? 0 : Math.min(1, Math.max(0, raw.confidence)),
       reasoning: raw.reasoning,

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -136,16 +136,19 @@ describe("ask Questions Integration Tests", () => {
 
   it("should support per-question answer options", async () => {
     const questions = [
-      { question: "Is this video about glasses?", answerOptions: ["yes", "no", "unsure"] },
       { question: "Is this video in color?" }, // defaults to yes/no
+      {
+        question: "What is the primary subject of this video?",
+        answerOptions: ["glasses", "watches", "shoes", "hats"],
+      },
     ];
 
     const result = await askQuestions(testAssetId, questions);
 
     expect(result.answers).toHaveLength(2);
-    expect(["yes", "no", "unsure"]).toContain(result.answers[0].answer);
-    expect(result.answers[0].answer).toBe("yes");
-    expect(["yes", "no"]).toContain(result.answers[1].answer);
+    expect(["yes", "no"]).toContain(result.answers[0].answer);
+    expect(["glasses", "watches", "shoes", "hats"]).toContain(result.answers[1].answer);
+    expect(result.answers[1].answer).toBe("glasses");
   });
 
   it("should throw error for empty questions array", async () => {

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -134,6 +134,20 @@ describe("ask Questions Integration Tests", () => {
     expect(["yes", "no"]).toContain(result.answers[0].answer);
   });
 
+  it("should support per-question answer options", async () => {
+    const questions = [
+      { question: "Is this video about glasses?", answerOptions: ["yes", "no", "unsure"] },
+      { question: "Is this video in color?" }, // defaults to yes/no
+    ];
+
+    const result = await askQuestions(testAssetId, questions);
+
+    expect(result.answers).toHaveLength(2);
+    expect(["yes", "no", "unsure"]).toContain(result.answers[0].answer);
+    expect(result.answers[0].answer).toBe("yes");
+    expect(["yes", "no"]).toContain(result.answers[1].answer);
+  });
+
   it("should throw error for empty questions array", async () => {
     await expect(
       askQuestions(testAssetId, []),

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -136,7 +136,7 @@ describe("ask Questions Integration Tests", () => {
 
   it("should support per-question answer options", async () => {
     const questions = [
-      { question: "Is this video in color?" }, // defaults to yes/no
+      { question: "Is this video in color?" }, // answer options default to yes/no
       {
         question: "What is the primary subject of this video?",
         answerOptions: ["glasses", "watches", "shoes", "hats"],


### PR DESCRIPTION
## Summary

Breaking change: `answerOptions` moves from `AskQuestionsOptions` to the `Question` interface, so each question in a single call can specify its own allowed answers (or have answer options default to `["yes", "no"]`). This makes it possible to mix yes/no checks with classification scales in one batched LLM call.

Under the hood:
- Each question's `answerOptions` is normalised (trim, dedupe, default) with per-question validation.
- The structured-output enum is the union of all per-question allowed answers plus the skip sentinel.
- Post-processing validates every non-skipped answer against its own question's allowed set, rejecting LLM outputs that pick a valid-but-wrong-for-this-question value.

The user prompt is restructured to co-locate each question with its constraints: a shared `<task>` section followed by a `<questions>` block containing per-question `<question>` blocks with nested `<text>` and `<allowed_answers>` sub-elements. The `<task>` block is built manually (not via `renderSection`) because its content intentionally references XML tag names that would otherwise be escaped.

The Zod schema's `question` field now carries `.describe("The full text of the original question")` to prevent the LLM from returning just the question number (from the XML `number` attribute) instead of the actual question text.

Also fixes a pre-existing bug in `prompt-builder.ts` where `escapeXmlText` replaced `>` with `&gt;/` (stray trailing slash) instead of `&gt;`. This affected all workflows using `renderSection` on content containing `>`.

CLI examples gain a pipe-delimited syntax for custom answer sets. Answer options remain yes/no by default, so existing invocations continue to work.

## Example

```typescript
const result = await askQuestions(assetId, [
  { question: "Does this contain cooking?" }, // answer options default to yes/no
  { question: "What is the production quality?", answerOptions: ["amateur", "semi-pro", "professional"] },
  { question: "What is the sentiment?", answerOptions: ["positive", "neutral", "negative"] },
]);
```

CLI:

```bash
npm run multiple <asset-id> \
  "Does this contain cooking?" \
  "What is the production quality?|amateur,semi-pro,professional"
```

## Suggested Review Order

1. `src/workflows/ask-questions.ts` — `Question` interface + `AskQuestionsOptions` (type surface), then `buildUserPrompt`, then the normalisation + post-processing in `askQuestions()`.
2. System prompt edits in the same file — the `<answer_guidelines>` and `<task>` sections now describe the per-question XML structure.
3. `src/lib/prompt-builder.ts` — one-character `escapeXmlText` fix (line 84).
4. `examples/ask-questions/parse-question.ts` + the three CLI example files — pipe-syntax helper and its callers.
5. `tests/integration/ask-questions.test.ts` — new "per-question answer options" case.
6. `docs/API.md`, `docs/WORKFLOWS.md`, `examples/ask-questions/README.md` — surface docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a breaking API change to `askQuestions` and rewrites prompt/validation logic, which could affect downstream callers and LLM output conformance. Risk is moderated by added normalization, stricter post-validation, and new integration coverage.
> 
> **Overview**
> **Breaking change:** `askQuestions` now takes `answerOptions` on each `Question` (defaulting to `['yes','no']`) instead of a single `options.answerOptions`, enabling mixed yes/no + multi-class classification in one call.
> 
> The workflow prompt is restructured to include per-question `<allowed_answers>` blocks, the structured-output schema enum becomes the union of all per-question options (plus the skip sentinel), and post-processing now validates each non-skipped answer against *that question’s* allowed set (throwing on mismatches). CLI examples gain a pipe-delimited syntax (`"Question|a,b,c"`) and reporting is updated to count arbitrary answers; docs and integration tests are updated accordingly.
> 
> Also fixes an XML escaping bug in `renderSection` where `>` was incorrectly escaped as `&gt;/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a6f132189cf88c9fc291502f78a3af497c051b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->