### PR TITLE
fix: ask-questions question filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -19,7 +19,7 @@ import type { ImageSubmissionMode, MuxAIOptions, TokenUsage, WorkflowCredentials
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** A single yes/no question to be answered about asset content. */
+/** A single question to be answered about asset content. */
 export interface Question {
   /** The question text */
   question: string;
@@ -154,8 +154,9 @@ const SYSTEM_PROMPT = dedent`
   <answer_guidelines>
     - Each question is presented as its own <question> block with a <text> element (the question) and an <allowed_answers> element (the permitted response values)
     - Choose only from the values listed in that question's <allowed_answers> element
-    - Choose the affirmative option only if you have clear evidence supporting it
-    - Choose the negative/contradicting option if evidence contradicts or if insufficient evidence exists
+    - Questions may have any set of allowed answers — they are NOT limited to yes/no. Always read the <allowed_answers> for each question and select the best matching option based on the evidence
+    - Select the answer best supported by observable evidence from the content
+    - When evidence is insufficient to choose confidently among the options, select the most conservative or least committal option available
     - Confidence should reflect the clarity and strength of evidence:
       * 0.9-1.0: Clear, unambiguous evidence
       * 0.7-0.9: Strong evidence with minor ambiguity
@@ -173,7 +174,8 @@ const SYSTEM_PROMPT = dedent`
 
     A question is relevant if it asks about something observable or inferable
     from the video content (visuals, audio, dialogue, setting, subjects,
-    actions, etc.).
+    actions, etc.). A question is NOT irrelevant just because it has non-yes/no
+    answer options — if it asks about the content, it is relevant.
 
     Mark a question as skipped (skipped: true) if it:
     - Is completely unrelated to the content of the video or audio (e.g., math, trivia, personal questions)
@@ -245,8 +247,9 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   <answer_guidelines>
     - Each question is presented as its own <question> block with a <text> element (the question) and an <allowed_answers> element (the permitted response values)
     - Choose only from the values listed in that question's <allowed_answers> element
-    - Choose the affirmative option only if you have clear evidence supporting it
-    - Choose the negative/contradicting option if evidence contradicts or if insufficient evidence exists
+    - Questions may have any set of allowed answers — they are NOT limited to yes/no. Always read the <allowed_answers> for each question and select the best matching option based on the evidence
+    - Select the answer best supported by observable evidence from the content
+    - When evidence is insufficient to choose confidently among the options, select the most conservative or least committal option available
     - Confidence should reflect the clarity and strength of evidence:
       * 0.9-1.0: Clear, unambiguous evidence
       * 0.7-0.9: Strong evidence with minor ambiguity
@@ -264,7 +267,9 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
 
     Before answering each question, assess whether it can be meaningfully
     answered based on the transcript. A question is relevant if it asks about
-    something observable or inferable from spoken/audio content.
+    something observable or inferable from spoken/audio content. A question is
+    NOT irrelevant just because it has non-yes/no answer options — if it asks
+    about the content, it is relevant.
 
     Mark a question as skipped (skipped: true) if it:
     - Is completely unrelated to transcript/audio content (e.g., math, trivia, personal questions)

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -156,7 +156,7 @@ const SYSTEM_PROMPT = dedent`
     - Choose only from the values listed in that question's <allowed_answers> element
     - Questions may have any set of allowed answers. Always read the <allowed_answers> for each question and select the best matching option based on the evidence
     - Select the answer best supported by observable evidence from the content
-    - When evidence is insufficient to choose confidently among the options, select the most conservative or least committal option available
+    - When evidence is ambiguous but some signal exists, select the most conservative option and use a low confidence score. If the question cannot be answered at all from the content, skip it per the relevance_filtering rules
     - Confidence should reflect the clarity and strength of evidence:
       * 0.9-1.0: Clear, unambiguous evidence
       * 0.7-0.9: Strong evidence with minor ambiguity
@@ -174,8 +174,7 @@ const SYSTEM_PROMPT = dedent`
 
     A question is relevant if it asks about something observable or inferable
     from the video content (visuals, audio, dialogue, setting, subjects,
-    actions, etc.). A question is NOT irrelevant because it has non-yes/no
-    answer options — if it asks about the content, it is relevant.
+    actions, etc.).
 
     Mark a question as skipped (skipped: true) if it:
     - Is completely unrelated to the content of the video or audio (e.g., math, trivia, personal questions)
@@ -249,7 +248,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
     - Choose only from the values listed in that question's <allowed_answers> element
     - Questions may have any set of allowed answers. Always read the <allowed_answers> for each question and select the best matching option based on the evidence
     - Select the answer best supported by observable evidence from the content
-    - When evidence is insufficient to choose confidently among the options, select the most conservative or least committal option available
+    - When evidence is ambiguous but some signal exists, select the most conservative option and use a low confidence score. If the question cannot be answered at all from the content, skip it per the relevance_filtering rules
     - Confidence should reflect the clarity and strength of evidence:
       * 0.9-1.0: Clear, unambiguous evidence
       * 0.7-0.9: Strong evidence with minor ambiguity
@@ -267,9 +266,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
 
     Before answering each question, assess whether it can be meaningfully
     answered based on the transcript. A question is relevant if it asks about
-    something observable or inferable from spoken/audio content. A question is
-    NOT irrelevant because it has non-yes/no answer options — if it asks about
-    the content, it is relevant.
+    something observable or inferable from spoken/audio content.
 
     Mark a question as skipped (skipped: true) if it:
     - Is completely unrelated to transcript/audio content (e.g., math, trivia, personal questions)

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -154,7 +154,7 @@ const SYSTEM_PROMPT = dedent`
   <answer_guidelines>
     - Each question is presented as its own <question> block with a <text> element (the question) and an <allowed_answers> element (the permitted response values)
     - Choose only from the values listed in that question's <allowed_answers> element
-    - Questions may have any set of allowed answers — they are NOT limited to yes/no. Always read the <allowed_answers> for each question and select the best matching option based on the evidence
+    - Questions may have any set of allowed answers. Always read the <allowed_answers> for each question and select the best matching option based on the evidence
     - Select the answer best supported by observable evidence from the content
     - When evidence is insufficient to choose confidently among the options, select the most conservative or least committal option available
     - Confidence should reflect the clarity and strength of evidence:
@@ -174,8 +174,7 @@ const SYSTEM_PROMPT = dedent`
 
     A question is relevant if it asks about something observable or inferable
     from the video content (visuals, audio, dialogue, setting, subjects,
-    actions, etc.). A question is NOT irrelevant just because it has non-yes/no
-    answer options — if it asks about the content, it is relevant.
+    actions, etc.).
 
     Mark a question as skipped (skipped: true) if it:
     - Is completely unrelated to the content of the video or audio (e.g., math, trivia, personal questions)
@@ -247,7 +246,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
   <answer_guidelines>
     - Each question is presented as its own <question> block with a <text> element (the question) and an <allowed_answers> element (the permitted response values)
     - Choose only from the values listed in that question's <allowed_answers> element
-    - Questions may have any set of allowed answers — they are NOT limited to yes/no. Always read the <allowed_answers> for each question and select the best matching option based on the evidence
+    - Questions may have any set of allowed answers. Always read the <allowed_answers> for each question and select the best matching option based on the evidence
     - Select the answer best supported by observable evidence from the content
     - When evidence is insufficient to choose confidently among the options, select the most conservative or least committal option available
     - Confidence should reflect the clarity and strength of evidence:
@@ -267,9 +266,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
 
     Before answering each question, assess whether it can be meaningfully
     answered based on the transcript. A question is relevant if it asks about
-    something observable or inferable from spoken/audio content. A question is
-    NOT irrelevant just because it has non-yes/no answer options — if it asks
-    about the content, it is relevant.
+    something observable or inferable from spoken/audio content.
 
     Mark a question as skipped (skipped: true) if it:
     - Is completely unrelated to transcript/audio content (e.g., math, trivia, personal questions)

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -174,7 +174,8 @@ const SYSTEM_PROMPT = dedent`
 
     A question is relevant if it asks about something observable or inferable
     from the video content (visuals, audio, dialogue, setting, subjects,
-    actions, etc.).
+    actions, etc.). A question is NOT irrelevant because it has non-yes/no
+    answer options — if it asks about the content, it is relevant.
 
     Mark a question as skipped (skipped: true) if it:
     - Is completely unrelated to the content of the video or audio (e.g., math, trivia, personal questions)
@@ -266,7 +267,9 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
 
     Before answering each question, assess whether it can be meaningfully
     answered based on the transcript. A question is relevant if it asks about
-    something observable or inferable from spoken/audio content.
+    something observable or inferable from spoken/audio content. A question is
+    NOT irrelevant because it has non-yes/no answer options — if it asks about
+    the content, it is relevant.
 
     Mark a question as skipped (skipped: true) if it:
     - Is completely unrelated to transcript/audio content (e.g., math, trivia, personal questions)

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -151,6 +151,24 @@ describe("ask Questions Integration Tests", () => {
     expect(result.answers[1].answer).toBe("glasses");
   });
 
+  it("should not skip content-relevant questions with custom answerOptions", async () => {
+    const result = await askQuestions(testAssetId, [
+      {
+        question: "What is the primary subject of this video?",
+        answerOptions: ["glasses", "watches", "shoes", "hats"],
+      },
+    ]);
+
+    expect(result.answers).toHaveLength(1);
+
+    const answer = result.answers[0];
+    expect(answer.skipped).toBe(false);
+    expect(answer.answer).not.toBeNull();
+    expect(["glasses", "watches", "shoes", "hats"]).toContain(answer.answer);
+    expect(answer.answer).toBe("glasses");
+    expect(answer.confidence).toBeGreaterThan(0);
+  });
+
   it("should throw error for empty questions array", async () => {
     await expect(
       askQuestions(testAssetId, []),


### PR DESCRIPTION
# Overview

Fix ask-questions workflow incorrectly skipping content-relevant questions that use custom `answerOptions`. The system prompts used yes/no-biased language ("affirmative option", "negative/contradicting option") and had an ambiguous low-evidence path that encouraged guessing over skipping, causing the LLM to mishandle non-yes/no questions.

# What was changed

- **`src/workflows/ask-questions.ts`** — Updated `<answer_guidelines>` in both video and audio-only system prompts: replaced "affirmative/negative" language with option-neutral guidance, and clarified the boundary between low-confidence answers (ambiguous but some signal) and skips (unanswerable from content). Fixed outdated JSDoc on the `Question` interface.
- **`tests/integration/ask-questions.test.ts`** — Added regression test: a single content-relevant question with only custom `answerOptions` (no yes/no in the batch) must not be skipped.
- **`package.json` / `package-lock.json`** — Version bump to 0.16.1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to LLM prompt wording plus a regression integration test and a patch version bump, with no API surface or data-handling logic changes.
> 
> **Overview**
> Fixes `askQuestions` incorrectly skipping content-relevant questions that use non-yes/no `answerOptions` by updating the system prompt `<answer_guidelines>` (video and audio-only) to be option-neutral and to always choose from each question’s `<allowed_answers>`.
> 
> Adds an integration regression test ensuring a single custom-answer question is answered (not skipped), and bumps the package version to `0.16.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee46eddaebf71720deab5c7a6dc5ebe8b37f1f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->