### PR TITLE
docs: Document outputLanguageCode

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -17,6 +17,7 @@ Analyzes a Mux video or audio asset and returns AI-generated metadata.
 - `tone?: 'neutral' | 'playful' | 'professional'` - Analysis tone (default: 'neutral')
 - `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `languageCode?: string` - Language code for transcript track selection (e.g., 'en', 'fr'). When omitted, prefers English if available.
+- `outputLanguageCode?: string` - BCP 47 language code (e.g., 'en', 'fr', 'ja') for the generated title, description, and tags. When omitted or set to `'auto'`, auto-detects from the selected transcript track's language. Falls back to unconstrained (LLM decides) if no language metadata is available.
 - `includeTranscript?: boolean` - Include transcript in analysis (default: true)
 - `cleanTranscript?: boolean` - Remove VTT timestamps and formatting from transcript (default: true)
 - `imageSubmissionMode?: 'url' | 'base64'` - How to submit storyboard to AI providers (default: 'url')
@@ -460,6 +461,7 @@ Generates AI-powered chapter markers by analyzing video or audio transcripts. Cr
 **Options:**
 
 - `languageCode?: string` - Language code for captions (e.g., 'en', 'es', 'fr'). When omitted, prefers English if available.
+- `outputLanguageCode?: string` - BCP 47 language code (e.g., 'en', 'fr', 'ja') for the generated chapter titles. When omitted or set to `'auto'`, auto-detects from the selected transcript track's language. Falls back to unconstrained (LLM decides) if no language metadata is available.
 - `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
 - `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `promptOverrides?: object` - Override specific sections of the chaptering prompt

--- a/examples/summarization/README.md
+++ b/examples/summarization/README.md
@@ -105,6 +105,7 @@ Key options for `getSummaryAndTags`:
 - `tone`: `'neutral' | 'playful' | 'professional'` (default: `'neutral'`)
 - `includeTranscript`: Include the asset transcript when available (default: `true`)
 - `imageSubmissionMode`: `'url' | 'base64'` storyboard transport (default: `'url'`)
+- `outputLanguageCode`: BCP 47 language code for the generated title, description, and tags (e.g. `'en'`, `'fr'`, `'ja'`). Defaults to auto-detection from the transcript track's language; pass `'auto'` or omit to use the default.
 - `promptOverrides`: Override specific sections of the prompt (see below)
 
 All credentials are automatically read from environment variables (`MUX_TOKEN_ID`, `MUX_TOKEN_SECRET`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`).


### PR DESCRIPTION
Document `outputLanguageCode`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding/clarifying the `outputLanguageCode` option for summarization and chapter generation; no runtime behavior is modified.
> 
> **Overview**
> Documents a new `outputLanguageCode` option for `getSummaryAndTags` and `generateChapters`, describing how output language is chosen (explicit BCP 47 code, `'auto'`/omitted auto-detect from the selected transcript track, with fallback when metadata is missing).
> 
> Updates the summarization example README to mention `outputLanguageCode` in the configuration options list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8839737236d8f2325643f285b94313a06af4b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->