### PR TITLE
refactor: consolidate shared prompt fragments to prevent drift

### DIFF
--- a/src/lib/prompt-fragments.ts
+++ b/src/lib/prompt-fragments.ts
@@ -1,3 +1,5 @@
+import dedent from "dedent";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared prompt fragments
 //
@@ -6,6 +8,22 @@
 // instruction is copy-pasted across files, updates to one copy can diverge
 // from the others over time.
 // ─────────────────────────────────────────────────────────────────────────────
+
+// ── Aligned dedent ───────────────────────────────────────────────────────────
+
+/**
+ * A `dedent` tag configured with `alignValues: true`.
+ *
+ * Plain `dedent` strips the common leading indent from template lines but
+ * does **not** re-indent continuation lines of interpolated multi-line
+ * values — those lines render at column 0, breaking the surrounding XML
+ * structure.  `alignValues: true` fixes this by aligning every continuation
+ * line of an interpolated value to the column of its `${}` placeholder.
+ *
+ * Use this tag (instead of bare `dedent`) for any template that interpolates
+ * multi-line prompt fragment constants.
+ */
+export const promptDedent = dedent.withOptions({ alignValues: true });
 
 // ── Constraint fragments ─────────────────────────────────────────────────────
 

--- a/src/lib/prompt-fragments.ts
+++ b/src/lib/prompt-fragments.ts
@@ -31,10 +31,10 @@ export const promptDedent = dedent.withOptions({ alignValues: true });
  * Warning that prevents the model from leaking delivery-infrastructure
  * details (URLs, playback IDs, file names, etc.) into its output.
  */
-export const METADATA_BOUNDARY_WARNING =
-  "Do NOT use any metadata such as URLs, file paths, domain names, file names,\n" +
-  "playback IDs, or technical parameters visible in this request. These are\n" +
-  "delivery infrastructure and are unrelated to the media content itself.";
+export const METADATA_BOUNDARY_WARNING = dedent`
+  Do NOT use any metadata such as URLs, file paths, domain names, file names,
+  playback IDs, or technical parameters visible in this request. These are
+  delivery infrastructure and are unrelated to the media content itself.`;
 
 /**
  * Constraint that prevents hallucinated details.
@@ -46,12 +46,6 @@ export const NO_FABRICATION_CONSTRAINT =
  * Constraint requiring structured output conforming to the provided schema.
  */
 export const STRUCTURED_DATA_CONSTRAINT =
-  "Return structured data matching the requested schema";
-
-/**
- * Stricter variant used where "exactly" is emphasised.
- */
-export const STRUCTURED_DATA_CONSTRAINT_EXACT =
   "Return structured data matching the requested schema exactly";
 
 // ── Storyboard ───────────────────────────────────────────────────────────────
@@ -60,9 +54,9 @@ export const STRUCTURED_DATA_CONSTRAINT_EXACT =
  * Instructions for reading a storyboard grid of video frames.
  * Used by any workflow that receives storyboard images.
  */
-export const STORYBOARD_FRAME_INSTRUCTIONS =
-  "These frames are arranged in a grid and represent the visual progression of the content over time.\n" +
-  "Read frames left-to-right, top-to-bottom to understand the temporal sequence.";
+export const STORYBOARD_FRAME_INSTRUCTIONS = dedent`
+  These frames are arranged in a grid and represent the visual progression of the content over time.
+  Read frames left-to-right, top-to-bottom to understand the temporal sequence.`;
 
 // ── Tone ─────────────────────────────────────────────────────────────────────
 
@@ -71,11 +65,11 @@ export const STORYBOARD_FRAME_INSTRUCTIONS =
  * Content only — the surrounding `<tone_guidance>` tags are written by the
  * workflow's system prompt template.
  */
-export const TONE_GUIDANCE =
-  "Pay special attention to the <tone> section and lean heavily into those instructions.\n" +
-  "Adapt your entire analysis and writing style to match the specified tone - this should influence\n" +
-  "your word choice, personality, formality level, and overall presentation of the content.\n" +
-  "The tone instructions are not suggestions but core requirements for how you should express yourself.";
+export const TONE_GUIDANCE = dedent`
+  Pay special attention to the <tone> section and lean heavily into those instructions.
+  Adapt your entire analysis and writing style to match the specified tone - this should influence
+  your word choice, personality, formality level, and overall presentation of the content.
+  The tone instructions are not suggestions but core requirements for how you should express yourself.`;
 
 // ── Confidence ───────────────────────────────────────────────────────────────
 
@@ -83,12 +77,12 @@ export const TONE_GUIDANCE =
  * Five-tier confidence scoring rubric (0.0 – 1.0).
  * Used by workflows that ask the model to self-report certainty.
  */
-export const CONFIDENCE_SCORING_RUBRIC =
-  "* 0.9-1.0: Clear, unambiguous evidence\n" +
-  "* 0.7-0.9: Strong evidence with minor ambiguity\n" +
-  "* 0.5-0.7: Moderate evidence or some conflicting signals\n" +
-  "* 0.3-0.5: Weak evidence or significant ambiguity\n" +
-  "* 0.0-0.3: Very uncertain, minimal relevant evidence";
+export const CONFIDENCE_SCORING_RUBRIC = dedent`
+  * 0.9-1.0: Clear, unambiguous evidence
+  * 0.7-0.9: Strong evidence with minor ambiguity
+  * 0.5-0.7: Moderate evidence or some conflicting signals
+  * 0.3-0.5: Weak evidence or significant ambiguity
+  * 0.0-0.3: Very uncertain, minimal relevant evidence`;
 
 // ── Language guidelines ──────────────────────────────────────────────────────
 
@@ -98,34 +92,32 @@ export const CONFIDENCE_SCORING_RUBRIC =
  */
 export function createLanguageGuidelines(mediaType: "video" | "audio"): string {
   if (mediaType === "video") {
-    return (
-      "AVOID these meta-descriptive phrases that reference the medium rather than the content:\n" +
-      "- \"The image shows...\" / \"The storyboard shows...\"\n" +
-      "- \"In this video...\" / \"This video features...\"\n" +
-      "- \"The frames depict...\" / \"The footage shows...\"\n" +
-      "- \"We can see...\" / \"You can see...\"\n" +
-      "- \"The clip shows...\" / \"The scene shows...\"\n" +
-      "\n" +
-      "INSTEAD, describe the content directly:\n" +
-      "- BAD: \"The video shows a chef preparing a meal\"\n" +
-      "- GOOD: \"A chef prepares a meal in a professional kitchen\"\n" +
-      "\n" +
-      "Write as if describing reality, not describing a recording of reality."
-    );
+    return dedent`
+      AVOID these meta-descriptive phrases that reference the medium rather than the content:
+      - "The image shows..." / "The storyboard shows..."
+      - "In this video..." / "This video features..."
+      - "The frames depict..." / "The footage shows..."
+      - "We can see..." / "You can see..."
+      - "The clip shows..." / "The scene shows..."
+
+      INSTEAD, describe the content directly:
+      - BAD: "The video shows a chef preparing a meal"
+      - GOOD: "A chef prepares a meal in a professional kitchen"
+
+      Write as if describing reality, not describing a recording of reality.`;
   }
 
   // audio
-  return (
-    "AVOID these meta-descriptive phrases that reference the medium rather than the content:\n" +
-    "- \"The audio shows...\" / \"The transcript shows...\"\n" +
-    "- \"In this recording...\" / \"This audio features...\"\n" +
-    "- \"The speaker says...\" / \"We can hear...\"\n" +
-    "- \"The clip contains...\" / \"The recording shows...\"\n" +
-    "\n" +
-    "INSTEAD, describe the content directly:\n" +
-    "- BAD: \"The audio features a discussion about climate change\"\n" +
-    "- GOOD: \"A panel discusses climate change impacts and solutions\"\n" +
-    "\n" +
-    "Write as if describing reality, not describing a recording of reality."
-  );
+  return dedent`
+    AVOID these meta-descriptive phrases that reference the medium rather than the content:
+    - "The audio shows..." / "The transcript shows..."
+    - "In this recording..." / "This audio features..."
+    - "The speaker says..." / "We can hear..."
+    - "The clip contains..." / "The recording shows..."
+
+    INSTEAD, describe the content directly:
+    - BAD: "The audio features a discussion about climate change"
+    - GOOD: "A panel discusses climate change impacts and solutions"
+
+    Write as if describing reality, not describing a recording of reality.`;
 }

--- a/src/lib/prompt-fragments.ts
+++ b/src/lib/prompt-fragments.ts
@@ -1,0 +1,113 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared prompt fragments
+//
+// Reusable constants and helpers for system/user prompts across workflows.
+// Centralising these fragments prevents prompt drift — when the same
+// instruction is copy-pasted across files, updates to one copy can diverge
+// from the others over time.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Constraint fragments ─────────────────────────────────────────────────────
+
+/**
+ * Warning that prevents the model from leaking delivery-infrastructure
+ * details (URLs, playback IDs, file names, etc.) into its output.
+ */
+export const METADATA_BOUNDARY_WARNING =
+  "Do NOT use any metadata such as URLs, file paths, domain names, file names,\n" +
+  "playback IDs, or technical parameters visible in this request. These are\n" +
+  "delivery infrastructure and are unrelated to the media content itself.";
+
+/**
+ * Constraint that prevents hallucinated details.
+ */
+export const NO_FABRICATION_CONSTRAINT =
+  "Do not fabricate details or make unsupported assumptions";
+
+/**
+ * Constraint requiring structured output conforming to the provided schema.
+ */
+export const STRUCTURED_DATA_CONSTRAINT =
+  "Return structured data matching the requested schema";
+
+/**
+ * Stricter variant used where "exactly" is emphasised.
+ */
+export const STRUCTURED_DATA_CONSTRAINT_EXACT =
+  "Return structured data matching the requested schema exactly";
+
+// ── Storyboard ───────────────────────────────────────────────────────────────
+
+/**
+ * Instructions for reading a storyboard grid of video frames.
+ * Used by any workflow that receives storyboard images.
+ */
+export const STORYBOARD_FRAME_INSTRUCTIONS =
+  "These frames are arranged in a grid and represent the visual progression of the content over time.\n" +
+  "Read frames left-to-right, top-to-bottom to understand the temporal sequence.";
+
+// ── Tone ─────────────────────────────────────────────────────────────────────
+
+/**
+ * System-level guidance for respecting the user-supplied `<tone>` section.
+ * Content only — the surrounding `<tone_guidance>` tags are written by the
+ * workflow's system prompt template.
+ */
+export const TONE_GUIDANCE =
+  "Pay special attention to the <tone> section and lean heavily into those instructions.\n" +
+  "Adapt your entire analysis and writing style to match the specified tone - this should influence\n" +
+  "your word choice, personality, formality level, and overall presentation of the content.\n" +
+  "The tone instructions are not suggestions but core requirements for how you should express yourself.";
+
+// ── Confidence ───────────────────────────────────────────────────────────────
+
+/**
+ * Five-tier confidence scoring rubric (0.0 – 1.0).
+ * Used by workflows that ask the model to self-report certainty.
+ */
+export const CONFIDENCE_SCORING_RUBRIC =
+  "* 0.9-1.0: Clear, unambiguous evidence\n" +
+  "* 0.7-0.9: Strong evidence with minor ambiguity\n" +
+  "* 0.5-0.7: Moderate evidence or some conflicting signals\n" +
+  "* 0.3-0.5: Weak evidence or significant ambiguity\n" +
+  "* 0.0-0.3: Very uncertain, minimal relevant evidence";
+
+// ── Language guidelines ──────────────────────────────────────────────────────
+
+/**
+ * Returns anti-meta-description language guidelines customised for video or
+ * audio content.  The examples and avoid-list differ by media type.
+ */
+export function createLanguageGuidelines(mediaType: "video" | "audio"): string {
+  if (mediaType === "video") {
+    return (
+      "AVOID these meta-descriptive phrases that reference the medium rather than the content:\n" +
+      "- \"The image shows...\" / \"The storyboard shows...\"\n" +
+      "- \"In this video...\" / \"This video features...\"\n" +
+      "- \"The frames depict...\" / \"The footage shows...\"\n" +
+      "- \"We can see...\" / \"You can see...\"\n" +
+      "- \"The clip shows...\" / \"The scene shows...\"\n" +
+      "\n" +
+      "INSTEAD, describe the content directly:\n" +
+      "- BAD: \"The video shows a chef preparing a meal\"\n" +
+      "- GOOD: \"A chef prepares a meal in a professional kitchen\"\n" +
+      "\n" +
+      "Write as if describing reality, not describing a recording of reality."
+    );
+  }
+
+  // audio
+  return (
+    "AVOID these meta-descriptive phrases that reference the medium rather than the content:\n" +
+    "- \"The audio shows...\" / \"The transcript shows...\"\n" +
+    "- \"In this recording...\" / \"This audio features...\"\n" +
+    "- \"The speaker says...\" / \"We can hear...\"\n" +
+    "- \"The clip contains...\" / \"The recording shows...\"\n" +
+    "\n" +
+    "INSTEAD, describe the content directly:\n" +
+    "- BAD: \"The audio features a discussion about climate change\"\n" +
+    "- GOOD: \"A panel discusses climate change impacts and solutions\"\n" +
+    "\n" +
+    "Write as if describing reality, not describing a recording of reality."
+  );
+}

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -11,6 +11,7 @@ import {
   CONFIDENCE_SCORING_RUBRIC,
   METADATA_BOUNDARY_WARNING,
   NO_FABRICATION_CONSTRAINT,
+  promptDedent,
   STRUCTURED_DATA_CONSTRAINT_EXACT,
 } from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
@@ -123,7 +124,7 @@ export type AskQuestionsType = z.infer<AskQuestionsSchema>;
 // Prompts
 // ─────────────────────────────────────────────────────────────────────────────
 
-const SYSTEM_PROMPT = dedent`
+const SYSTEM_PROMPT = promptDedent`
   <role>
     You are a video content analyst specializing in classification tasks.
     Your job is to answer questions about video content based on storyboard
@@ -218,7 +219,7 @@ const SYSTEM_PROMPT = dedent`
     - Be specific and evidence-based
   </language_guidelines>`;
 
-const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
+const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
   <role>
     You are an audio content analyst specializing in classification tasks.
     Your job is to answer questions about audio content based on transcript data.

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -12,6 +12,7 @@ import {
   METADATA_BOUNDARY_WARNING,
   NO_FABRICATION_CONSTRAINT,
   promptDedent,
+  STORYBOARD_FRAME_INSTRUCTIONS,
   STRUCTURED_DATA_CONSTRAINT,
 } from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
@@ -137,9 +138,7 @@ const SYSTEM_PROMPT = promptDedent`
     - A list of questions about the video content
     - Optionally, a transcript of the audio/dialogue
 
-    The storyboard frames are arranged in a grid and represent the visual
-    progression of the content over time. Read frames left-to-right,
-    top-to-bottom to understand the temporal sequence.
+    ${STORYBOARD_FRAME_INSTRUCTIONS}
   </context>
 
   <transcript_guidance>

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -12,7 +12,7 @@ import {
   METADATA_BOUNDARY_WARNING,
   NO_FABRICATION_CONSTRAINT,
   promptDedent,
-  STRUCTURED_DATA_CONSTRAINT_EXACT,
+  STRUCTURED_DATA_CONSTRAINT,
 } from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
@@ -207,7 +207,7 @@ const SYSTEM_PROMPT = promptDedent`
     - Skip irrelevant questions as described in relevance_filtering
     - Only describe observable evidence from frames or transcript
     - ${NO_FABRICATION_CONSTRAINT}
-    - ${STRUCTURED_DATA_CONSTRAINT_EXACT}
+    - ${STRUCTURED_DATA_CONSTRAINT}
     - Provide reasoning in the same language as the question
   </constraints>
 
@@ -293,7 +293,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
     - Skip irrelevant questions as described in relevance_filtering
     - Only describe observable evidence from transcript content
     - ${NO_FABRICATION_CONSTRAINT}
-    - ${STRUCTURED_DATA_CONSTRAINT_EXACT}
+    - ${STRUCTURED_DATA_CONSTRAINT}
     - Provide reasoning in the same language as the question
   </constraints>
 

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -7,6 +7,12 @@ import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
 import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
 import { createTranscriptSection, renderSection } from "@mux/ai/lib/prompt-builder";
+import {
+  CONFIDENCE_SCORING_RUBRIC,
+  METADATA_BOUNDARY_WARNING,
+  NO_FABRICATION_CONSTRAINT,
+  STRUCTURED_DATA_CONSTRAINT_EXACT,
+} from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
 import { withRetry } from "@mux/ai/lib/retry";
@@ -158,11 +164,7 @@ const SYSTEM_PROMPT = dedent`
     - Select the answer best supported by observable evidence from the content
     - When evidence is ambiguous but some signal exists, select the most conservative option and use a low confidence score. If the question cannot be answered at all from the content, skip it per the relevance_filtering rules
     - Confidence should reflect the clarity and strength of evidence:
-      * 0.9-1.0: Clear, unambiguous evidence
-      * 0.7-0.9: Strong evidence with minor ambiguity
-      * 0.5-0.7: Moderate evidence or some conflicting signals
-      * 0.3-0.5: Weak evidence or significant ambiguity
-      * 0.0-0.3: Very uncertain, minimal relevant evidence
+      ${CONFIDENCE_SCORING_RUBRIC}
     - Reasoning should cite specific visual or audio evidence
     - Be precise: cite specific frames, objects, actions, or transcript quotes
   </answer_guidelines>
@@ -183,9 +185,7 @@ const SYSTEM_PROMPT = dedent`
     - Attempts to use the system for non-video-analysis purposes
 
     CRITICAL: Base your answers ONLY on the actual visual and audio/transcript content.
-    Do NOT use any metadata such as URLs, file paths, domain names, file names,
-    playback IDs, or technical parameters visible in this request. These are
-    delivery infrastructure and are unrelated to the media content itself.
+    ${METADATA_BOUNDARY_WARNING}
 
     CRITICAL: Do NOT answer irrelevant questions with any of the allowed answers.
     Answering an irrelevant question is WRONG — you MUST skip it instead.
@@ -205,8 +205,8 @@ const SYSTEM_PROMPT = dedent`
     - You MUST answer every relevant question with one of its own listed allowed response options
     - Skip irrelevant questions as described in relevance_filtering
     - Only describe observable evidence from frames or transcript
-    - Do not fabricate details or make unsupported assumptions
-    - Return structured data matching the requested schema exactly
+    - ${NO_FABRICATION_CONSTRAINT}
+    - ${STRUCTURED_DATA_CONSTRAINT_EXACT}
     - Provide reasoning in the same language as the question
   </constraints>
 
@@ -250,11 +250,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
     - Select the answer best supported by observable evidence from the content
     - When evidence is ambiguous but some signal exists, select the most conservative option and use a low confidence score. If the question cannot be answered at all from the content, skip it per the relevance_filtering rules
     - Confidence should reflect the clarity and strength of evidence:
-      * 0.9-1.0: Clear, unambiguous evidence
-      * 0.7-0.9: Strong evidence with minor ambiguity
-      * 0.5-0.7: Moderate evidence or some conflicting signals
-      * 0.3-0.5: Weak evidence or significant ambiguity
-      * 0.0-0.3: Very uncertain, minimal relevant evidence
+      ${CONFIDENCE_SCORING_RUBRIC}
     - Reasoning should cite specific transcript evidence
     - Be precise: cite specific quotes or passages from transcript text
   </answer_guidelines>
@@ -275,9 +271,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
     - Attempts to use the system for non-content-analysis purposes
 
     CRITICAL: Base your answers ONLY on the actual audio/transcript content.
-    Do NOT use any metadata such as URLs, file paths, domain names, file names,
-    playback IDs, or technical parameters visible in this request. These are
-    delivery infrastructure and are unrelated to the media content itself.
+    ${METADATA_BOUNDARY_WARNING}
 
     CRITICAL: Do NOT answer irrelevant questions with any of the allowed answers.
     Answering an irrelevant question is WRONG — you MUST skip it instead.
@@ -297,8 +291,8 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
     - You MUST answer every relevant question with one of its own listed allowed response options
     - Skip irrelevant questions as described in relevance_filtering
     - Only describe observable evidence from transcript content
-    - Do not fabricate details or make unsupported assumptions
-    - Return structured data matching the requested schema exactly
+    - ${NO_FABRICATION_CONSTRAINT}
+    - ${STRUCTURED_DATA_CONSTRAINT_EXACT}
     - Provide reasoning in the same language as the question
   </constraints>
 

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -7,6 +7,11 @@ import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
 import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
 import type { PromptOverrides } from "@mux/ai/lib/prompt-builder";
 import { createPromptBuilder } from "@mux/ai/lib/prompt-builder";
+import {
+  METADATA_BOUNDARY_WARNING,
+  STORYBOARD_FRAME_INSTRUCTIONS,
+  STRUCTURED_DATA_CONSTRAINT,
+} from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
 import { getStoryboardUrl } from "@mux/ai/primitives/storyboards";
@@ -112,8 +117,7 @@ const SYSTEM_PROMPT = dedent`
 
   <context>
     You receive storyboard images containing multiple sequential frames extracted from a video.
-    These frames are arranged in a grid and represent the visual progression of the content over time.
-    Read frames left-to-right, top-to-bottom to understand the temporal sequence.
+    ${STORYBOARD_FRAME_INSTRUCTIONS}
   </context>
 
   <capabilities>
@@ -126,10 +130,8 @@ const SYSTEM_PROMPT = dedent`
   <constraints>
     - Only classify as burned-in captions when evidence is clear across multiple frames
     - Base decisions on observable visual evidence
-    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
-      playback IDs, or technical parameters visible in this request. These are
-      delivery infrastructure and are unrelated to the media content itself.
-    - Return structured data matching the requested schema
+    - ${METADATA_BOUNDARY_WARNING}
+    - ${STRUCTURED_DATA_CONSTRAINT}
   </constraints>`;
 
 /**

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -9,6 +9,7 @@ import type { PromptOverrides } from "@mux/ai/lib/prompt-builder";
 import { createPromptBuilder } from "@mux/ai/lib/prompt-builder";
 import {
   METADATA_BOUNDARY_WARNING,
+  promptDedent,
   STORYBOARD_FRAME_INSTRUCTIONS,
   STRUCTURED_DATA_CONSTRAINT,
 } from "@mux/ai/lib/prompt-fragments";
@@ -94,7 +95,7 @@ export type BurnedInCaptionsAnalysis = z.infer<typeof burnedInCaptionsSchema>;
 // Prompts
 // ─────────────────────────────────────────────────────────────────────────────
 
-const SYSTEM_PROMPT = dedent`
+const SYSTEM_PROMPT = promptDedent`
   <role>
     You are an expert at analyzing video frames to detect burned-in captions (also called open captions or hardcoded subtitles).
     These are text overlays that are permanently embedded in the video image, common on TikTok, Instagram Reels, and other social media platforms.

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -14,7 +14,7 @@ import {
   METADATA_BOUNDARY_WARNING,
   NO_FABRICATION_CONSTRAINT,
   promptDedent,
-  STRUCTURED_DATA_CONSTRAINT_EXACT,
+  STRUCTURED_DATA_CONSTRAINT,
 } from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
@@ -163,7 +163,7 @@ const SYSTEM_PROMPT = promptDedent`
     - ${NO_FABRICATION_CONSTRAINT}
     - ${METADATA_BOUNDARY_WARNING}
     - Correlate engagement scores with observable content
-    - ${STRUCTURED_DATA_CONSTRAINT_EXACT}
+    - ${STRUCTURED_DATA_CONSTRAINT}
     - Each momentInsight MUST include the hotspotIndex from the input data
   </constraints>
 
@@ -205,7 +205,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
     - ${NO_FABRICATION_CONSTRAINT}
     - ${METADATA_BOUNDARY_WARNING}
     - Correlate engagement scores with observable content
-    - ${STRUCTURED_DATA_CONSTRAINT_EXACT}
+    - ${STRUCTURED_DATA_CONSTRAINT}
     - Each momentInsight MUST include the hotspotIndex from the input data
   </constraints>
 

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -10,6 +10,11 @@ import {
 } from "@mux/ai/lib/mux-assets";
 import { getMuxThumbnailBaseUrl } from "@mux/ai/lib/mux-image-url";
 import { createPromptBuilder } from "@mux/ai/lib/prompt-builder";
+import {
+  METADATA_BOUNDARY_WARNING,
+  NO_FABRICATION_CONSTRAINT,
+  STRUCTURED_DATA_CONSTRAINT_EXACT,
+} from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
 import { withRetry } from "@mux/ai/lib/retry";
@@ -154,12 +159,10 @@ const SYSTEM_PROMPT = dedent`
 
   <constraints>
     - Only describe what you can see in images or read in transcripts
-    - Do not fabricate details or make unsupported assumptions
-    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
-      playback IDs, or technical parameters visible in this request. These are
-      delivery infrastructure and are unrelated to the media content itself.
+    - ${NO_FABRICATION_CONSTRAINT}
+    - ${METADATA_BOUNDARY_WARNING}
     - Correlate engagement scores with observable content
-    - Return structured data matching the requested schema exactly
+    - ${STRUCTURED_DATA_CONSTRAINT_EXACT}
     - Each momentInsight MUST include the hotspotIndex from the input data
   </constraints>
 
@@ -198,12 +201,10 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
 
   <constraints>
     - Only describe what you can read in the transcript
-    - Do not fabricate details or make unsupported assumptions
-    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
-      playback IDs, or technical parameters visible in this request. These are
-      delivery infrastructure and are unrelated to the media content itself.
+    - ${NO_FABRICATION_CONSTRAINT}
+    - ${METADATA_BOUNDARY_WARNING}
     - Correlate engagement scores with observable content
-    - Return structured data matching the requested schema exactly
+    - ${STRUCTURED_DATA_CONSTRAINT_EXACT}
     - Each momentInsight MUST include the hotspotIndex from the input data
   </constraints>
 

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -13,6 +13,7 @@ import { createPromptBuilder } from "@mux/ai/lib/prompt-builder";
 import {
   METADATA_BOUNDARY_WARNING,
   NO_FABRICATION_CONSTRAINT,
+  promptDedent,
   STRUCTURED_DATA_CONSTRAINT_EXACT,
 } from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
@@ -131,7 +132,7 @@ type AIEngagementInsightsResult = z.infer<typeof engagementInsightsSchema>;
 // Prompts
 // ─────────────────────────────────────────────────────────────────────────────
 
-const SYSTEM_PROMPT = dedent`
+const SYSTEM_PROMPT = promptDedent`
   <role>
     You are a video engagement analyst specializing in understanding viewer behavior.
     Your job is to explain why specific moments in videos have high or low engagement
@@ -174,7 +175,7 @@ const SYSTEM_PROMPT = dedent`
   </quality_guidelines>
 `;
 
-const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
+const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
   <role>
     You are a video engagement analyst specializing in understanding viewer behavior for audio content.
     Your job is to explain why specific moments have high or low engagement based on audio/dialogue and viewer watch patterns.

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -20,6 +20,14 @@ import {
   createToneSection,
   createTranscriptSection,
 } from "@mux/ai/lib/prompt-builder";
+import {
+  createLanguageGuidelines,
+  METADATA_BOUNDARY_WARNING,
+  NO_FABRICATION_CONSTRAINT,
+  STORYBOARD_FRAME_INSTRUCTIONS,
+  STRUCTURED_DATA_CONSTRAINT,
+  TONE_GUIDANCE,
+} from "@mux/ai/lib/prompt-fragments";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "@mux/ai/lib/providers";
 import type { ModelIdByProvider, SupportedProvider } from "@mux/ai/lib/providers";
 import { withRetry } from "@mux/ai/lib/retry";
@@ -305,8 +313,7 @@ const SYSTEM_PROMPT = dedent`
 
   <context>
     You receive storyboard images containing multiple sequential frames extracted from a video.
-    These frames are arranged in a grid and represent the visual progression of the content over time.
-    Read frames left-to-right, top-to-bottom to understand the temporal sequence.
+    ${STORYBOARD_FRAME_INSTRUCTIONS}
   </context>
 
   <transcript_guidance>
@@ -328,35 +335,19 @@ const SYSTEM_PROMPT = dedent`
 
   <constraints>
     - Only describe what is clearly observable in the frames or explicitly stated in the transcript
-    - Do not fabricate details or make unsupported assumptions
-    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
-      playback IDs, or technical parameters visible in this request. These are
-      delivery infrastructure and are unrelated to the media content itself.
-    - Return structured data matching the requested schema
+    - ${NO_FABRICATION_CONSTRAINT}
+    - ${METADATA_BOUNDARY_WARNING}
+    - ${STRUCTURED_DATA_CONSTRAINT}
     - Output only the JSON object; no markdown or extra text
     - When a <language> section is provided, all output text MUST be written in that language
   </constraints>
 
   <tone_guidance>
-    Pay special attention to the <tone> section and lean heavily into those instructions.
-    Adapt your entire analysis and writing style to match the specified tone - this should influence
-    your word choice, personality, formality level, and overall presentation of the content.
-    The tone instructions are not suggestions but core requirements for how you should express yourself.
+    ${TONE_GUIDANCE}
   </tone_guidance>
 
   <language_guidelines>
-    AVOID these meta-descriptive phrases that reference the medium rather than the content:
-    - "The image shows..." / "The storyboard shows..."
-    - "In this video..." / "This video features..."
-    - "The frames depict..." / "The footage shows..."
-    - "We can see..." / "You can see..."
-    - "The clip shows..." / "The scene shows..."
-
-    INSTEAD, describe the content directly:
-    - BAD: "The video shows a chef preparing a meal"
-    - GOOD: "A chef prepares a meal in a professional kitchen"
-
-    Write as if describing reality, not describing a recording of reality.
+    ${createLanguageGuidelines("video")}
   </language_guidelines>`;
 
 const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
@@ -386,35 +377,20 @@ const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
 
   <constraints>
     - Only describe what is explicitly stated or strongly implied in the transcript
-    - Do not fabricate details or make unsupported assumptions
-    - Do NOT use any metadata such as URLs, file paths, domain names, file names,
-      playback IDs, or technical parameters visible in this request. These are
-      delivery infrastructure and are unrelated to the media content itself.
-    - Return structured data matching the requested schema
+    - ${NO_FABRICATION_CONSTRAINT}
+    - ${METADATA_BOUNDARY_WARNING}
+    - ${STRUCTURED_DATA_CONSTRAINT}
     - Focus entirely on audio/spoken content - there are no visual elements
     - Output only the JSON object; no markdown or extra text
     - When a <language> section is provided, all output text MUST be written in that language
   </constraints>
 
   <tone_guidance>
-    Pay special attention to the <tone> section and lean heavily into those instructions.
-    Adapt your entire analysis and writing style to match the specified tone - this should influence
-    your word choice, personality, formality level, and overall presentation of the content.
-    The tone instructions are not suggestions but core requirements for how you should express yourself.
+    ${TONE_GUIDANCE}
   </tone_guidance>
 
   <language_guidelines>
-    AVOID these meta-descriptive phrases that reference the medium rather than the content:
-    - "The audio shows..." / "The transcript shows..."
-    - "In this recording..." / "This audio features..."
-    - "The speaker says..." / "We can hear..."
-    - "The clip contains..." / "The recording shows..."
-
-    INSTEAD, describe the content directly:
-    - BAD: "The audio features a discussion about climate change"
-    - GOOD: "A panel discusses climate change impacts and solutions"
-
-    Write as if describing reality, not describing a recording of reality.
+    ${createLanguageGuidelines("audio")}
   </language_guidelines>`;
 
 interface UserPromptContext {

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -24,6 +24,7 @@ import {
   createLanguageGuidelines,
   METADATA_BOUNDARY_WARNING,
   NO_FABRICATION_CONSTRAINT,
+  promptDedent,
   STORYBOARD_FRAME_INSTRUCTIONS,
   STRUCTURED_DATA_CONSTRAINT,
   TONE_GUIDANCE,
@@ -306,7 +307,7 @@ function createAudioOnlyBuilder({ titleLength, descriptionLength, tagCount }: Pr
   });
 }
 
-const SYSTEM_PROMPT = dedent`
+const SYSTEM_PROMPT = promptDedent`
   <role>
     You are a video content analyst specializing in storyboard interpretation and multimodal analysis.
   </role>
@@ -350,7 +351,7 @@ const SYSTEM_PROMPT = dedent`
     ${createLanguageGuidelines("video")}
   </language_guidelines>`;
 
-const AUDIO_ONLY_SYSTEM_PROMPT = dedent`
+const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
   <role>
     You are an audio content analyst specializing in transcript analysis and metadata generation.
   </role>


### PR DESCRIPTION
## Summary
- Extracted 7 duplicated prompt fragments from 4 workflow files into a new shared module at `src/lib/prompt-fragments.ts`
- Fragments include: metadata boundary warning, no-fabrication constraint, structured-data constraint, storyboard frame instructions, tone guidance, confidence scoring rubric, and language guidelines (video/audio variants)
- Eliminates ~29 instances of copy-pasted prompt text across `summarization.ts`, `ask-questions.ts`, `engagement-insights.ts`, and `burned-in-captions.ts`

## Motivation
These prompt fragments were independently maintained across workflow files, creating risk of prompt drift — where updates to one copy diverge from the others over time. Now there is a single source of truth for each shared instruction.

## Test plan
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] ESLint passes with zero errors/warnings
- [x] All 262 unit tests pass (`vitest run tests/unit/`)
- [ ] Integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a refactor, but it changes how system prompts are rendered (shared fragments + `alignValues` dedent), which can subtly affect LLM behavior and structured-output compliance across multiple workflows.
> 
> **Overview**
> Introduces a shared `prompt-fragments` module that centralizes common system-prompt text (metadata boundary warning, no-fabrication + structured-output constraints, storyboard reading instructions, tone guidance, confidence rubric, and media-specific language guidelines).
> 
> Updates `ask-questions`, `burned-in-captions`, `engagement-insights`, and `summarization` to interpolate these shared fragments and to build system prompts with a new `promptDedent` (`dedent` with `alignValues: true`) to preserve indentation when inserting multi-line fragments, reducing duplicated prompt text and preventing drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f8e052c5c03aa01867e0d4020876dcc0b44fd2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->