### PR TITLE
feat: ignore tracks with low confidence in language categorization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ai-sdk/anthropic": "^3.0.16",
         "@ai-sdk/google": "^3.0.10",
         "@ai-sdk/openai": "^3.0.12",
-        "@mux/mux-node": "^12.5.0",
+        "@mux/mux-node": "^14.0.0",
         "@noble/ciphers": "^2.1.1",
         "ai": "^6.0.42",
         "dedent": "^1.7.0",
@@ -2150,35 +2150,13 @@
       }
     },
     "node_modules/@mux/mux-node": {
-      "version": "12.8.1",
-      "resolved": "https://registry.npmjs.org/@mux/mux-node/-/mux-node-12.8.1.tgz",
-      "integrity": "sha512-ey2eKn7iwVrjRVJfB/yF9HPDVpEl+fZV00ydx0kc9/BMs+wjBi0KgU0HMqUjTgEoyMUTlHmJ3U3BfDvreyg5iQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-node/-/mux-node-14.0.0.tgz",
+      "integrity": "sha512-jhp1a7OACEQKzOr7Zz9yquW0Gma/XSWvbvUnRiRRMs5ObNWKAaRVDCMBEorbVDawDTxwlQNfGKViuvzCXWUJpQ==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "jose": "^4.14.4",
-        "node-fetch": "^2.6.7"
+      "bin": {
+        "mux-mux-node": "bin/cli"
       }
-    },
-    "node_modules/@mux/mux-node/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@mux/mux-node/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
@@ -5038,19 +5016,10 @@
       "version": "20.19.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/responselike": {
@@ -6399,7 +6368,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -6462,18 +6433,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ai": {
@@ -6754,12 +6713,6 @@
       "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -7425,6 +7378,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7751,18 +7705,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -8121,15 +8063,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8276,6 +8209,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -8431,6 +8365,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8440,6 +8375,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8456,24 +8392,10 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9418,7 +9340,9 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10233,28 +10157,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -10262,19 +10164,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
-      }
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
       }
     },
     "node_modules/forwarded": {
@@ -10331,6 +10220,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10353,6 +10243,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -10387,6 +10278,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -10590,6 +10482,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10691,22 +10584,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -10718,6 +10597,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -10796,15 +10676,6 @@
       "peer": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -11182,15 +11053,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {
@@ -11665,6 +11527,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12615,6 +12478,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12624,6 +12488,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -12759,6 +12624,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mylas": {
@@ -12885,46 +12751,6 @@
           "optional": true
         },
         "xml2js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
           "optional": true
         }
       }
@@ -15501,12 +15327,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -15985,6 +15805,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -16502,37 +16323,12 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@ai-sdk/anthropic": "^3.0.16",
     "@ai-sdk/google": "^3.0.10",
     "@ai-sdk/openai": "^3.0.12",
-    "@mux/mux-node": "^12.5.0",
+    "@mux/mux-node": "^14.0.0",
     "@noble/ciphers": "^2.1.1",
     "ai": "^6.0.42",
     "dedent": "^1.7.0",

--- a/src/lib/language-codes.ts
+++ b/src/lib/language-codes.ts
@@ -231,13 +231,41 @@ export function isValidISO639_3(code: string): boolean {
   return code.length === 3 && code.toLowerCase() in ISO639_3_TO_1;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Undetermined / Special Language Codes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * ISO 639-2 special language codes that do not represent a specific language.
+ * These should not be used as LLM output language instructions.
+ *
+ * - `und` — undetermined (e.g. Mux Video sets this when auto-detection confidence is too low)
+ * - `mul` — multiple languages
+ * - `mis` — miscellaneous / uncoded
+ * - `zxx` — no linguistic content
+ */
+const UNDETERMINED_LANGUAGE_CODES = new Set(["und", "mul", "mis", "zxx"]);
+
+/**
+ * Returns true if the given language code represents an undetermined,
+ * multiple, miscellaneous, or non-linguistic language tag.
+ */
+export function isUndeterminedLanguageCode(code: string): boolean {
+  return UNDETERMINED_LANGUAGE_CODES.has(code.toLowerCase().trim());
+}
+
 /**
  * Gets the human-readable language name for a given code.
+ * Returns `undefined` for undetermined / special language codes
+ * that should not be used as LLM output language instructions.
  *
  * @param code - Language code in either ISO 639-1 or ISO 639-3 format
- * @returns Human-readable language name (e.g., "English", "French")
+ * @returns Human-readable language name (e.g., "English", "French"), or undefined for undetermined codes
  */
-export function getLanguageName(code: string): string {
+export function getLanguageName(code: string): string | undefined {
+  if (isUndeterminedLanguageCode(code)) {
+    return undefined;
+  }
   const iso639_1 = toISO639_1(code);
   try {
     const displayNames = new Intl.DisplayNames(["en"], { type: "language" });

--- a/src/primitives/heatmap.ts
+++ b/src/primitives/heatmap.ts
@@ -122,7 +122,7 @@ async function fetchHeatmap(
 
   // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
   const path = `/data/v1/engagement/${identifierType}/${id}/heatmap?${queryParams.toString()}`;
-  const response = await mux.get<unknown, HeatmapApiResponse>(path);
+  const response = await mux.get<HeatmapApiResponse>(path);
 
   return transformHeatmapResponse(response);
 }

--- a/src/primitives/hotspots.ts
+++ b/src/primitives/hotspots.ts
@@ -146,7 +146,7 @@ async function fetchHotspots(
 
   // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
   const path = `/data/v1/engagement/${identifierType}/${id}/hotspots?${queryParams.toString()}`;
-  const response = await mux.get<unknown, HotspotApiResponse>(path);
+  const response = await mux.get<HotspotApiResponse>(path);
 
   return transformHotspotResponse(response);
 }

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -76,8 +76,6 @@ interface ShotsManifestResponse {
   }>;
 }
 
-type RequestShotsApiRequestBody = Record<string, never>;
-
 const DEFAULT_POLL_INTERVAL_MS = 2000;
 const MIN_POLL_INTERVAL_MS = 1000;
 const DEFAULT_MAX_ATTEMPTS = 60;
@@ -186,7 +184,7 @@ export async function requestShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.post<RequestShotsApiRequestBody, ShotsApiResponse>(
+  const response = await mux.post<ShotsApiResponse>(
     getShotsPath(assetId),
     { body: {} },
   );
@@ -216,7 +214,7 @@ export async function getShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.get<unknown, ShotsApiResponse>(
+  const response = await mux.get<ShotsApiResponse>(
     getShotsPath(assetId),
   );
 

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -67,7 +67,7 @@ export function findCaptionTrack(asset: MuxAsset, languageCode?: string): AssetT
 }
 
 /**
- * Minimum auto-detection confidence required to trust a track's language code.
+ * Default minimum auto-detection confidence required to trust a track's language code.
  * Below this threshold, the language is treated as undetermined.
  */
 export const LOW_CONFIDENCE_THRESHOLD = 0.5;
@@ -79,19 +79,25 @@ export const LOW_CONFIDENCE_THRESHOLD = 0.5;
  * Returns `undefined` when:
  * - The track or its language code is missing
  * - The language code is undetermined (`und`, `mul`, `mis`, `zxx`)
- * - The language was auto-detected with confidence below {@link LOW_CONFIDENCE_THRESHOLD}
+ * - The language was auto-detected with confidence below the threshold
  *
  * Trusts the language code when:
  * - `auto_language_confidence` is absent (manually set or non-auto tracks)
  * - `auto_language_confidence` meets the threshold
+ *
+ * @param track - The text track to inspect
+ * @param confidenceThreshold - Minimum confidence to trust auto-detected language (default: {@link LOW_CONFIDENCE_THRESHOLD})
  */
-export function getReliableLanguageCode(track: AssetTextTrack | undefined): string | undefined {
+export function getReliableLanguageCode(
+  track: AssetTextTrack | undefined,
+  confidenceThreshold: number = LOW_CONFIDENCE_THRESHOLD,
+): string | undefined {
   if (!track?.language_code)
     return undefined;
   if (isUndeterminedLanguageCode(track.language_code))
     return undefined;
   if (track.auto_language_confidence !== undefined &&
-    track.auto_language_confidence < LOW_CONFIDENCE_THRESHOLD) {
+    track.auto_language_confidence < confidenceThreshold) {
     return undefined;
   }
   return track.language_code;

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -1,3 +1,4 @@
+import { isUndeterminedLanguageCode } from "@mux/ai/lib/language-codes";
 import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import { isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
 import { signUrl } from "@mux/ai/lib/url-signing";
@@ -63,6 +64,37 @@ export function findCaptionTrack(asset: MuxAsset, languageCode?: string): AssetT
   }
 
   return undefined;
+}
+
+/**
+ * Minimum auto-detection confidence required to trust a track's language code.
+ * Below this threshold, the language is treated as undetermined.
+ */
+export const LOW_CONFIDENCE_THRESHOLD = 0.5;
+
+/**
+ * Extracts a trustworthy language code from a track, returning `undefined`
+ * when the language metadata shouldn't be used as an LLM output language.
+ *
+ * Returns `undefined` when:
+ * - The track or its language code is missing
+ * - The language code is undetermined (`und`, `mul`, `mis`, `zxx`)
+ * - The language was auto-detected with confidence below {@link LOW_CONFIDENCE_THRESHOLD}
+ *
+ * Trusts the language code when:
+ * - `auto_language_confidence` is absent (manually set or non-auto tracks)
+ * - `auto_language_confidence` meets the threshold
+ */
+export function getReliableLanguageCode(track: AssetTextTrack | undefined): string | undefined {
+  if (!track?.language_code)
+    return undefined;
+  if (isUndeterminedLanguageCode(track.language_code))
+    return undefined;
+  if (track.auto_language_confidence !== undefined &&
+    track.auto_language_confidence < LOW_CONFIDENCE_THRESHOLD) {
+    return undefined;
+  }
+  return track.language_code;
 }
 
 function normalizeLineEndings(value: string): string {

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -19,6 +19,7 @@ import {
   extractTimestampedTranscript,
   fetchTranscriptForAsset,
   getReadyTextTracks,
+  getReliableLanguageCode,
 } from "@mux/ai/primitives/transcripts";
 import type { MuxAIOptions, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
 
@@ -350,10 +351,11 @@ export async function generateChapters(
     throw new MuxAiError(`No usable content found in ${contentLabel}.`, { type: "validation_error" });
   }
 
-  // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track
+  // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track.
+  // Low-confidence auto-detected languages and undetermined codes ("und") are filtered out.
   const resolvedLanguageCode = outputLanguageCode && outputLanguageCode !== "auto" ?
     outputLanguageCode :
-      (transcriptResult.track?.language_code ?? languageCode);
+      (getReliableLanguageCode(transcriptResult.track) ?? languageCode);
   const languageName = resolvedLanguageCode ? getLanguageName(resolvedLanguageCode) : undefined;
 
   const userPrompt = buildUserPrompt({
@@ -411,7 +413,7 @@ export async function generateChapters(
 
   return {
     assetId,
-    languageCode: languageCode ?? transcriptResult.track?.language_code ?? "en",
+    languageCode: languageCode ?? getReliableLanguageCode(transcriptResult.track) ?? "en",
     chapters: validChapters,
     usage: usageWithMetadata,
   };

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -27,7 +27,7 @@ import {
   resolveMuxSigningContext,
 } from "@mux/ai/lib/workflow-credentials";
 import { getStoryboardUrl } from "@mux/ai/primitives/storyboards";
-import { fetchTranscriptForAsset, getReadyTextTracks } from "@mux/ai/primitives/transcripts";
+import { fetchTranscriptForAsset, getReadyTextTracks, getReliableLanguageCode } from "@mux/ai/primitives/transcripts";
 import type {
   ImageSubmissionMode,
   MuxAIOptions,
@@ -669,10 +669,11 @@ export async function getSummaryAndTags(
       undefined;
   const transcriptText = transcriptResult?.transcriptText ?? "";
 
-  // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track
+  // Resolve output language: explicit code takes priority, otherwise auto-detect from transcript track.
+  // Low-confidence auto-detected languages and undetermined codes ("und") are filtered out.
   const resolvedLanguageCode = outputLanguageCode && outputLanguageCode !== "auto" ?
     outputLanguageCode :
-      (transcriptResult?.track?.language_code ?? getReadyTextTracks(assetData)[0]?.language_code);
+      (getReliableLanguageCode(transcriptResult?.track) ?? getReliableLanguageCode(getReadyTextTracks(assetData)[0]));
   const languageName = resolvedLanguageCode ? getLanguageName(resolvedLanguageCode) : undefined;
 
   // Build the user prompt with all context and any overrides

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -827,7 +827,7 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     // Add translated track to Mux asset (only when uploadToMux is true)
     if (uploadToMux) {
       try {
-        const languageName = getLanguageName(toLanguageCode);
+        const languageName = getLanguageName(toLanguageCode) ?? toLanguageCode.toUpperCase();
         const trackName = `${languageName} (auto-translated)`;
 
         uploadedTrackId = await createTextTrackOnMux(

--- a/tests/unit/language-codes.test.ts
+++ b/tests/unit/language-codes.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getLanguageName,
+  isUndeterminedLanguageCode,
+} from "../../src/lib/language-codes";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isUndeterminedLanguageCode
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("isUndeterminedLanguageCode", () => {
+  it.each(["und", "mul", "mis", "zxx"])("returns true for special code '%s'", (code) => {
+    expect(isUndeterminedLanguageCode(code)).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isUndeterminedLanguageCode("UND")).toBe(true);
+    expect(isUndeterminedLanguageCode("Und")).toBe(true);
+  });
+
+  it("trims whitespace", () => {
+    expect(isUndeterminedLanguageCode(" und ")).toBe(true);
+  });
+
+  it.each(["en", "nn", "fr", "de", "ja"])("returns false for real language code '%s'", (code) => {
+    expect(isUndeterminedLanguageCode(code)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isUndeterminedLanguageCode("")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getLanguageName
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getLanguageName", () => {
+  it("returns undefined for undetermined language code", () => {
+    expect(getLanguageName("und")).toBeUndefined();
+  });
+
+  it("returns undefined for all special codes", () => {
+    expect(getLanguageName("mul")).toBeUndefined();
+    expect(getLanguageName("mis")).toBeUndefined();
+    expect(getLanguageName("zxx")).toBeUndefined();
+  });
+
+  it("returns the correct name for English", () => {
+    expect(getLanguageName("en")).toBe("English");
+  });
+
+  it("returns the correct name for Norwegian Nynorsk", () => {
+    // nn is a real language code — the upstream fix converts bad detections to "und"
+    expect(getLanguageName("nn")).toBe("Norwegian Nynorsk");
+  });
+
+  it("returns human-readable names for common languages", () => {
+    expect(getLanguageName("fr")).toBe("French");
+    expect(getLanguageName("es")).toBe("Spanish");
+    expect(getLanguageName("ja")).toBe("Japanese");
+  });
+});

--- a/tests/unit/transcripts.test.ts
+++ b/tests/unit/transcripts.test.ts
@@ -7,12 +7,14 @@ import {
   concatenateVttSegments,
   extractTextFromVTT,
   findCaptionTrack,
+  getReliableLanguageCode,
+  LOW_CONFIDENCE_THRESHOLD,
   parseVTTCues,
   secondsToTimestamp,
   splitVttPreambleAndCueBlocks,
   vttTimestampToSeconds,
 } from "../../src/primitives/transcripts";
-import type { MuxAsset } from "../../src/types";
+import type { AssetTextTrack, MuxAsset } from "../../src/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // vttTimestampToSeconds
@@ -295,6 +297,71 @@ describe("findCaptionTrack", () => {
     const track = findCaptionTrack(asset as MuxAsset, "fr");
 
     expect(track?.id).toBe("text-1");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getReliableLanguageCode
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getReliableLanguageCode", () => {
+  it("returns undefined for undefined track", () => {
+    expect(getReliableLanguageCode(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when track has no language_code", () => {
+    const track = { type: "text", id: "t1" } as AssetTextTrack;
+    expect(getReliableLanguageCode(track)).toBeUndefined();
+  });
+
+  it("returns undefined for undetermined language code", () => {
+    const track = { type: "text", id: "t1", language_code: "und" } as AssetTextTrack;
+    expect(getReliableLanguageCode(track)).toBeUndefined();
+  });
+
+  it("returns undefined for low-confidence auto-detected language", () => {
+    const track = {
+      type: "text",
+      id: "t1",
+      language_code: "nn",
+      auto_language_confidence: 0.27,
+    } as AssetTextTrack;
+    expect(getReliableLanguageCode(track)).toBeUndefined();
+  });
+
+  it("returns the language code for high-confidence auto-detected language", () => {
+    const track = {
+      type: "text",
+      id: "t1",
+      language_code: "en",
+      auto_language_confidence: 0.95,
+    } as AssetTextTrack;
+    expect(getReliableLanguageCode(track)).toBe("en");
+  });
+
+  it("returns the language code when auto_language_confidence is absent (manually set)", () => {
+    const track = { type: "text", id: "t1", language_code: "fr" } as AssetTextTrack;
+    expect(getReliableLanguageCode(track)).toBe("fr");
+  });
+
+  it("returns undefined when confidence is exactly at the threshold", () => {
+    const track = {
+      type: "text",
+      id: "t1",
+      language_code: "de",
+      auto_language_confidence: LOW_CONFIDENCE_THRESHOLD,
+    } as AssetTextTrack;
+    expect(getReliableLanguageCode(track)).toBe("de");
+  });
+
+  it("returns undefined when confidence is just below the threshold", () => {
+    const track = {
+      type: "text",
+      id: "t1",
+      language_code: "de",
+      auto_language_confidence: LOW_CONFIDENCE_THRESHOLD - 0.01,
+    } as AssetTextTrack;
+    expect(getReliableLanguageCode(track)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
# Overview

Handle undetermined (`und`) and low-confidence language codes in @mux/ai workflows. Previously, when Mux Video's auto-captioning had low confidence (e.g., assigning Norwegian Nynorsk to a silent video), the bad language code flowed into LLM prompts producing nonsensical output like "All output MUST be written in root." This adds a two-layer defense: explicit `und` handling plus `auto_language_confidence` filtering (enabled by upgrading `@mux/mux-node` to v14).

# What was changed

- **`package.json`** — Upgraded `@mux/mux-node` from `^12.5.0` to `^14.0.0` to get typed `auto_language_confidence` on track objects.
- **`src/lib/language-codes.ts`** — Added `isUndeterminedLanguageCode()` predicate and changed `getLanguageName()` to return `undefined` for special ISO 639-2 codes (`und`, `mul`, `mis`, `zxx`).
- **`src/primitives/transcripts.ts`** — Added `getReliableLanguageCode(track)` helper that rejects undetermined codes and low-confidence auto-detections (< 0.5 threshold).
- **`src/workflows/summarization.ts`** — Language resolution now uses `getReliableLanguageCode()` instead of raw `track.language_code`.
- **`src/workflows/chapters.ts`** — Same language resolution fix, plus the returned `languageCode` no longer leaks `"und"`.
- **`src/workflows/translate-captions.ts`** — Added nullability fallback for `getLanguageName()` return type change.
- **`src/primitives/heatmap.ts`, `hotspots.ts`, `shots.ts`** — Fixed SDK v14 type breakage: `mux.get<TReq, TRsp>()` → `mux.get<TRsp>()`.
- **`tests/unit/language-codes.test.ts`** (new) — Tests for `isUndeterminedLanguageCode` and `getLanguageName` with special codes.
- **`tests/unit/transcripts.test.ts`** — Tests for `getReliableLanguageCode` covering undefined tracks, `und`, low/high confidence, manually set codes, and threshold boundaries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to upgrading `@mux/mux-node` to v14 and changing language-resolution logic that affects LLM prompt construction and returned workflow metadata.
> 
> **Overview**
> Improves workflow language handling by **filtering out undetermined/special codes** (`und`, `mul`, `mis`, `zxx`) and **ignoring low-confidence auto-detected track languages** when deciding output language for LLM prompts.
> 
> Adds `isUndeterminedLanguageCode`, makes `getLanguageName` return `undefined` for special codes, and introduces `getReliableLanguageCode` (with a 0.5 confidence threshold) used by `chapters` and `summarization` to avoid leaking bad language tags into prompts/outputs. Also upgrades `@mux/mux-node` to `^14.0.0`, updates raw `mux.get/post` generic usage for SDK type changes, and adds unit tests covering the new language-code and confidence behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b21a6cb71c00f804a37252c1691a2b00dbb8dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->