### PR TITLE
feat: add Baseten provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/@mux%2Fai.svg)](https://www.npmjs.com/package/@mux/ai)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Easy to use, purpose-driven, cost effective, configurable **_workflow functions_** in a TypeScript SDK for building AI-powered video and audio workflows on the server, powered by [Mux](https://www.mux.com), with support for popular AI/LLM providers (OpenAI, Anthropic, Google).
+Easy to use, purpose-driven, cost effective, configurable **_workflow functions_** in a TypeScript SDK for building AI-powered video and audio workflows on the server, powered by [Mux](https://www.mux.com), with support for popular AI/LLM providers (OpenAI, Baseten, Anthropic, Google).
 
 - **Examples:** [`getSummaryAndTags`](#video-summarization), [`getModerationScores`](#content-moderation), [`hasBurnedInCaptions`](#burned-in-caption-detection), [`generateChapters`](#chapter-generation), [`generateEmbeddings`](#search-with-embeddings), [`generateEngagementInsights`](#engagement-insights), [`translateCaptions`](#caption-translation), [`editCaptions`](#caption-editing), [`translateAudio`](#audio-dubbing)
 - Workflows automatically ship with `"use workflow"` [compatability with Workflow DevKit](#compatability-with-workflow-devkit)
@@ -25,7 +25,12 @@ Add your credentials to a `.env` file (we support [dotenv](https://www.npmjs.com
 ```bash
 MUX_TOKEN_ID=your_mux_token_id
 MUX_TOKEN_SECRET=your_mux_token_secret
-OPENAI_API_KEY=your_openai_api_key          # or ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY
+OPENAI_API_KEY=your_openai_api_key          # or BASETEN_API_KEY, ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY
+BASETEN_API_KEY=your_baseten_api_key
+BASETEN_BASE_URL=https://model-123.api.baseten.co/environments/production/sync/v1
+BASETEN_MODEL=your-baseten-chat-model
+BASETEN_EMBEDDING_BASE_URL=https://model-456.api.baseten.co/environments/production/sync/v1   # optional
+BASETEN_EMBEDDING_MODEL=your-baseten-embedding-model                                           # optional
 ```
 
 You only need credentials for the AI provider you're using. See the [Credentials guide](./docs/CREDENTIALS.md) for full setup details including signed playback, S3 storage, and all supported providers.
@@ -54,7 +59,7 @@ console.log(result.tags);         // ["typescript", "tutorial", "programming"]
 
 - **Pre-built workflows for media AI tasks.** Common multi-step operations (transcript access, frame analysis, LLM calls, and structured parsing) are available as high-level functions.
 - **Support for video and audio assets.** The same workflows work with video and [audio-only assets](./docs/AUDIO-ONLY.md), including summarization, moderation, chaptering, and more.
-- **Provider-flexible API.** Choose OpenAI, Anthropic, or Google through workflow options while keeping the same workflow interface.
+- **Provider-flexible API.** Choose OpenAI, Baseten, Anthropic, or Google through workflow options while keeping the same workflow interface.
 - **Published evaluation coverage.** Workflows include [evals](./docs/EVALS.md) for quality, latency, and cost, with results [published publicly](https://evaluating-mux-ai.vercel.app/) on pushes to `main`.
 - **Sensible default models.** Defaults (`gpt-5.1`, `claude-sonnet-4-5`, `gemini-3-flash-preview`) are selected to balance output quality and runtime cost.
 - **Typed end-to-end.** Workflow inputs, options, and outputs are fully typed in TypeScript.
@@ -68,14 +73,14 @@ Workflows are high-level functions that handle complete media AI tasks end-to-en
 
 | Workflow | What it does | Providers | Audio-only |
 | --- | --- | --- | :---: |
-| [`getSummaryAndTags`](./docs/WORKFLOWS.md#video-summarization) | Generate titles, descriptions, and tags | OpenAI, Anthropic, Google | Yes |
+| [`getSummaryAndTags`](./docs/WORKFLOWS.md#video-summarization) | Generate titles, descriptions, and tags | OpenAI, Baseten, Anthropic, Google | Yes |
 | [`getModerationScores`](./docs/WORKFLOWS.md#content-moderation) | Detect inappropriate content | OpenAI, Hive | Yes |
-| [`hasBurnedInCaptions`](./docs/WORKFLOWS.md#burned-in-caption-detection) | Detect hardcoded subtitles in video frames | OpenAI, Anthropic, Google | — |
-| [`askQuestions`](./docs/WORKFLOWS.md#ask-questions) | Answer yes/no questions about asset content | OpenAI, Anthropic, Google | Yes |
-| [`generateChapters`](./docs/WORKFLOWS.md#chapter-generation) | Create chapter markers from transcripts | OpenAI, Anthropic, Google | Yes |
-| [`generateEmbeddings`](./docs/WORKFLOWS.md#embeddings) | Generate vector embeddings for semantic search | OpenAI, Google | Yes |
-| [`translateCaptions`](./docs/WORKFLOWS.md#caption-translation) | Translate captions into other languages | OpenAI, Anthropic, Google | Yes |
-| [`editCaptions`](./docs/WORKFLOWS.md#caption-editing) | Edit captions: censor profanity and/or apply static replacements | OpenAI, Anthropic, Google | Yes |
+| [`hasBurnedInCaptions`](./docs/WORKFLOWS.md#burned-in-caption-detection) | Detect hardcoded subtitles in video frames | OpenAI, Baseten, Anthropic, Google | — |
+| [`askQuestions`](./docs/WORKFLOWS.md#ask-questions) | Answer yes/no questions about asset content | OpenAI, Baseten, Anthropic, Google | Yes |
+| [`generateChapters`](./docs/WORKFLOWS.md#chapter-generation) | Create chapter markers from transcripts | OpenAI, Baseten, Anthropic, Google | Yes |
+| [`generateEmbeddings`](./docs/WORKFLOWS.md#embeddings) | Generate vector embeddings for semantic search | OpenAI, Baseten, Google | Yes |
+| [`translateCaptions`](./docs/WORKFLOWS.md#caption-translation) | Translate captions into other languages | OpenAI, Baseten, Anthropic, Google | Yes |
+| [`editCaptions`](./docs/WORKFLOWS.md#caption-editing) | Edit captions: censor profanity and/or apply static replacements | OpenAI, Baseten, Anthropic, Google | Yes |
 | [`translateAudio`](./docs/WORKFLOWS.md#audio-dubbing) | Create AI-dubbed audio tracks | ElevenLabs | Yes |
 
 See the [Workflows guide](./docs/WORKFLOWS.md) for detailed documentation, options, and examples for each workflow. See the [API Reference](./docs/API.md) for complete parameter and return type details.

--- a/docs/API.md
+++ b/docs/API.md
@@ -13,9 +13,9 @@ Analyzes a Mux video or audio asset and returns AI-generated metadata.
 
 **Options:**
 
-- `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
+- `provider?: 'openai' | 'baseten' | 'anthropic' | 'google'` - AI provider (default: 'openai')
 - `tone?: 'neutral' | 'playful' | 'professional'` - Analysis tone (default: 'neutral')
-- `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
+- `model?: string` - AI model to use (defaults: `gpt-5.1`, `BASETEN_MODEL`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `languageCode?: string` - Language code for transcript track selection (e.g., 'en', 'fr'). When omitted, prefers English if available.
 - `outputLanguageCode?: string` - BCP 47 language code (e.g., 'en', 'fr', 'ja') for the generated title, description, and tags. When omitted or set to `'auto'`, auto-detects from the selected transcript track's language. Falls back to unconstrained (LLM decides) if no language metadata is available.
 - `includeTranscript?: boolean` - Include transcript in analysis (default: true)
@@ -127,8 +127,8 @@ Analyzes video frames to detect burned-in captions (hardcoded subtitles) that ar
 
 **Options:**
 
-- `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
-- `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
+- `provider?: 'openai' | 'baseten' | 'anthropic' | 'google'` - AI provider (default: 'openai')
+- `model?: string` - AI model to use (defaults: `gpt-5.1`, `BASETEN_MODEL`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `imageSubmissionMode?: 'url' | 'base64'` - How to submit storyboard to AI providers (default: 'url')
 - `imageDownloadOptions?: object` - Options for image download when using base64 mode
   - `timeout?: number` - Request timeout in milliseconds (default: 10000)
@@ -178,8 +178,8 @@ Answer questions about asset content by analyzing storyboard frames and optional
 
 **Options:**
 
-- `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
-- `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
+- `provider?: 'openai' | 'baseten' | 'anthropic' | 'google'` - AI provider (default: 'openai')
+- `model?: string` - AI model to use (defaults: `gpt-5.1`, `BASETEN_MODEL`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `languageCode?: string` - Language code for transcript track selection (e.g., 'en', 'fr'). When omitted, prefers English if available.
 - `includeTranscript?: boolean` - Include transcript in analysis (default: true, required for audio-only assets)
 - `cleanTranscript?: boolean` - Remove VTT timestamps and formatting from transcript (default: true)
@@ -262,8 +262,8 @@ Generate AI-powered insights explaining viewer engagement patterns by analyzing 
 
 **Options:**
 
-- `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
-- `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
+- `provider?: 'openai' | 'baseten' | 'anthropic' | 'google'` - AI provider (default: 'openai')
+- `model?: string` - AI model to use (defaults: `gpt-5.1`, `BASETEN_MODEL`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `hotspotLimit?: number` - Number of engagement moments to analyze per direction (default: 5, range: 1-10). Note: actual moment count may be up to 2x this value since both peaks and valleys are fetched.
 - `timeframe?: string` - Engagement data timeframe (default: '7:days')
   - Examples: `'60:minutes'`, `'24:hours'`, `'7:days'`, `'30:days'`
@@ -345,7 +345,7 @@ Translates existing captions from one language to another and optionally adds th
 
 **Options:**
 
-- `provider: 'openai' | 'anthropic' | 'google'` - AI provider (required)
+- `provider: 'openai' | 'baseten' | 'anthropic' | 'google'` - AI provider (required)
 - `model?: string` - Model to use (defaults to the provider's chat model if omitted)
 - `uploadToMux?: boolean` - Whether to upload translated track to Mux (default: true)
 - `s3Endpoint?: string` - S3-compatible storage endpoint
@@ -401,7 +401,7 @@ Edits a caption track using LLM-powered profanity censorship, static find/replac
 
 **Options:**
 
-- `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (required when `autoCensorProfanity` is set)
+- `provider?: 'openai' | 'baseten' | 'anthropic' | 'google'` - AI provider (required when `autoCensorProfanity` is set)
 - `model?: string` - Model to use (defaults to the provider's chat model if omitted)
 - `autoCensorProfanity?: object` - LLM-powered profanity censorship (optional)
   - `mode?: 'blank' | 'remove' | 'mask'` - Replacement strategy (default: 'blank')
@@ -462,8 +462,8 @@ Generates AI-powered chapter markers by analyzing video or audio transcripts. Cr
 
 - `languageCode?: string` - Language code for captions (e.g., 'en', 'es', 'fr'). When omitted, prefers English if available.
 - `outputLanguageCode?: string` - BCP 47 language code (e.g., 'en', 'fr', 'ja') for the generated chapter titles. When omitted or set to `'auto'`, auto-detects from the selected transcript track's language. Falls back to unconstrained (LLM decides) if no language metadata is available.
-- `provider?: 'openai' | 'anthropic' | 'google'` - AI provider (default: 'openai')
-- `model?: string` - AI model to use (defaults: `gpt-5.1`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
+- `provider?: 'openai' | 'baseten' | 'anthropic' | 'google'` - AI provider (default: 'openai')
+- `model?: string` - AI model to use (defaults: `gpt-5.1`, `BASETEN_MODEL`, `claude-sonnet-4-5`, or `gemini-3-flash-preview`)
 - `promptOverrides?: object` - Override specific sections of the chaptering prompt
   - `task?: string` - Override the main task instruction
   - `outputFormat?: string` - Override the expected output format description
@@ -562,8 +562,8 @@ Generate vector embeddings for transcript chunks from video or audio assets for 
 
 **Options:**
 
-- `provider?: 'openai' | 'google'` - Embedding provider (default: 'openai')
-- `model?: string` - Model to use (defaults: `text-embedding-3-small` for OpenAI, `gemini-embedding-001` for Google)
+- `provider?: 'openai' | 'baseten' | 'google'` - Embedding provider (default: 'openai')
+- `model?: string` - Model to use (defaults: `text-embedding-3-small` for OpenAI, `BASETEN_EMBEDDING_MODEL` or `BASETEN_MODEL` for Baseten, `gemini-embedding-001` for Google)
 - `chunkingStrategy?: object` - How to chunk the transcript
   - `type: 'token' | 'vtt'` - Chunking method
   - `maxTokens?: number` - Maximum tokens per chunk (default: 500)

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -45,12 +45,31 @@ Different workflows support various AI providers. You only need to configure API
 
 ### OpenAI
 
-**Used by:** `getSummaryAndTags`, `getModerationScores`, `hasBurnedInCaptions`, `askQuestions`, `generateChapters`, `generateEmbeddings`, `translateCaptions`
+**Used by:** `getSummaryAndTags`, `getModerationScores`, `hasBurnedInCaptions`, `askQuestions`, `generateChapters`, `generateEmbeddings`, `translateCaptions`, `editCaptions`
 
 **Get your API key:** [OpenAI API Keys](https://platform.openai.com/api-keys)
 
 ```bash
 OPENAI_API_KEY=your_openai_api_key
+```
+
+### Baseten
+
+**Used by:** `getSummaryAndTags`, `hasBurnedInCaptions`, `askQuestions`, `generateChapters`, `generateEmbeddings`, `translateCaptions`, `editCaptions`
+
+**Get your API key:** [Baseten API Keys](https://app.baseten.co/settings/api_keys)
+
+```bash
+BASETEN_API_KEY=your_baseten_api_key
+BASETEN_BASE_URL=https://model-123.api.baseten.co/environments/production/sync/v1
+BASETEN_MODEL=your-baseten-chat-model
+```
+
+For embeddings, you can point to a separate embedding deployment or reuse the same endpoint if it supports embeddings:
+
+```bash
+BASETEN_EMBEDDING_BASE_URL=https://model-456.api.baseten.co/environments/production/sync/v1
+BASETEN_EMBEDDING_MODEL=your-baseten-embedding-model
 ```
 
 ### Anthropic
@@ -160,6 +179,9 @@ Supported credential fields:
 | `muxSigningKey` | Mux signing key ID (for signed playback) |
 | `muxPrivateKey` | Mux private key (for signed playback) |
 | `openaiApiKey` | OpenAI API key |
+| `basetenApiKey` | Baseten API key |
+| `basetenBaseUrl` | Baseten base URL for language-model requests |
+| `basetenEmbeddingBaseUrl` | Baseten base URL for embedding requests |
 | `anthropicApiKey` | Anthropic API key |
 | `googleApiKey` | Google Generative AI API key |
 | `hiveApiKey` | Hive API key |
@@ -226,6 +248,11 @@ MUX_PRIVATE_KEY=your_base64_encoded_private_key
 
 # AI Providers (configure only what you need)
 OPENAI_API_KEY=your_openai_api_key
+BASETEN_API_KEY=your_baseten_api_key
+BASETEN_BASE_URL=https://model-123.api.baseten.co/environments/production/sync/v1
+BASETEN_MODEL=your-baseten-chat-model
+BASETEN_EMBEDDING_BASE_URL=https://model-456.api.baseten.co/environments/production/sync/v1
+BASETEN_EMBEDDING_MODEL=your-baseten-embedding-model
 ANTHROPIC_API_KEY=your_anthropic_api_key
 GOOGLE_GENERATIVE_AI_API_KEY=your_google_api_key
 ELEVENLABS_API_KEY=your_elevenlabs_api_key

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -198,7 +198,7 @@ const result = await askQuestions(assetId, [
 
 ```typescript
 const result = await askQuestions(assetId, questions, {
-  provider: "openai", // "openai", "anthropic", or "google" (default: "openai")
+  provider: "openai", // "openai", "baseten", "anthropic", or "google" (default: "openai")
   model: "gpt-5.1", // Override default model
   includeTranscript: true, // Include transcript (default: true)
   cleanTranscript: true, // Remove timestamps/markup (default: true)
@@ -278,7 +278,7 @@ console.log("Trends:", result.overallInsight.trends);
 
 ```typescript
 const result = await generateEngagementInsights(assetId, {
-  provider: "openai", // "openai", "anthropic", or "google"
+  provider: "openai", // "openai", "baseten", "anthropic", or "google"
   hotspotLimit: 5, // Moments per direction (1-10, default: 5). Up to 2x total.
   timeframe: "7:days", // "1:hour", "24:hours", "7:days", "30:days"
   skipShots: false, // Skip shots polling, use thumbnails (default: false)
@@ -685,6 +685,12 @@ const openaiResult = await getSummaryAndTags(assetId, {
   tone: "professional"
 });
 
+// Baseten analysis (default: BASETEN_MODEL)
+const basetenResult = await getSummaryAndTags(assetId, {
+  provider: "baseten",
+  tone: "professional"
+});
+
 // Anthropic analysis (default: claude-sonnet-4-5)
 const anthropicResult = await getSummaryAndTags(assetId, {
   provider: "anthropic",
@@ -699,6 +705,7 @@ const googleResult = await getSummaryAndTags(assetId, {
 
 // Compare results
 console.log("OpenAI:", openaiResult.title);
+console.log("Baseten:", basetenResult.title);
 console.log("Anthropic:", anthropicResult.title);
 console.log("Google:", googleResult.title);
 ```
@@ -711,6 +718,11 @@ import { generateChapters } from "@mux/ai/workflows";
 // OpenAI (default: gpt-5.1)
 const openaiChapters = await generateChapters(assetId, {
   provider: "openai"
+});
+
+// Baseten (default: BASETEN_MODEL)
+const basetenChapters = await generateChapters(assetId, {
+  provider: "baseten"
 });
 
 // Anthropic (default: claude-sonnet-4-5)

--- a/env.test.example
+++ b/env.test.example
@@ -18,6 +18,11 @@ MUX_PRIVATE_KEY=
 # AI Providers (set the ones you want to test)
 # ──────────────────────────────────────────────────────────────────────────────
 OPENAI_API_KEY=
+BASETEN_API_KEY=
+BASETEN_BASE_URL=
+BASETEN_EMBEDDING_BASE_URL=
+BASETEN_MODEL=
+BASETEN_EMBEDDING_MODEL=
 ANTHROPIC_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEY=
 
@@ -51,5 +56,4 @@ S3_REGION=
 S3_BUCKET=
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
-
 

--- a/examples/ask-questions/README.md
+++ b/examples/ask-questions/README.md
@@ -10,7 +10,8 @@ npm install
 ```
 
 2. Set the required environment variables:
-   - `OPENAI_API_KEY` - Your OpenAI API key
+   - `OPENAI_API_KEY` or Baseten/Anthropic/Google credentials for the provider you plan to use
+   - `BASETEN_API_KEY`, `BASETEN_BASE_URL`, and `BASETEN_MODEL` when using Baseten
    - `MUX_TOKEN_ID` - Your Mux API token ID
    - `MUX_TOKEN_SECRET` - Your Mux API token secret
 
@@ -46,7 +47,8 @@ npm run example:ask-questions -- <asset-id> "Does this video contain cooking?"
 
 #### Options
 
-- `-m, --model <model>` - Specify the OpenAI model to use (default: gpt-5.1)
+- `-m, --model <model>` - Specify the AI model to use (provider default when omitted)
+- `-p, --provider <provider>` - Choose `openai`, `baseten`, `anthropic`, or `google` (default: `openai`)
 - `--no-transcript` - Exclude the transcript from analysis (visual only)
 
 #### Examples
@@ -63,6 +65,9 @@ npm run basic abc123 "Are there people visible in this video?" --no-transcript
 
 # Use a specific model
 npm run basic abc123 "Is this video shot outdoors?" --model gpt-4o
+
+# Run against Baseten
+npm run basic abc123 "Does this video contain cooking?" --provider baseten
 ```
 
 ### Multiple Questions Example
@@ -93,8 +98,8 @@ If no asset ID is provided, the script uses `MUX_TEST_ASSET_ID_AUDIO_ONLY`.
 
 #### Options
 
-- `-m, --model <model>` - Specify the OpenAI model to use (default: gpt-5.1)
-- `--no-transcript` - Exclude the transcript from analysis (visual only)
+- `-m, --model <model>` - Specify the AI model to use (provider default when omitted)
+- `-p, --provider <provider>` - Choose `openai`, `baseten`, `anthropic`, or `google` (default: `openai`)
 
 #### Examples
 

--- a/examples/ask-questions/audio-only-example.ts
+++ b/examples/ask-questions/audio-only-example.ts
@@ -5,10 +5,11 @@ import { askQuestions } from "@mux/ai/workflows";
 import env from "../env";
 import { parseQuestionArg } from "./parse-question";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3.1-flash-lite-preview",
 };
@@ -30,7 +31,7 @@ program
     "append a pipe + comma-separated options for custom allowed answers, e.g. " +
     "\"What is the speaker's tone?|calm,excited,angry\"",
   )
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "openai")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .action(async (assetId: string | undefined, questionArg: string | undefined, options: {
     provider: Provider;
@@ -46,8 +47,8 @@ program
       process.exit(1);
     }
 
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/ask-questions/basic-example.ts
+++ b/examples/ask-questions/basic-example.ts
@@ -4,6 +4,8 @@ import { askQuestions } from "@mux/ai/workflows";
 
 import { parseQuestionArg } from "./parse-question";
 
+type Provider = "openai" | "baseten" | "anthropic" | "google";
+
 const program = new Command();
 
 program
@@ -16,11 +18,11 @@ program
     "append a pipe followed by comma-separated options, e.g. " +
     "\"What is the quality?|amateur,semi-pro,professional\"",
   )
-  .option("-p, --provider <provider>", "AI provider: openai, anthropic, google (default: openai)")
+  .option("-p, --provider <provider>", "AI provider: openai, baseten, anthropic, google (default: openai)")
   .option("-m, --model <model>", "Model name (default varies by provider)")
   .option("--no-transcript", "Exclude transcript from analysis")
   .action(async (assetId: string, questionArg: string, options: {
-    provider?: string;
+    provider?: Provider;
     model?: string;
     transcript: boolean;
   }) => {

--- a/examples/ask-questions/multiple-questions-example.ts
+++ b/examples/ask-questions/multiple-questions-example.ts
@@ -4,6 +4,8 @@ import { askQuestions } from "@mux/ai/workflows";
 
 import { parseQuestionArg } from "./parse-question";
 
+type Provider = "openai" | "baseten" | "anthropic" | "google";
+
 const program = new Command();
 
 program
@@ -16,11 +18,11 @@ program
     "To use custom allowed answers for a question, append a pipe followed by " +
     "comma-separated options, e.g. \"What is the quality?|amateur,semi-pro,professional\"",
   )
-  .option("-p, --provider <provider>", "AI provider: openai, anthropic, google (default: openai)")
+  .option("-p, --provider <provider>", "AI provider: openai, baseten, anthropic, google (default: openai)")
   .option("-m, --model <model>", "Model name (default varies by provider)")
   .option("--no-transcript", "Exclude transcript from analysis")
   .action(async (assetId: string, questionArgs: string[], options: {
-    provider?: string;
+    provider?: Provider;
     model?: string;
     transcript: boolean;
   }) => {

--- a/examples/burned-in-captions/basic-example.ts
+++ b/examples/burned-in-captions/basic-example.ts
@@ -4,7 +4,7 @@ import { hasBurnedInCaptions } from "@mux/ai/workflows";
 
 import "../env";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const program = new Command();
 
@@ -12,13 +12,13 @@ program
   .name("burned-in-captions")
   .description("Detect burned-in captions in a Mux video asset")
   .argument("<asset-id>", "Mux asset ID to analyze")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "openai")
   .action(async (assetId: string, options: {
     provider: Provider;
   }) => {
     // Validate provider
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/chapters/basic-example.ts
+++ b/examples/chapters/basic-example.ts
@@ -5,7 +5,7 @@ import { generateChapters } from "@mux/ai/workflows";
 
 import "../env";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const program = new Command();
 
@@ -14,7 +14,7 @@ program
   .description("Generate chapters for a Mux video asset")
   .argument("<asset-id>", "Mux asset ID to analyze")
   .option("-l, --language <code>", "Language code for transcription", "en")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "openai")
   .option("--output-language <code>", "Output language as BCP 47 code (e.g. 'fr', 'ja') or 'auto'")
   .action(async (assetId: string, options: {
     language: string;
@@ -22,8 +22,8 @@ program
     outputLanguage?: string;
   }) => {
     // Validate provider
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/edit-captions/basic-example.ts
+++ b/examples/edit-captions/basic-example.ts
@@ -5,10 +5,11 @@ import { editCaptions } from "@mux/ai/workflows";
 
 import "../env";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
@@ -22,7 +23,7 @@ program
   .description("Edit captions for a Mux video asset: censor profanity and/or apply static replacements")
   .argument("<asset-id>", "Mux asset ID")
   .argument("<track-id>", "Caption track ID to edit")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "anthropic")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "anthropic")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("--mode <mode>", "Censor mode: blank ([____]), remove, or mask (????)", "blank")
   .option("--always-censor <words>", "Comma-separated words to always censor", "")
@@ -42,8 +43,8 @@ program
     upload: boolean;
     delete: boolean;
   }) => {
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/embeddings/basic-example.ts
+++ b/examples/embeddings/basic-example.ts
@@ -5,7 +5,7 @@ import { generateEmbeddings } from "@mux/ai/workflows";
 
 import "../env";
 
-type Provider = "openai" | "google";
+type Provider = "openai" | "baseten" | "google";
 type Strategy = "token" | "vtt";
 
 const program = new Command();
@@ -15,7 +15,7 @@ program
   .description("Generate embeddings for a Mux asset transcript")
   .argument("<asset-id>", "Mux asset ID to analyze")
   .option("-l, --language <code>", "Language code for transcription", "en")
-  .option("-p, --provider <provider>", "AI provider (openai, google)", "openai")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, google)", "openai")
   .option("-s, --strategy <type>", "Chunking strategy (token, vtt)", "token")
   .option("-t, --max-tokens <number>", "Maximum tokens per chunk", "500")
   .option("-o, --overlap <number>", "Overlap between chunks (tokens for token, cues for vtt)", "100")
@@ -27,8 +27,8 @@ program
     strategy: string;
   }) => {
     // Validate provider
-    if (!["openai", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, google");
+    if (!["openai", "baseten", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, google");
       process.exit(1);
     }
 

--- a/examples/signed-playback/signed-summarization.ts
+++ b/examples/signed-playback/signed-summarization.ts
@@ -11,10 +11,11 @@ import { Command } from "commander";
 import type { ToneType } from "@mux/ai";
 import { getSummaryAndTags } from "@mux/ai/workflows";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
@@ -25,7 +26,7 @@ program
   .name("signed-summarization")
   .description("Generate summary and tags for a Mux asset with signed playback policy")
   .argument("<asset-id>", "Mux asset ID with signed playback policy")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "anthropic")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "anthropic")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("-t, --tone <tone>", "Tone for summary (neutral, playful, professional)", "professional")
   .option("--no-transcript", "Exclude transcript from analysis")
@@ -48,8 +49,8 @@ Notes:
     transcript: boolean;
   }) => {
     // Validate provider
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/summarization/audio-only-example.ts
+++ b/examples/summarization/audio-only-example.ts
@@ -5,10 +5,11 @@ import { getSummaryAndTags } from "@mux/ai/workflows";
 
 import env from "../env";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
@@ -22,7 +23,7 @@ program
     "[asset-id]",
     "Mux asset ID to analyze (defaults to MUX_TEST_ASSET_ID_AUDIO_ONLY)",
   )
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "openai")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("-t, --tone <tone>", "Tone for summary (neutral, playful, professional)", "neutral")
   .action(async (assetId: string | undefined, options: {
@@ -39,8 +40,8 @@ program
       process.exit(1);
     }
 
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/summarization/basic-example.ts
+++ b/examples/summarization/basic-example.ts
@@ -3,10 +3,11 @@ import { Command } from "commander";
 import type { ToneType } from "@mux/ai";
 import { getSummaryAndTags } from "@mux/ai/workflows";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
@@ -17,7 +18,7 @@ program
   .name("summarization")
   .description("Generate summary and tags for a Mux video asset")
   .argument("<asset-id>", "Mux asset ID to analyze")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "openai")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("-t, --tone <tone>", "Tone for summary (neutral, playful, professional)", "neutral")
   .option("--no-transcript", "Exclude transcript from analysis")
@@ -36,8 +37,8 @@ program
     outputLanguage?: string;
   }) => {
     // Validate provider
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/summarization/custom-prompt-example.ts
+++ b/examples/summarization/custom-prompt-example.ts
@@ -29,11 +29,12 @@ import type { ToneType } from "@mux/ai";
 import type { SummarizationPromptOverrides } from "@mux/ai/workflows";
 import { getSummaryAndTags } from "@mux/ai/workflows";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 type Preset = "seo" | "social" | "technical" | "ecommerce";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
@@ -158,7 +159,7 @@ program
   .option("--title-guidance <text>", "Override title generation guidance")
   .option("--description-guidance <text>", "Override description generation guidance")
   .option("--keywords-guidance <text>", "Override keywords generation guidance")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "openai")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("-t, --tone <tone>", "Tone for summary (neutral, playful, professional)", "professional")
   .option("--no-transcript", "Exclude transcript from analysis")
@@ -174,8 +175,8 @@ program
     transcript: boolean;
   }) => {
     // Validate provider
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/summarization/tone-variations.ts
+++ b/examples/summarization/tone-variations.ts
@@ -5,10 +5,11 @@ import { getSummaryAndTags } from "@mux/ai/workflows";
 
 import "../env";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
@@ -19,7 +20,7 @@ program
   .name("tone-variations")
   .description("Demonstrate summary generation with different tone variations")
   .argument("<asset-id>", "Mux asset ID to analyze")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "openai")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "openai")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("--no-transcript", "Exclude transcript from analysis")
   .action(async (assetId: string, options: {
@@ -28,8 +29,8 @@ program
     transcript: boolean;
   }) => {
     // Validate provider
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/translate-captions/aws-sdk-storage-adapter-example.ts
+++ b/examples/translate-captions/aws-sdk-storage-adapter-example.ts
@@ -7,10 +7,11 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 import "../env";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
@@ -72,7 +73,7 @@ program
   .argument("<asset-id>", "Mux asset ID to translate")
   .requiredOption("--track <trackId>", "Source text track ID")
   .option("-t, --to <language>", "Target language code", "es")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "anthropic")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "anthropic")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("--s3-endpoint <url>", "S3 endpoint override", process.env.S3_ENDPOINT ?? "https://s3.amazonaws.com")
   .option("--s3-region <region>", "S3 region", process.env.S3_REGION ?? "us-east-1")
@@ -86,8 +87,8 @@ program
     s3Region: string;
     s3Bucket?: string;
   }) => {
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("❌ Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("❌ Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/examples/translate-captions/basic-example.ts
+++ b/examples/translate-captions/basic-example.ts
@@ -4,10 +4,11 @@ import { translateCaptions } from "@mux/ai/workflows";
 
 import "../env";
 
-type Provider = "openai" | "anthropic" | "google";
+type Provider = "openai" | "baseten" | "anthropic" | "google";
 
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
+  baseten: process.env.BASETEN_MODEL || "your-baseten-model",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
@@ -20,7 +21,7 @@ program
   .argument("<asset-id>", "Mux asset ID to translate")
   .requiredOption("--track <trackId>", "Source text track ID")
   .option("-t, --to <language>", "Target language code", "es")
-  .option("-p, --provider <provider>", "AI provider (openai, anthropic, google)", "anthropic")
+  .option("-p, --provider <provider>", "AI provider (openai, baseten, anthropic, google)", "anthropic")
   .option("-m, --model <model>", "Model name (overrides default for provider)")
   .option("--no-upload", "Skip uploading translated captions to Mux (returns presigned URL only)")
   .action(async (assetId: string, options: {
@@ -31,8 +32,8 @@ program
     upload: boolean;
   }) => {
     // Validate provider
-    if (!["openai", "anthropic", "google"].includes(options.provider)) {
-      console.error("Unsupported provider. Choose from: openai, anthropic, google");
+    if (!["openai", "baseten", "anthropic", "google"].includes(options.provider)) {
+      console.error("Unsupported provider. Choose from: openai, baseten, anthropic, google");
       process.exit(1);
     }
 

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 
 import env from "../src/env";
 import { getAssetDurationSeconds } from "../src/lib/mux-assets";
-import { DEFAULT_LANGUAGE_MODELS } from "../src/lib/providers";
+import { DEFAULT_LANGUAGE_MODELS, getDefaultLanguageModel } from "../src/lib/providers";
 import type { SupportedProvider } from "../src/lib/providers";
 
 import type { LanguageModel } from "ai";
@@ -894,13 +894,15 @@ function resolveInsightsModel(options: GenerateInsightsOptions = {}): ResolvedMo
 
   // If a specific provider is requested, use it (will fail if credentials missing)
   if (preferredProvider) {
-    const modelId = preferredModel ?? DEFAULT_LANGUAGE_MODELS[preferredProvider];
+    const modelId = preferredModel ?? getDefaultLanguageModel(preferredProvider);
     switch (preferredProvider) {
       case "openai":
         if (!env.OPENAI_API_KEY) {
           throw new Error("OPENAI_API_KEY is required when using --provider openai");
         }
         return { model: openai(modelId), provider: "openai", modelId };
+      case "baseten":
+        throw new Error("Baseten is not yet supported for Evalite insights generation.");
       case "anthropic":
         if (!env.ANTHROPIC_API_KEY) {
           throw new Error("ANTHROPIC_API_KEY is required when using --provider anthropic");

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -894,6 +894,10 @@ function resolveInsightsModel(options: GenerateInsightsOptions = {}): ResolvedMo
 
   // If a specific provider is requested, use it (will fail if credentials missing)
   if (preferredProvider) {
+    if (preferredProvider === "baseten") {
+      throw new Error("Baseten is not yet supported for Evalite insights generation.");
+    }
+
     const modelId = preferredModel ?? getDefaultLanguageModel(preferredProvider);
     switch (preferredProvider) {
       case "openai":
@@ -901,8 +905,6 @@ function resolveInsightsModel(options: GenerateInsightsOptions = {}): ResolvedMo
           throw new Error("OPENAI_API_KEY is required when using --provider openai");
         }
         return { model: openai(modelId), provider: "openai", modelId };
-      case "baseten":
-        throw new Error("Baseten is not yet supported for Evalite insights generation.");
       case "anthropic":
         if (!env.ANTHROPIC_API_KEY) {
           throw new Error("ANTHROPIC_API_KEY is required when using --provider anthropic");

--- a/src/env.ts
+++ b/src/env.ts
@@ -69,6 +69,23 @@ const EnvSchema = z.object({
 
   // AI Providers
   OPENAI_API_KEY: optionalString("OpenAI API key for OpenAI-backed workflows.", "OpenAI API key"),
+  BASETEN_API_KEY: optionalString("Baseten API key for Baseten-backed workflows.", "Baseten API key"),
+  BASETEN_BASE_URL: optionalString(
+    "Base URL for Baseten language-model deployments (expects an OpenAI-compatible endpoint root such as .../sync/v1).",
+    "Baseten base URL",
+  ),
+  BASETEN_EMBEDDING_BASE_URL: optionalString(
+    "Base URL for Baseten embedding deployments. Falls back to BASETEN_BASE_URL when omitted.",
+    "Baseten embedding base URL",
+  ),
+  BASETEN_MODEL: optionalString(
+    "Default Baseten language model identifier used when provider='baseten' and no explicit model is passed.",
+    "Baseten model",
+  ),
+  BASETEN_EMBEDDING_MODEL: optionalString(
+    "Default Baseten embedding model identifier used when provider='baseten' and no explicit model is passed.",
+    "Baseten embedding model",
+  ),
   ANTHROPIC_API_KEY: optionalString("Anthropic API key for Claude-backed workflows.", "Anthropic API key"),
   GOOGLE_GENERATIVE_AI_API_KEY: optionalString("Google Generative AI API key for Gemini-backed workflows.", "Google Generative AI API key"),
 

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -4,30 +4,34 @@ import { createOpenAI } from "@ai-sdk/openai";
 
 import type { Env } from "@mux/ai/env";
 import env from "@mux/ai/env";
-import { resolveProviderApiKey } from "@mux/ai/lib/workflow-credentials";
+import { resolveProviderApiKey, resolveWorkflowCredentials } from "@mux/ai/lib/workflow-credentials";
 import type { MuxAIOptions, WorkflowCredentialsInput } from "@mux/ai/types";
 
 import type { EmbeddingModel, LanguageModel } from "ai";
 
-export type SupportedProvider = "openai" | "anthropic" | "google";
-export type SupportedEmbeddingProvider = "openai" | "google";
+export type SupportedProvider = "openai" | "baseten" | "anthropic" | "google";
+export type SupportedEmbeddingProvider = "openai" | "baseten" | "google";
 
 // Model ID unions inferred from ai-sdk provider call signatures
 type OpenAIModelId = Parameters<ReturnType<typeof createOpenAI>["chat"]>[0];
+type BasetenModelId = string;
 type AnthropicModelId = Parameters<ReturnType<typeof createAnthropic>["chat"]>[0];
 type GoogleModelId = Parameters<ReturnType<typeof createGoogleGenerativeAI>["chat"]>[0];
 
 type OpenAIEmbeddingModelId = Parameters<ReturnType<typeof createOpenAI>["embedding"]>[0];
+type BasetenEmbeddingModelId = string;
 type GoogleEmbeddingModelId = Parameters<ReturnType<typeof createGoogleGenerativeAI>["textEmbeddingModel"]>[0];
 
 export interface ModelIdByProvider {
   openai: OpenAIModelId;
+  baseten: BasetenModelId;
   anthropic: AnthropicModelId;
   google: GoogleModelId;
 }
 
 export interface EmbeddingModelIdByProvider {
   openai: OpenAIEmbeddingModelId;
+  baseten: BasetenEmbeddingModelId;
   google: GoogleEmbeddingModelId;
 }
 
@@ -42,23 +46,69 @@ export interface ResolvedModel<P extends SupportedProvider = SupportedProvider> 
   model: LanguageModel;
 }
 
-export const DEFAULT_LANGUAGE_MODELS: { [K in SupportedProvider]: ModelIdByProvider[K] } = {
+export const DEFAULT_LANGUAGE_MODELS: {
+  [K in Exclude<SupportedProvider, "baseten">]: ModelIdByProvider[K];
+} = {
   openai: "gpt-5.1",
   anthropic: "claude-sonnet-4-5",
   google: "gemini-3-flash-preview",
 };
 
-const DEFAULT_EMBEDDING_MODELS: { [K in SupportedEmbeddingProvider]: EmbeddingModelIdByProvider[K] } = {
+const DEFAULT_EMBEDDING_MODELS: {
+  [K in Exclude<SupportedEmbeddingProvider, "baseten">]: EmbeddingModelIdByProvider[K];
+} = {
   openai: "text-embedding-3-small",
   google: "gemini-embedding-001",
 };
+
+function resolveBasetenLanguageModelId(model?: string): BasetenModelId {
+  const resolved = model ?? env.BASETEN_MODEL;
+  if (!resolved) {
+    throw new Error(
+      "Baseten model is required. Pass `model` when provider is \"baseten\" or set BASETEN_MODEL.",
+    );
+  }
+  return resolved;
+}
+
+function resolveBasetenEmbeddingModelId(model?: string): BasetenEmbeddingModelId {
+  const resolved = model ?? env.BASETEN_EMBEDDING_MODEL ?? env.BASETEN_MODEL;
+  if (!resolved) {
+    throw new Error(
+      "Baseten embedding model is required. Pass `model` when provider is \"baseten\" or set BASETEN_EMBEDDING_MODEL.",
+    );
+  }
+  return resolved;
+}
+
+export function getDefaultLanguageModel<P extends SupportedProvider = SupportedProvider>(
+  provider: P,
+): ModelIdByProvider[P] {
+  if (provider === "baseten") {
+    return resolveBasetenLanguageModelId() as ModelIdByProvider[P];
+  }
+
+  return DEFAULT_LANGUAGE_MODELS[provider as Exclude<SupportedProvider, "baseten">] as ModelIdByProvider[P];
+}
+
+export function getDefaultEmbeddingModel<P extends SupportedEmbeddingProvider = SupportedEmbeddingProvider>(
+  provider: P,
+): EmbeddingModelIdByProvider[P] {
+  if (provider === "baseten") {
+    return resolveBasetenEmbeddingModelId() as EmbeddingModelIdByProvider[P];
+  }
+
+  return DEFAULT_EMBEDDING_MODELS[provider as Exclude<SupportedEmbeddingProvider, "baseten">] as EmbeddingModelIdByProvider[P];
+}
 
 /**
  * All language models available per provider.
  * Includes the default model plus any additional models for evaluation and selection.
  * New models are additive — existing defaults are unchanged.
  */
-export const LANGUAGE_MODELS: { [K in SupportedProvider]: ModelIdByProvider[K][] } = {
+export const LANGUAGE_MODELS: {
+  [K in Exclude<SupportedProvider, "baseten">]: ModelIdByProvider[K][];
+} = {
   openai: ["gpt-5.1", "gpt-5-mini"],
   anthropic: ["claude-sonnet-4-5"],
   google: ["gemini-3-flash-preview", "gemini-3.1-flash-lite-preview", "gemini-2.5-flash"],
@@ -151,8 +201,8 @@ export function resetLanguageModelDeprecationWarningsForTests(): void {
  * A (provider, modelId) pair used for evaluation iteration.
  */
 export interface EvalModelConfig {
-  provider: SupportedProvider;
-  modelId: ModelIdByProvider[SupportedProvider];
+  provider: Exclude<SupportedProvider, "baseten">;
+  modelId: ModelIdByProvider[Exclude<SupportedProvider, "baseten">];
 }
 
 export type EvalModelSelection = "default" | "all";
@@ -163,16 +213,22 @@ export interface ResolveEvalModelConfigsOptions {
 }
 
 function getDefaultEvalModelConfigs(): EvalModelConfig[] {
-  return (Object.entries(DEFAULT_LANGUAGE_MODELS) as [SupportedProvider, ModelIdByProvider[SupportedProvider]][])
+  return (Object.entries(DEFAULT_LANGUAGE_MODELS) as [
+    Exclude<SupportedProvider, "baseten">,
+    ModelIdByProvider[Exclude<SupportedProvider, "baseten">],
+  ][])
     .map(([provider, modelId]) => ({ provider, modelId }));
 }
 
 function getAllEvalModelConfigs(): EvalModelConfig[] {
-  return (Object.entries(LANGUAGE_MODELS) as [SupportedProvider, ModelIdByProvider[SupportedProvider][]][])
+  return (Object.entries(LANGUAGE_MODELS) as [
+    Exclude<SupportedProvider, "baseten">,
+    ModelIdByProvider[Exclude<SupportedProvider, "baseten">][],
+  ][])
     .flatMap(([provider, models]) => models.map(modelId => ({ provider, modelId })));
 }
 
-function isSupportedProvider(value: string): value is SupportedProvider {
+function isSupportedProvider(value: string): value is Exclude<SupportedProvider, "baseten"> {
   return value === "openai" || value === "anthropic" || value === "google";
 }
 
@@ -205,7 +261,7 @@ function parseEvalModelPair(value: string): EvalModelConfig {
 
   return {
     provider,
-    modelId: modelId as ModelIdByProvider[SupportedProvider],
+    modelId: modelId as ModelIdByProvider[Exclude<SupportedProvider, "baseten">],
   };
 }
 
@@ -274,7 +330,7 @@ export function resolveLanguageModelConfig<P extends SupportedProvider = Support
   options: ModelRequestOptions<P> = {},
 ): { provider: P; modelId: ModelIdByProvider[P] } {
   const provider = options.provider || ("openai" as P);
-  const modelId = (options.model || DEFAULT_LANGUAGE_MODELS[provider]) as ModelIdByProvider[P];
+  const modelId = (options.model ?? getDefaultLanguageModel(provider)) as ModelIdByProvider[P];
   maybeWarnOrThrowForDeprecatedLanguageModel(provider, modelId);
 
   return { provider, modelId };
@@ -284,7 +340,7 @@ export function resolveEmbeddingModelConfig<P extends SupportedEmbeddingProvider
   options: MuxAIOptions & { provider?: P; model?: EmbeddingModelIdByProvider[P] } = {},
 ): { provider: P; modelId: EmbeddingModelIdByProvider[P] } {
   const provider = options.provider || ("openai" as P);
-  const modelId = (options.model || DEFAULT_EMBEDDING_MODELS[provider]) as EmbeddingModelIdByProvider[P];
+  const modelId = (options.model ?? getDefaultEmbeddingModel(provider)) as EmbeddingModelIdByProvider[P];
 
   return { provider, modelId };
 }
@@ -432,6 +488,10 @@ export function calculateCost(
   outputTokens: number,
   cachedInputTokens: number = 0,
 ): number {
+  if (provider === "baseten") {
+    return 0;
+  }
+
   const defaultModelId = DEFAULT_LANGUAGE_MODELS[provider];
   return calculateModelCost(defaultModelId, inputTokens, outputTokens, cachedInputTokens);
 }
@@ -441,6 +501,56 @@ function requireEnv(value: string | undefined, name: string): string {
     throw new Error(`Missing ${name}. Set ${name} in your environment or pass it in options.`);
   }
   return value;
+}
+
+function normalizeOpenAICompatibleBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  return trimmed
+    .replace(/\/(chat\/completions|responses|embeddings)\/?$/, "")
+    .replace(/\/$/, "");
+}
+
+async function resolveBasetenBaseUrl(
+  credentials?: WorkflowCredentialsInput,
+  kind: "language" | "embedding" = "language",
+): Promise<string> {
+  const resolved = await resolveWorkflowCredentials(credentials);
+  const record = resolved as Record<string, unknown>;
+  const basetenBaseUrl = typeof record.basetenBaseUrl === "string" ? record.basetenBaseUrl : undefined;
+  const basetenEmbeddingBaseUrl = typeof record.basetenEmbeddingBaseUrl === "string" ? record.basetenEmbeddingBaseUrl : undefined;
+  const candidates = kind === "embedding" ?
+      [basetenEmbeddingBaseUrl, env.BASETEN_EMBEDDING_BASE_URL, basetenBaseUrl, env.BASETEN_BASE_URL] :
+      [basetenBaseUrl, env.BASETEN_BASE_URL];
+  const normalized = normalizeOpenAICompatibleBaseUrl(candidates.find(Boolean) ?? "");
+
+  if (!normalized) {
+    const envVar = kind === "embedding" ? "BASETEN_EMBEDDING_BASE_URL" : "BASETEN_BASE_URL";
+    throw new Error(
+      `Baseten ${kind} base URL is required. Set ${envVar}${kind === "embedding" ? " (or BASETEN_BASE_URL)" : ""} or provide ${kind === "embedding" ? "basetenEmbeddingBaseUrl" : "basetenBaseUrl"} in credentials.`,
+    );
+  }
+
+  return normalized;
+}
+
+function resolveBasetenBaseUrlFromEnv(kind: "language" | "embedding" = "language"): string {
+  const candidates = kind === "embedding" ?
+      [env.BASETEN_EMBEDDING_BASE_URL, env.BASETEN_BASE_URL] :
+      [env.BASETEN_BASE_URL];
+  const normalized = normalizeOpenAICompatibleBaseUrl(candidates.find(Boolean) ?? "");
+
+  if (!normalized) {
+    const envVar = kind === "embedding" ? "BASETEN_EMBEDDING_BASE_URL" : "BASETEN_BASE_URL";
+    throw new Error(
+      `Baseten ${kind} base URL is required. Set ${envVar}${kind === "embedding" ? " (or BASETEN_BASE_URL)" : ""}.`,
+    );
+  }
+
+  return normalized;
 }
 
 /**
@@ -460,6 +570,12 @@ export async function createLanguageModelFromConfig<P extends SupportedProvider 
       const apiKey = await resolveProviderApiKey("openai", credentials);
       const openai = createOpenAI({ apiKey });
       return openai(modelId);
+    }
+    case "baseten": {
+      const apiKey = await resolveProviderApiKey("baseten", credentials);
+      const baseURL = await resolveBasetenBaseUrl(credentials, "language");
+      const baseten = createOpenAI({ apiKey, baseURL });
+      return baseten.chat(modelId);
     }
     case "anthropic": {
       const apiKey = await resolveProviderApiKey("anthropic", credentials);
@@ -496,6 +612,12 @@ export async function createEmbeddingModelFromConfig<
       const openai = createOpenAI({ apiKey });
       return openai.embedding(modelId);
     }
+    case "baseten": {
+      const apiKey = await resolveProviderApiKey("baseten", credentials);
+      const baseURL = await resolveBasetenBaseUrl(credentials, "embedding");
+      const baseten = createOpenAI({ apiKey, baseURL });
+      return baseten.embedding(modelId);
+    }
     case "google": {
       const apiKey = await resolveProviderApiKey("google", credentials);
       const google = createGoogleGenerativeAI({ apiKey });
@@ -514,9 +636,7 @@ export async function createEmbeddingModelFromConfig<
 export function resolveLanguageModel<P extends SupportedProvider = SupportedProvider>(
   options: ModelRequestOptions<P> = {},
 ): ResolvedModel<P> {
-  const provider = options.provider || ("openai" as P);
-  const modelId = (options.model || DEFAULT_LANGUAGE_MODELS[provider]) as ModelIdByProvider[P];
-  maybeWarnOrThrowForDeprecatedLanguageModel(provider, modelId);
+  const { provider, modelId } = resolveLanguageModelConfig(options);
 
   switch (provider) {
     case "openai": {
@@ -530,6 +650,21 @@ export function resolveLanguageModel<P extends SupportedProvider = SupportedProv
         provider,
         modelId,
         model: openai(modelId),
+      };
+    }
+    case "baseten": {
+      const apiKey = env.BASETEN_API_KEY;
+      requireEnv(apiKey, "BASETEN_API_KEY");
+      const baseURL = resolveBasetenBaseUrlFromEnv("language");
+      const baseten = createOpenAI({
+        apiKey,
+        baseURL,
+      });
+
+      return {
+        provider,
+        modelId,
+        model: baseten.chat(modelId),
       };
     }
     case "anthropic": {
@@ -571,8 +706,7 @@ export function resolveLanguageModel<P extends SupportedProvider = SupportedProv
 export function resolveEmbeddingModel<P extends SupportedEmbeddingProvider = "openai">(
   options: MuxAIOptions & { provider?: P; model?: EmbeddingModelIdByProvider[P] } = {},
 ): { provider: P; modelId: EmbeddingModelIdByProvider[P]; model: EmbeddingModel } {
-  const provider = options.provider || ("openai" as P);
-  const modelId = (options.model || DEFAULT_EMBEDDING_MODELS[provider]) as EmbeddingModelIdByProvider[P];
+  const { provider, modelId } = resolveEmbeddingModelConfig(options);
 
   switch (provider) {
     case "openai": {
@@ -586,6 +720,21 @@ export function resolveEmbeddingModel<P extends SupportedEmbeddingProvider = "op
         provider,
         modelId,
         model: openai.embedding(modelId),
+      };
+    }
+    case "baseten": {
+      const apiKey = env.BASETEN_API_KEY;
+      requireEnv(apiKey, "BASETEN_API_KEY");
+      const baseURL = resolveBasetenBaseUrlFromEnv("embedding");
+      const baseten = createOpenAI({
+        apiKey,
+        baseURL,
+      });
+
+      return {
+        provider,
+        modelId,
+        model: baseten.embedding(modelId),
       };
     }
     case "google": {

--- a/src/lib/workflow-credentials.ts
+++ b/src/lib/workflow-credentials.ts
@@ -241,7 +241,7 @@ export async function resolveMuxClient(
 }
 
 /** Supported AI/ML provider identifiers for API key resolution. */
-export type ApiKeyProvider = "openai" | "anthropic" | "google" | "hive" | "elevenlabs";
+export type ApiKeyProvider = "openai" | "baseten" | "anthropic" | "google" | "hive" | "elevenlabs";
 
 function resolveProviderApiKeyFromCredentials(
   provider: ApiKeyProvider,
@@ -249,6 +249,7 @@ function resolveProviderApiKeyFromCredentials(
 ): string {
   const record = resolved as Record<string, unknown>;
   const openaiApiKey = readString(record, "openaiApiKey");
+  const basetenApiKey = readString(record, "basetenApiKey");
   const anthropicApiKey = readString(record, "anthropicApiKey");
   const googleApiKey = readString(record, "googleApiKey");
   const hiveApiKey = readString(record, "hiveApiKey");
@@ -257,6 +258,7 @@ function resolveProviderApiKeyFromCredentials(
   // Map each provider to its credential source and env var fallback
   const apiKeyMap: Record<ApiKeyProvider, string | undefined> = {
     openai: openaiApiKey ?? env.OPENAI_API_KEY,
+    baseten: basetenApiKey ?? env.BASETEN_API_KEY,
     anthropic: anthropicApiKey ?? env.ANTHROPIC_API_KEY,
     google: googleApiKey ?? env.GOOGLE_GENERATIVE_AI_API_KEY,
     hive: hiveApiKey ?? env.HIVE_API_KEY,
@@ -269,6 +271,7 @@ function resolveProviderApiKeyFromCredentials(
     // Using `satisfies` ensures these stay in sync with the Env schema.
     const envVarNames = {
       openai: "OPENAI_API_KEY",
+      baseten: "BASETEN_API_KEY",
       anthropic: "ANTHROPIC_API_KEY",
       google: "GOOGLE_GENERATIVE_AI_API_KEY",
       hive: "HIVE_API_KEY",

--- a/src/primitives/heatmap.ts
+++ b/src/primitives/heatmap.ts
@@ -122,7 +122,7 @@ async function fetchHeatmap(
 
   // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
   const path = `/data/v1/engagement/${identifierType}/${id}/heatmap?${queryParams.toString()}`;
-  const response = await mux.get<HeatmapApiResponse>(path);
+  const response = await mux.get(path) as HeatmapApiResponse;
 
   return transformHeatmapResponse(response);
 }

--- a/src/primitives/hotspots.ts
+++ b/src/primitives/hotspots.ts
@@ -146,7 +146,7 @@ async function fetchHotspots(
 
   // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
   const path = `/data/v1/engagement/${identifierType}/${id}/hotspots?${queryParams.toString()}`;
-  const response = await mux.get<HotspotApiResponse>(path);
+  const response = await mux.get(path) as HotspotApiResponse;
 
   return transformHotspotResponse(response);
 }

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -184,10 +184,10 @@ export async function requestShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.post<ShotsApiResponse>(
+  const response = await mux.post(
     getShotsPath(assetId),
     { body: {} },
-  );
+  ) as ShotsApiResponse;
   const result = await transformShotsResponse(response);
 
   if (result.status !== "pending") {
@@ -214,9 +214,9 @@ export async function getShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.get<ShotsApiResponse>(
+  const response = await mux.get(
     getShotsPath(assetId),
-  );
+  ) as ShotsApiResponse;
 
   return await transformShotsResponse(response);
 }

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -73,6 +73,11 @@ export function findCaptionTrack(asset: MuxAsset, languageCode?: string): AssetT
  */
 export const LOW_CONFIDENCE_THRESHOLD = 0.5;
 
+function getAutoLanguageConfidence(track: AssetTextTrack): number | undefined {
+  const value = (track as AssetTextTrack & { auto_language_confidence?: unknown }).auto_language_confidence;
+  return typeof value === "number" ? value : undefined;
+}
+
 /**
  * Extracts a trustworthy language code from a track, returning `undefined`
  * when the language metadata shouldn't be used as an LLM output language.
@@ -97,8 +102,8 @@ export function getReliableLanguageCode(
     return undefined;
   if (isUndeterminedLanguageCode(track.language_code))
     return undefined;
-  if (track.auto_language_confidence !== undefined &&
-    track.auto_language_confidence < confidenceThreshold) {
+  const autoLanguageConfidence = getAutoLanguageConfidence(track);
+  if (autoLanguageConfidence !== undefined && autoLanguageConfidence < confidenceThreshold) {
     return undefined;
   }
   return track.language_code;

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,12 @@ export interface WorkflowCredentials {
   muxPrivateKey?: string;
   /** Optional direct OpenAI API key for per-request credential injection. */
   openaiApiKey?: string;
+  /** Optional direct Baseten API key for per-request credential injection. */
+  basetenApiKey?: string;
+  /** Optional direct Baseten base URL for language-model requests. */
+  basetenBaseUrl?: string;
+  /** Optional direct Baseten base URL for embedding requests. Falls back to `basetenBaseUrl`. */
+  basetenEmbeddingBaseUrl?: string;
   /** Optional direct Anthropic API key for per-request credential injection. */
   anthropicApiKey?: string;
   /** Optional direct Google API key for per-request credential injection. */

--- a/tests/unit/providers-baseten.test.ts
+++ b/tests/unit/providers-baseten.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createOpenAIMock = vi.fn((config: { apiKey: string; baseURL?: string }) => {
+  const callable = vi.fn((modelId: string) => ({
+    config,
+    kind: "language",
+    modelId,
+    transport: "responses",
+  }));
+  callable.chat = vi.fn((modelId: string) => ({
+    config,
+    kind: "language",
+    modelId,
+    transport: "chat",
+  }));
+  callable.embedding = vi.fn((modelId: string) => ({
+    config,
+    kind: "embedding",
+    modelId,
+  }));
+  return callable;
+});
+
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: createOpenAIMock,
+}));
+
+const resolveProviderApiKeyMock = vi.fn(async (
+  provider: string,
+  credentials?: Record<string, unknown>,
+) => {
+  if (provider === "baseten") {
+    const direct = typeof credentials?.basetenApiKey === "string" ? credentials.basetenApiKey : undefined;
+    const processLike = Reflect.get(globalThis, "process") as { env?: Record<string, string | undefined> } | undefined;
+    return direct ?? processLike?.env?.BASETEN_API_KEY ?? "";
+  }
+
+  throw new Error(`Unexpected provider in test mock: ${provider}`);
+});
+
+const resolveWorkflowCredentialsMock = vi.fn(async (credentials?: Record<string, unknown>) => credentials ?? {});
+
+vi.mock("@mux/ai/lib/workflow-credentials", () => ({
+  resolveProviderApiKey: resolveProviderApiKeyMock,
+  resolveWorkflowCredentials: resolveWorkflowCredentialsMock,
+}));
+
+function stubBaseEnv() {
+  vi.stubEnv("MUX_TOKEN_ID", "test-token-id");
+  vi.stubEnv("MUX_TOKEN_SECRET", "test-token-secret");
+  vi.stubEnv("BASETEN_API_KEY", "");
+  vi.stubEnv("BASETEN_BASE_URL", "");
+  vi.stubEnv("BASETEN_EMBEDDING_BASE_URL", "");
+  vi.stubEnv("BASETEN_MODEL", "");
+  vi.stubEnv("BASETEN_EMBEDDING_MODEL", "");
+}
+
+describe("baseten provider integration", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    createOpenAIMock.mockClear();
+    resolveProviderApiKeyMock.mockClear();
+    resolveWorkflowCredentialsMock.mockClear();
+    stubBaseEnv();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("resolves Baseten language model defaults from BASETEN_MODEL", async () => {
+    vi.stubEnv("BASETEN_MODEL", "mux-summarizer");
+
+    const { resolveLanguageModelConfig } = await import("../../src/lib/providers");
+
+    expect(resolveLanguageModelConfig({ provider: "baseten" })).toEqual({
+      provider: "baseten",
+      modelId: "mux-summarizer",
+    });
+  });
+
+  it("requires an explicit Baseten model when no default is configured", async () => {
+    const { resolveLanguageModelConfig } = await import("../../src/lib/providers");
+
+    expect(() => resolveLanguageModelConfig({ provider: "baseten" })).toThrow(
+      "Baseten model is required.",
+    );
+  });
+
+  it("normalizes Baseten chat endpoints for workflow language models", async () => {
+    const { createLanguageModelFromConfig } = await import("../../src/lib/providers");
+
+    const model = await createLanguageModelFromConfig(
+      "baseten",
+      "mux-summarizer",
+      {
+        basetenApiKey: "bt-key",
+        basetenBaseUrl: "https://model-123.api.baseten.co/environments/production/sync/v1/chat/completions",
+      },
+    );
+
+    expect(model).toMatchObject({ kind: "language", modelId: "mux-summarizer", transport: "chat" });
+    expect(createOpenAIMock).toHaveBeenCalledWith({
+      apiKey: "bt-key",
+      baseURL: "https://model-123.api.baseten.co/environments/production/sync/v1",
+    });
+    expect(createOpenAIMock.mock.results[0]?.value.chat).toHaveBeenCalledWith("mux-summarizer");
+  });
+
+  it("uses Baseten embedding-specific defaults and base URL fallback", async () => {
+    vi.stubEnv("BASETEN_API_KEY", "bt-key");
+    vi.stubEnv("BASETEN_BASE_URL", "https://model-456.api.baseten.co/environments/production/sync/v1");
+    vi.stubEnv("BASETEN_MODEL", "mux-shared-model");
+
+    const {
+      resolveEmbeddingModelConfig,
+      createEmbeddingModelFromConfig,
+    } = await import("../../src/lib/providers");
+
+    expect(resolveEmbeddingModelConfig({ provider: "baseten" })).toEqual({
+      provider: "baseten",
+      modelId: "mux-shared-model",
+    });
+
+    const model = await createEmbeddingModelFromConfig("baseten", "mux-shared-model");
+
+    expect(model).toMatchObject({ kind: "embedding", modelId: "mux-shared-model" });
+    expect(createOpenAIMock).toHaveBeenCalledWith({
+      apiKey: "bt-key",
+      baseURL: "https://model-456.api.baseten.co/environments/production/sync/v1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Baseten as an OpenAI-compatible language and embedding provider, including env/runtime credential support and base URL normalization
- reapply the provider work on top of the latest `main` changes and update docs/examples so Baseten support is reflected across the current codebase
- add Baseten coverage in unit tests and fix small upstream SDK typing mismatches so the rebased branch typechecks cleanly

## Testing
- npm run typecheck
- npm exec vitest run tests/unit/providers-baseten.test.ts tests/unit/language-codes.test.ts tests/unit/transcripts.test.ts tests/unit/shots.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new AI provider and updates core model/credential resolution paths, which can affect workflow execution and configuration. Most changes are additive with tests and documentation updates, but misconfiguration of Baseten base URLs/models could surface at runtime.
> 
> **Overview**
> Adds **Baseten** as a first-class `provider` option for language and embedding workflows, implemented as an OpenAI-compatible backend with required `BASETEN_*` env/runtime credentials and base-URL normalization.
> 
> Updates provider/model resolution utilities to support Baseten defaults (`BASETEN_MODEL` / `BASETEN_EMBEDDING_MODEL` with fallbacks), adds Baseten API key handling in workflow credentials/types, and explicitly excludes Baseten from Evalite insights generation for now.
> 
> Refreshes docs, env examples, and CLI examples to advertise/select `baseten`, and adds unit coverage for Baseten model/default/baseURL behavior; also tweaks a few Mux SDK calls and transcript language confidence parsing to keep typechecking clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58074d7c6c14569c1d3d2cea62d7622c1a0d0633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->