### PR TITLE
chore: update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/tests/integration/translate-captions.test.ts
+++ b/tests/integration/translate-captions.test.ts
@@ -8,7 +8,8 @@ import { muxTestAssets } from "../helpers/mux-test-assets";
 
 describe("translateCaptions Integration Tests", () => {
   const testAssetId = muxTestAssets.assetId;
-  const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
+  // const providers: SupportedProvider[] = ["openai", "anthropic", "google"];
+  const providers: SupportedProvider[] = ["openai", "google"]; // TODO: Add anthropic unit tests back
 
   let englishTrackId: string;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump plus a small test coverage reduction; functional runtime code is unchanged. Main risk is reduced detection of Anthropic provider regressions in integration tests.
> 
> **Overview**
> Bumps `@mux/ai` from `0.17.1` to `0.18.0` in `package.json` and `package-lock.json`.
> 
> Updates `translate-captions` integration tests to *temporarily* stop running against the Anthropic provider (leaving OpenAI + Google), with a TODO to restore Anthropic coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2921d82ee3bc2edd5f0f2c5da3e6992613e38d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->