### PR TITLE
feat: Add case sensitivty option in static replacements in `edit-captions`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -410,7 +410,7 @@ Edits a caption track using LLM-powered profanity censorship, static find/replac
     - `'mask'`: `shit` → `????` (question marks matching word length)
   - `alwaysCensor?: string[]` - Words to always censor regardless of LLM output
   - `neverCensor?: string[]` - Words to never censor even if the LLM flags them (takes precedence over `alwaysCensor`)
-- `replacements?: Array<{ find: string; replace: string }>` - Static find/replace pairs (optional, no LLM needed)
+- `replacements?: Array<{ find: string; replace: string; caseSensitive?: boolean }>` - Static find/replace pairs (optional, no LLM needed). Each entry matches case-sensitively by default; set `caseSensitive: false` to match regardless of case.
 - `uploadToMux?: boolean` - Whether to upload edited track to Mux (default: true)
 - `deleteOriginalTrack?: boolean` - Whether to delete the original track after uploading the edited one (default: true)
 - `s3Endpoint?: string` - S3-compatible storage endpoint

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -579,7 +579,16 @@ const result = await editCaptions(assetId, trackId, {
 });
 ```
 
-Replacements use word-boundary matching and are case-sensitive.
+Replacements use word-boundary matching and are case-sensitive by default. Set `caseSensitive: false` on an individual entry to match regardless of case:
+
+```typescript
+const result = await editCaptions(assetId, trackId, {
+  replacements: [
+    { find: "Mucks", replace: "Mux" }, // case-sensitive (default)
+    { find: "gonna", replace: "going to", caseSensitive: false }, // matches "Gonna", "GONNA", etc.
+  ],
+});
+```
 
 ### Application Order
 

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -51,6 +51,8 @@ export interface AutoCensorProfanityOptions {
 export interface CaptionReplacement {
   find: string;
   replace: string;
+  /** Match `find` with case-sensitivity. Defaults to `true`. */
+  caseSensitive?: boolean;
 }
 
 export interface ReplacementRecord {
@@ -307,9 +309,11 @@ export function applyOverrideLists(
 
 /**
  * Applies static find/replace pairs to cue text lines in raw VTT content
- * using word-boundary regex. Case-sensitive matching since static replacements
- * target specific known strings. Headers, timestamps, and cue identifiers are
- * untouched. Returns the edited VTT and the total number of replacements.
+ * using word-boundary regex. Defaults to case-sensitive matching since static
+ * replacements typically target specific known strings; each entry may opt
+ * into case-insensitive matching via `caseSensitive: false`. Headers,
+ * timestamps, and cue identifiers are untouched. Returns the edited VTT and
+ * the total number of replacements.
  */
 export function applyReplacements(
   rawVtt: string,
@@ -324,9 +328,10 @@ export function applyReplacements(
 
   const editedVtt = transformCueText(rawVtt, (line, cueStartTime) => {
     let result = line;
-    for (const { find, replace } of filtered) {
+    for (const { find, replace, caseSensitive } of filtered) {
       const escaped = find.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const regex = new RegExp(`\\b${escaped}\\b`, "g");
+      const flags = caseSensitive === false ? "gi" : "g";
+      const regex = new RegExp(`\\b${escaped}\\b`, flags);
       result = result.replace(regex, (match) => {
         records.push({ cueStartTime, before: match, after: replace });
         return replace;

--- a/tests/unit/edit-captions.test.ts
+++ b/tests/unit/edit-captions.test.ts
@@ -418,6 +418,54 @@ describe("applyReplacements", () => {
     expect(replacements).toHaveLength(0);
   });
 
+  it("is case-sensitive when caseSensitive is explicitly true", () => {
+    const { editedVtt, replacements } = applyReplacements(sampleVtt, [
+      { find: "mucks", replace: "Mux", caseSensitive: true },
+    ]);
+    expect(editedVtt).toContain("Mucks");
+    expect(replacements).toHaveLength(0);
+  });
+
+  it("matches case-insensitively when caseSensitive is false", () => {
+    const { editedVtt, replacements } = applyReplacements(sampleVtt, [
+      { find: "mucks", replace: "Mux", caseSensitive: false },
+    ]);
+    expect(editedVtt).toContain("Welcome to Mux streaming platform.");
+    expect(editedVtt).not.toContain("Mucks");
+    expect(replacements).toHaveLength(1);
+    expect(replacements[0].before).toBe("Mucks");
+    expect(replacements[0].after).toBe("Mux");
+  });
+
+  it("caseSensitive: false matches all case variants of the same word", () => {
+    const vtt = [
+      "WEBVTT",
+      "",
+      "00:00:01.000 --> 00:00:04.000",
+      "MUCKS Mucks mucks MuCkS!",
+    ].join("\n");
+    const { editedVtt, replacements } = applyReplacements(vtt, [
+      { find: "mucks", replace: "Mux", caseSensitive: false },
+    ]);
+    expect(editedVtt).toContain("Mux Mux Mux Mux!");
+    expect(replacements).toHaveLength(4);
+  });
+
+  it("applies caseSensitive per-entry independently", () => {
+    const vtt = [
+      "WEBVTT",
+      "",
+      "00:00:01.000 --> 00:00:04.000",
+      "Welcome to Mucks and mucks. We're Gonna go.",
+    ].join("\n");
+    const { editedVtt, replacements } = applyReplacements(vtt, [
+      { find: "Mucks", replace: "Mux" },
+      { find: "gonna", replace: "going to", caseSensitive: false },
+    ]);
+    expect(editedVtt).toContain("Welcome to Mux and mucks. We're going to go.");
+    expect(replacements).toHaveLength(2);
+  });
+
   it("respects word boundaries", () => {
     const vtt = [
       "WEBVTT",


### PR DESCRIPTION
## Summary

Adds an optional per-entry `caseSensitive` flag to the `replacements` array in `editCaptions`. Defaults to `true`, preserving current behaviour; set to `false` to match regardless of case.

The existing case-sensitive default made sense for specific brand-name corrections (`"Mucks" → "Mux"`), but was clumsy for anything where the caption source varies in case — e.g. a filler like `gonna` that might appear as `Gonna` at the start of a cue.

## Example

```typescript
const result = await editCaptions(assetId, trackId, {
  replacements: [
    { find: "Mucks", replace: "Mux" }, // case-sensitive (default)
    { find: "gonna", replace: "going to", caseSensitive: false }, // matches "Gonna", "GONNA", etc.
  ],
});
```

Auto-censor profanity behaviour and override lists are untouched — those remain case-insensitive as before.

## Suggested review order

1. `src/workflows/edit-captions.ts` — type field + the `gi` vs `g` branch in `applyReplacements`
2. `tests/unit/edit-captions.test.ts` — four new cases covering default, explicit true/false, all-case variants, and per-entry mixing
3. `docs/API.md` and `docs/WORKFLOWS.md` — updated option docs

Note: the CLI (`examples/edit-captions/basic-example.ts`) is intentionally not extended — the `find:replace` DSL stays simple; programmatic API only.