### PR TITLE
fix!: Bubble up track manipulation failures

### DIFF
--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -681,7 +681,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
           credentials,
         );
       } catch (error) {
-        console.warn(`Failed to add track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+        wrapError(error, "Failed to add edited track to Mux asset");
       }
 
       // Delete original track only if the replacement track was created
@@ -689,7 +689,7 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
         try {
           await deleteTrackOnMux(assetId, trackId, credentials);
         } catch (error) {
-          console.warn(`Failed to delete original track: ${error instanceof Error ? error.message : "Unknown error"}`);
+          wrapError(error, "Failed to delete original track");
         }
       }
     }


### PR DESCRIPTION
## Summary

`editCaptions` previously caught failures from `createTextTrackOnMux` and `deleteTrackOnMux` and logged a `console.warn`, then resolved successfully. Callers had no programmatic signal that anything went wrong — they had to scan stderr, or infer from `result.uploadedTrackId === undefined`.

This switches both catches to `wrapError`, matching the pattern already used for the S3 upload (`edit-captions.ts:661`), the VTT fetch (`:558`), and the profanity-detection step (`:604`). Errors now propagate with safety-scrubbed context instead of being swallowed.

## Behavioural change

This is **breaking** for callers that relied on the silent-success behaviour:

- **Track create fails** (e.g. duplicate-track 4xx from the Mux API): the workflow now rejects. The original track is untouched, and the edited VTT is still in S3 — `presignedUrl` was returned to the caller from the prior step. Previously: returned a result with `uploadedTrackId: undefined`.
- **Track delete fails**: the workflow now rejects after the new track has already been created on Mux. The asset ends up with both tracks attached; the caller doesn't get the result back, but can re-fetch the asset to find the new track. Previously: returned a result with `uploadedTrackId` set, original silently retained.

## Suggested review order

1. `src/workflows/edit-captions.ts:683` and `:691` — the two `wrapError` swaps
2. The asymmetry on the delete path is worth a sanity check — open to attaching `uploadedTrackId` to the thrown error if losing it from the result is an issue in practice. Left as plain `wrapError` for now.

No tests added — neither path has existing test coverage and neither workflow tests the failure modes of the Mux/S3 step calls (would need step-function mocking, no precedent in the repo). No doc updates needed; the previous swallow behaviour was undocumented.