### PR TITLE
feat: allow passing full asset to bypass looking up asset in mux

### DIFF
--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -39,7 +39,7 @@ export function isAudioOnlyAsset(asset: MuxAsset): boolean {
   return hasAudioTrack && !hasVideoTrack;
 }
 
-function toPlaybackAsset(asset: MuxAsset): PlaybackAsset {
+export function toPlaybackAsset(asset: MuxAsset): PlaybackAsset {
   const { id: playbackId, policy } = getPlaybackId(asset);
   return { asset, playbackId, policy };
 }

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
 import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
-import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, isAudioOnlyAsset } from "@mux/ai/lib/mux-assets";
+import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, isAudioOnlyAsset, toPlaybackAsset } from "@mux/ai/lib/mux-assets";
 import { createSafetyReporter, detectUnexpectedKeys, detectUnexpectedKeysFromRawText } from "@mux/ai/lib/output-safety";
 import type { SafetyReport } from "@mux/ai/lib/output-safety";
 import { createTranscriptSection, renderSection } from "@mux/ai/lib/prompt-builder";
@@ -28,7 +28,7 @@ import { withRetry } from "@mux/ai/lib/retry";
 import { resolveMuxSigningContext } from "@mux/ai/lib/workflow-credentials";
 import { getStoryboardUrl } from "@mux/ai/primitives/storyboards";
 import { fetchTranscriptForAsset } from "@mux/ai/primitives/transcripts";
-import type { ImageSubmissionMode, MuxAIOptions, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
+import type { ImageSubmissionMode, MuxAIOptions, MuxAsset, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -557,7 +557,7 @@ async function analyzeQuestions({
  * scores and reasoning for each question. All questions are processed in a single LLM call for
  * efficiency.
  *
- * @param assetId - The Mux asset ID to analyze
+ * @param asset - The Mux asset to analyze (identified by asset ID string or MuxAsset object)
  * @param questions - Array of questions to answer (each must have a 'question' field)
  * @param options - Configuration options for the workflow
  * @returns Structured answers with confidence scores and reasoning
@@ -579,7 +579,7 @@ async function analyzeQuestions({
  * ```
  */
 export async function askQuestions(
-  assetId: string,
+  asset: string | MuxAsset,
   questions: Question[],
   options?: AskQuestionsOptions,
 ): Promise<AskQuestionsResult> {
@@ -686,8 +686,11 @@ export async function askQuestions(
     model,
     provider: provider as SupportedProvider,
   });
+  const assetId = typeof asset === "string" ? asset : asset.id;
   // Fetch asset data and playback ID from Mux
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
 
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
   const isAudioOnly = isAudioOnlyAsset(assetData);

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import type { ImageDownloadOptions } from "@mux/ai/lib/image-download";
 import { downloadImageAsBase64 } from "@mux/ai/lib/image-download";
-import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, toPlaybackAsset } from "@mux/ai/lib/mux-assets";
 import { createSafetyReporter, detectUnexpectedKeysFromRawText } from "@mux/ai/lib/output-safety";
 import type { SafetyReport } from "@mux/ai/lib/output-safety";
 import type { PromptOverrides } from "@mux/ai/lib/prompt-builder";
@@ -25,6 +25,7 @@ import { getStoryboardUrl } from "@mux/ai/primitives/storyboards";
 import type {
   ImageSubmissionMode,
   MuxAIOptions,
+  MuxAsset,
   TokenUsage,
   WorkflowCredentialsInput,
 } from "@mux/ai/types";
@@ -324,7 +325,7 @@ async function analyzeStoryboard({
 }
 
 export async function hasBurnedInCaptions(
-  assetId: string,
+  asset: string | MuxAsset,
   options: BurnedInCaptionsOptions = {},
 ): Promise<BurnedInCaptionsResult> {
   "use workflow";
@@ -346,7 +347,10 @@ export async function hasBurnedInCaptions(
     model,
     provider: provider as SupportedProvider,
   });
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const assetId = typeof asset === "string" ? asset : asset.id;
+  const { asset: assetData, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
 
   const imageUrl = await getStoryboardUrl(playbackId, 640, policy === "signed", credentials);

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -8,6 +8,7 @@ import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
   isAudioOnlyAsset,
+  toPlaybackAsset,
 } from "@mux/ai/lib/mux-assets";
 import { createSafetyReporter, detectUnexpectedKeys, detectUnexpectedKeysFromRawText } from "@mux/ai/lib/output-safety";
 import type { SafetyReport } from "@mux/ai/lib/output-safety";
@@ -28,7 +29,7 @@ import {
   getReadyTextTracks,
   getReliableLanguageCode,
 } from "@mux/ai/primitives/transcripts";
-import type { MuxAIOptions, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
+import type { MuxAIOptions, MuxAsset, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -364,7 +365,7 @@ function buildUserPrompt({
 }
 
 export async function generateChapters(
-  assetId: string,
+  asset: string | MuxAsset,
   options: ChaptersOptions = {},
 ): Promise<ChaptersResult> {
   "use workflow";
@@ -384,8 +385,11 @@ export async function generateChapters(
     model,
     provider: provider as SupportedProvider,
   });
+  const assetId = typeof asset === "string" ? asset : asset.id;
   // Fetch asset and transcript
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
   const isAudioOnly = isAudioOnlyAsset(assetData);
 

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -6,6 +6,7 @@ import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
+  toPlaybackAsset,
 } from "@mux/ai/lib/mux-assets";
 import { createTextTrackOnMux, fetchVttFromMux } from "@mux/ai/lib/mux-tracks";
 import { createSafetyReporter, detectUnexpectedKeysFromRawText } from "@mux/ai/lib/output-safety";
@@ -30,6 +31,7 @@ import {
 import { buildTranscriptUrl, extractTextFromVTT, getReadyTextTracks, vttTimestampToSeconds } from "@mux/ai/primitives/transcripts";
 import type {
   MuxAIOptions,
+  MuxAsset,
   StorageAdapter,
   TokenUsage,
   WorkflowCredentialsInput,
@@ -472,7 +474,7 @@ async function deleteTrackOnMux(
 // ─────────────────────────────────────────────────────────────────────────────
 
 export async function editCaptions<P extends SupportedProvider = SupportedProvider>(
-  assetId: string,
+  asset: string | MuxAsset,
   trackId: string,
   options: EditCaptionsOptions<P>,
 ): Promise<EditCaptionsResult> {
@@ -525,8 +527,11 @@ export async function editCaptions<P extends SupportedProvider = SupportedProvid
     );
   }
 
+  const assetId = typeof asset === "string" ? asset : asset.id;
   // Fetch asset data and playback ID from Mux
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
 
   // Resolve signing context for signed playback IDs

--- a/src/workflows/embeddings.ts
+++ b/src/workflows/embeddings.ts
@@ -3,6 +3,7 @@ import { embed } from "ai";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
+  toPlaybackAsset,
 } from "@mux/ai/lib/mux-assets";
 import type { EmbeddingModelIdByProvider, SupportedEmbeddingProvider } from "@mux/ai/lib/providers";
 import { createEmbeddingModelFromConfig, resolveEmbeddingModelConfig } from "@mux/ai/lib/providers";
@@ -14,6 +15,7 @@ import type {
   ChunkEmbedding,
   ChunkingStrategy,
   MuxAIOptions,
+  MuxAsset,
   TextChunk,
   VideoEmbeddingsResult,
   WorkflowCredentialsInput,
@@ -122,7 +124,7 @@ async function generateSingleChunkEmbedding({
  * 3. Generates embeddings for each chunk using the specified AI provider
  * 4. Returns both individual chunk embeddings and an averaged embedding
  *
- * @param assetId - Mux asset ID
+ * @param asset - Mux asset to process (identified by asset ID string or MuxAsset object)
  * @param options - Configuration options
  * @returns Embeddings result with chunks and averaged embedding
  *
@@ -145,7 +147,7 @@ async function generateSingleChunkEmbedding({
  * ```
  */
 async function generateEmbeddingsInternal(
-  assetId: string,
+  asset: string | MuxAsset,
   options: EmbeddingsOptions = {},
 ): Promise<EmbeddingsResult> {
   const {
@@ -158,8 +160,11 @@ async function generateEmbeddingsInternal(
   } = options;
 
   const embeddingModel = resolveEmbeddingModelConfig({ ...options, provider, model });
+  const assetId = typeof asset === "string" ? asset : asset.id;
   // Fetch asset and playback ID
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
 
   // Resolve signing context for signed playback IDs
@@ -252,21 +257,21 @@ async function generateEmbeddingsInternal(
 }
 
 export async function generateEmbeddings(
-  assetId: string,
+  asset: string | MuxAsset,
   options: EmbeddingsOptions = {},
 ): Promise<EmbeddingsResult> {
   "use workflow";
-  return generateEmbeddingsInternal(assetId, options);
+  return generateEmbeddingsInternal(asset, options);
 }
 
 /**
  * @deprecated Use {@link generateEmbeddings} instead. This name will be removed in a future release.
  */
 export async function generateVideoEmbeddings(
-  assetId: string,
+  asset: string | MuxAsset,
   options: EmbeddingsOptions = {},
 ): Promise<EmbeddingsResult> {
   "use workflow";
   console.warn("generateVideoEmbeddings is deprecated. Use generateEmbeddings instead.");
-  return generateEmbeddingsInternal(assetId, options);
+  return generateEmbeddingsInternal(asset, options);
 }

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -7,6 +7,7 @@ import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
   isAudioOnlyAsset,
+  toPlaybackAsset,
 } from "@mux/ai/lib/mux-assets";
 import { getMuxThumbnailBaseUrl } from "@mux/ai/lib/mux-url";
 import { createSafetyReporter, detectUnexpectedKeys, detectUnexpectedKeysFromRawText } from "@mux/ai/lib/output-safety";
@@ -36,7 +37,7 @@ import type { Shot } from "@mux/ai/primitives/shots";
 import { getShotsForAsset } from "@mux/ai/primitives/shots";
 import { getStoryboardUrl } from "@mux/ai/primitives/storyboards";
 import { fetchTranscriptForAsset, parseVTTCues, secondsToTimestamp } from "@mux/ai/primitives/transcripts";
-import type { MuxAIOptions, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
+import type { MuxAIOptions, MuxAsset, TokenUsage, WorkflowCredentialsInput } from "@mux/ai/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -623,7 +624,7 @@ async function generateInsightsWithAI(
  * are engaging or disengaging. It combines hotspot data, heatmap statistics, visual
  * frames (from shots or thumbnails), and transcript analysis to generate AI-powered insights.
  *
- * @param assetId - The Mux asset ID to analyze
+ * @param asset - The Mux asset to analyze (identified by asset ID string or MuxAsset object)
  * @param options - Configuration options for the workflow
  * @returns Structured insights with moment-by-moment and overall analysis
  *
@@ -640,7 +641,7 @@ async function generateInsightsWithAI(
  * ```
  */
 export async function generateEngagementInsights(
-  assetId: string,
+  asset: string | MuxAsset,
   options: EngagementInsightsOptions = {},
 ): Promise<EngagementInsightsResult> {
   "use workflow";
@@ -664,15 +665,18 @@ export async function generateEngagementInsights(
     provider: provider as SupportedProvider,
   });
 
+  const assetId = typeof asset === "string" ? asset : asset.id;
   // Step 1: Fetch asset metadata
-  const { asset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
-  const assetDurationSeconds = getAssetDurationSecondsFromAsset(asset);
+  const { asset: assetData, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
+  const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
 
   if (!assetDurationSeconds) {
     throw new MuxAiError(`Asset ${assetId} has no valid duration.`, { type: "validation_error" });
   }
 
-  const audioOnly = isAudioOnlyAsset(asset);
+  const audioOnly = isAudioOnlyAsset(assetData);
 
   const signingContext = await resolveMuxSigningContext(credentials);
   if (policy === "signed" && !signingContext) {
@@ -715,7 +719,7 @@ export async function generateEngagementInsights(
     await Promise.allSettled([
       fetchEngagementData(assetId, { hotspotLimit, timeframe, credentials }),
       shotsPromise,
-      fetchTranscriptForAsset(asset, playbackId, {
+      fetchTranscriptForAsset(assetData, playbackId, {
         cleanTranscript: false,
         shouldSign,
         credentials,

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -7,6 +7,7 @@ import {
   getVideoTrackDurationSecondsFromAsset,
   getVideoTrackMaxFrameRateFromAsset,
   isAudioOnlyAsset,
+  toPlaybackAsset,
 } from "@mux/ai/lib/mux-assets";
 import { getMuxThumbnailBaseUrl } from "@mux/ai/lib/mux-url";
 import { withRetry } from "@mux/ai/lib/retry";
@@ -18,6 +19,7 @@ import { fetchTranscriptForAsset } from "@mux/ai/primitives/transcripts";
 import type {
   ImageSubmissionMode,
   MuxAIOptions,
+  MuxAsset,
   TokenUsage,
   WorkflowCredentialsInput,
 } from "@mux/ai/types";
@@ -607,7 +609,7 @@ async function getThumbnailUrlsFromTimestamps(
  * - provider 'hive' uses Hive's moderation API for thumbnails only (requires HIVE_API_KEY)
  */
 export async function getModerationScores(
-  assetId: string,
+  asset: string | MuxAsset,
   options: ModerationOptions = {},
 ): Promise<ModerationResult> {
   "use workflow";
@@ -625,18 +627,21 @@ export async function getModerationScores(
     credentials: providedCredentials,
   } = options;
   const credentials = providedCredentials;
+  const assetId = typeof asset === "string" ? asset : asset.id;
   // Fetch asset data and playback ID from Mux via helper
-  const { asset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
-  const videoTrackDurationSeconds = getVideoTrackDurationSecondsFromAsset(asset);
-  const videoTrackFps = getVideoTrackMaxFrameRateFromAsset(asset);
-  const assetDurationSeconds = getAssetDurationSecondsFromAsset(asset);
+  const { asset: resolvedAsset, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
+  const videoTrackDurationSeconds = getVideoTrackDurationSecondsFromAsset(resolvedAsset);
+  const videoTrackFps = getVideoTrackMaxFrameRateFromAsset(resolvedAsset);
+  const assetDurationSeconds = getAssetDurationSecondsFromAsset(resolvedAsset);
   // Use the shorter of video-track and asset duration so thumbnail timestamps never
   // exceed the renderable range reported by the Mux thumbnail service.
   const candidateDurations = [videoTrackDurationSeconds, assetDurationSeconds].filter(
     (d): d is number => d != null,
   );
   const duration = candidateDurations.length > 0 ? Math.min(...candidateDurations) : 0;
-  const isAudioOnly = isAudioOnlyAsset(asset);
+  const isAudioOnly = isAudioOnlyAsset(resolvedAsset);
 
   // Resolve signing context for signed playback IDs
   const signingContext = await resolveMuxSigningContext(credentials);
@@ -653,7 +658,7 @@ export async function getModerationScores(
 
   if (isAudioOnly) {
     mode = "transcript";
-    const transcriptResult = await fetchTranscriptForAsset(asset, playbackId, {
+    const transcriptResult = await fetchTranscriptForAsset(resolvedAsset, playbackId, {
       languageCode,
       cleanTranscript: true,
       shouldSign: policy === "signed",

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -10,6 +10,7 @@ import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
   isAudioOnlyAsset,
+  toPlaybackAsset,
 } from "@mux/ai/lib/mux-assets";
 import { createSafetyReporter, detectUnexpectedKeysFromRawText } from "@mux/ai/lib/output-safety";
 import type { SafetyReport } from "@mux/ai/lib/output-safety";
@@ -46,6 +47,7 @@ import { fetchTranscriptForAsset, getReadyTextTracks, getReliableLanguageCode } 
 import type {
   ImageSubmissionMode,
   MuxAIOptions,
+  MuxAsset,
   TokenUsage,
   ToneType,
   WorkflowCredentialsInput,
@@ -678,7 +680,7 @@ function normalizeKeywords(keywords?: string[], limit: number = DEFAULT_SUMMARY_
 }
 
 export async function getSummaryAndTags(
-  assetId: string,
+  asset: string | MuxAsset,
   options?: SummarizationOptions,
 ): Promise<SummaryAndTagsResult> {
   "use workflow";
@@ -713,9 +715,12 @@ export async function getSummaryAndTags(
     provider: provider as SupportedProvider,
   });
   const workflowCredentials = credentials;
+  const assetId = typeof asset === "string" ? asset : asset.id;
 
   // Fetch asset data from Mux and grab playback/transcript details
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, workflowCredentials);
+  const { asset: assetData, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, workflowCredentials) :
+      toPlaybackAsset(asset);
 
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
 

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -3,7 +3,7 @@ import { getApiKeyFromEnv } from "@mux/ai/lib/client-factory";
 import { getLanguageCodePair, toISO639_1, toISO639_3 } from "@mux/ai/lib/language-codes";
 import type { LanguageCodePair, SupportedISO639_1 } from "@mux/ai/lib/language-codes";
 import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
-import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } from "@mux/ai/lib/mux-assets";
+import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset, toPlaybackAsset } from "@mux/ai/lib/mux-assets";
 import { getMuxStreamOrigin } from "@mux/ai/lib/mux-url";
 import {
   createPresignedGetUrlWithStorageAdapter,
@@ -13,6 +13,7 @@ import { signUrl } from "@mux/ai/lib/url-signing";
 import { resolveMuxClient } from "@mux/ai/lib/workflow-credentials";
 import type {
   MuxAIOptions,
+  MuxAsset,
   StorageAdapter,
   TokenUsage,
   WorkflowCredentialsInput,
@@ -392,7 +393,7 @@ async function createAudioTrackOnMux(
 }
 
 export async function translateAudio(
-  assetId: string,
+  asset: string | MuxAsset,
   toLanguageCode: string,
   options: AudioTranslationOptions = {},
 ): Promise<AudioTranslationResult> {
@@ -429,8 +430,11 @@ export async function translateAudio(
     throw new MuxAiError("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.", { type: "validation_error" });
   }
 
+  const assetId = typeof asset === "string" ? asset : asset.id;
   // Fetch asset data and playback ID from Mux
-  const { asset: initialAsset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: initialAsset, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(initialAsset);
 
   // Check for audio-only static rendition

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -15,6 +15,7 @@ import { MuxAiError, wrapError } from "@mux/ai/lib/mux-ai-error";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
+  toPlaybackAsset,
 } from "@mux/ai/lib/mux-assets";
 import { createTextTrackOnMux, fetchVttFromMux } from "@mux/ai/lib/mux-tracks";
 import {
@@ -51,6 +52,7 @@ import {
 } from "@mux/ai/primitives/transcripts";
 import type {
   MuxAIOptions,
+  MuxAsset,
   StorageAdapter,
   TokenUsage,
   WorkflowCredentialsInput,
@@ -991,7 +993,7 @@ async function uploadVttToS3({
 }
 
 export async function translateCaptions<P extends SupportedProvider = SupportedProvider>(
-  assetId: string,
+  asset: string | MuxAsset,
   trackId: string,
   toLanguageCode: string,
   options: TranslationOptions<P>,
@@ -1031,8 +1033,11 @@ export async function translateCaptions<P extends SupportedProvider = SupportedP
     throw new MuxAiError("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.", { type: "validation_error" });
   }
 
+  const assetId = typeof asset === "string" ? asset : asset.id;
   // Fetch asset data and playback ID from Mux
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = typeof asset === "string" ?
+      await getPlaybackIdForAsset(asset, credentials) :
+      toPlaybackAsset(asset);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
 
   // Resolve signing context for signed playback IDs

--- a/tests/unit/asset-input.test.ts
+++ b/tests/unit/asset-input.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests that every workflow correctly branches on whether the first argument is
+ * a string asset ID or a pre-fetched MuxAsset object.
+ *
+ * When a string is passed:   getPlaybackIdForAsset IS called (hits api.mux.com)
+ * When an asset is passed:   toPlaybackAsset IS called, getPlaybackIdForAsset is NOT
+ *
+ * Each workflow test lets the function reject after asset resolution (since
+ * downstream dependencies like AI providers or transcript fetches are not fully
+ * mocked), but the spy assertions are recorded before any rejection.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/lib/mux-assets", () => ({
+  getAssetDurationSecondsFromAsset: vi.fn(),
+  getPlaybackIdForAsset: vi.fn(),
+  getVideoTrackDurationSecondsFromAsset: vi.fn(),
+  getVideoTrackMaxFrameRateFromAsset: vi.fn(),
+  isAudioOnlyAsset: vi.fn(),
+  toPlaybackAsset: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflow-credentials", () => ({
+  resolveMuxSigningContext: vi.fn(),
+  resolveMuxClient: vi.fn(),
+  resolveProviderApiKey: vi.fn(),
+}));
+
+vi.mock("../../src/primitives/transcripts", () => ({
+  fetchTranscriptForAsset: vi.fn(),
+  getReadyTextTracks: vi.fn(),
+  getReliableLanguageCode: vi.fn(),
+  parseVTTCues: vi.fn(),
+  secondsToTimestamp: vi.fn(),
+  buildTranscriptUrl: vi.fn(),
+  extractTextFromVTT: vi.fn(),
+  vttTimestampToSeconds: vi.fn(),
+  stripVttMetadataBlocks: vi.fn(),
+}));
+
+vi.mock("../../src/primitives/storyboards", () => ({
+  getStoryboardUrl: vi.fn(),
+}));
+
+vi.mock("../../src/primitives/hotspots", () => ({
+  getHotspotsForAsset: vi.fn(),
+}));
+
+vi.mock("../../src/primitives/heatmap", () => ({
+  getHeatmapForAsset: vi.fn(),
+}));
+
+vi.mock("../../src/primitives/shots", () => ({
+  getShotsForAsset: vi.fn(),
+}));
+
+vi.mock("../../src/lib/mux-tracks", () => ({
+  fetchVttFromMux: vi.fn(),
+  createTextTrackOnMux: vi.fn(),
+}));
+
+vi.mock("../../src/primitives/thumbnails", () => ({
+  getThumbnailUrls: vi.fn(),
+  getThumbnailUrlsFromTimestamps: vi.fn(),
+}));
+
+const {
+  getAssetDurationSecondsFromAsset,
+  getPlaybackIdForAsset,
+  getVideoTrackDurationSecondsFromAsset,
+  getVideoTrackMaxFrameRateFromAsset,
+  isAudioOnlyAsset,
+  toPlaybackAsset,
+} = await import("../../src/lib/mux-assets");
+
+const { resolveMuxSigningContext, resolveMuxClient } = await import("../../src/lib/workflow-credentials");
+const { fetchTranscriptForAsset, getReadyTextTracks, getReliableLanguageCode } = await import("../../src/primitives/transcripts");
+const { getStoryboardUrl } = await import("../../src/primitives/storyboards");
+const { getHotspotsForAsset } = await import("../../src/primitives/hotspots");
+const { getHeatmapForAsset } = await import("../../src/primitives/heatmap");
+const { getShotsForAsset } = await import("../../src/primitives/shots");
+const { fetchVttFromMux } = await import("../../src/lib/mux-tracks");
+const { getThumbnailUrls } = await import("../../src/primitives/thumbnails");
+
+const { getSummaryAndTags } = await import("../../src/workflows/summarization");
+const { generateChapters } = await import("../../src/workflows/chapters");
+const { hasBurnedInCaptions } = await import("../../src/workflows/burned-in-captions");
+const { getModerationScores } = await import("../../src/workflows/moderation");
+const { generateEngagementInsights } = await import("../../src/workflows/engagement-insights");
+const { editCaptions } = await import("../../src/workflows/edit-captions");
+const { askQuestions } = await import("../../src/workflows/ask-questions");
+const { generateEmbeddings } = await import("../../src/workflows/embeddings");
+const { translateAudio } = await import("../../src/workflows/translate-audio");
+const { translateCaptions } = await import("../../src/workflows/translate-captions");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockAsset = {
+  id: "asset-abc",
+  playback_ids: [{ id: "pb-xyz", policy: "public" }],
+  tracks: [{ type: "video", id: "v1" }, { type: "audio", id: "a1" }],
+} as any;
+
+const mockPlaybackAsset = { asset: mockAsset, playbackId: "pb-xyz", policy: "public" as const };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  // Core asset-resolution mocks
+  vi.mocked(toPlaybackAsset).mockReturnValue(mockPlaybackAsset);
+  vi.mocked(getPlaybackIdForAsset).mockResolvedValue(mockPlaybackAsset);
+
+  // Asset metadata helpers
+  vi.mocked(getAssetDurationSecondsFromAsset).mockReturnValue(60);
+  vi.mocked(isAudioOnlyAsset).mockReturnValue(false);
+  vi.mocked(getVideoTrackDurationSecondsFromAsset).mockReturnValue(60);
+  vi.mocked(getVideoTrackMaxFrameRateFromAsset).mockReturnValue(30);
+
+  // Credentials helpers — fail fast so workflows reject after asset resolution
+  vi.mocked(resolveMuxSigningContext).mockResolvedValue(undefined);
+  vi.mocked(resolveMuxClient).mockRejectedValue(new Error("mocked: no mux client"));
+
+  // Downstream primitives — fail fast to avoid real network calls
+  vi.mocked(fetchTranscriptForAsset).mockRejectedValue(new Error("mocked: no transcript"));
+  vi.mocked(getReadyTextTracks).mockReturnValue([]);
+  vi.mocked(getReliableLanguageCode).mockReturnValue(undefined);
+  vi.mocked(getStoryboardUrl).mockRejectedValue(new Error("mocked: no storyboard"));
+  vi.mocked(getHotspotsForAsset).mockRejectedValue(new Error("mocked: no hotspots"));
+  vi.mocked(getHeatmapForAsset).mockRejectedValue(new Error("mocked: no heatmap"));
+  vi.mocked(getShotsForAsset).mockRejectedValue(new Error("mocked: no shots"));
+  vi.mocked(fetchVttFromMux).mockRejectedValue(new Error("mocked: no vtt"));
+  vi.mocked(getThumbnailUrls).mockRejectedValue(new Error("mocked: no thumbnails"));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Runs `fn` and asserts it eventually rejects (the downstream mocks are set up
+ * to fail after asset resolution), then checks the spy calls.
+ */
+async function runAndAssertAssetResolution(
+  fn: () => Promise<unknown>,
+  { expectAssetObject }: { expectAssetObject: boolean },
+) {
+  await expect(fn()).rejects.toThrow();
+
+  if (expectAssetObject) {
+    expect(getPlaybackIdForAsset).not.toHaveBeenCalled();
+    expect(toPlaybackAsset).toHaveBeenCalledWith(mockAsset);
+  } else {
+    expect(toPlaybackAsset).not.toHaveBeenCalled();
+    expect(getPlaybackIdForAsset).toHaveBeenCalled();
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getSummaryAndTags
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getSummaryAndTags", () => {
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => getSummaryAndTags(mockAsset),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => getSummaryAndTags("asset-abc"),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateChapters
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("generateChapters", () => {
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => generateChapters(mockAsset),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => generateChapters("asset-abc"),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// hasBurnedInCaptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("hasBurnedInCaptions", () => {
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => hasBurnedInCaptions(mockAsset),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => hasBurnedInCaptions("asset-abc"),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getModerationScores
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getModerationScores", () => {
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => getModerationScores(mockAsset),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => getModerationScores("asset-abc"),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateEngagementInsights
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("generateEngagementInsights", () => {
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => generateEngagementInsights(mockAsset),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => generateEngagementInsights("asset-abc"),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// editCaptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("editCaptions", () => {
+  // replacements required to pass validation; uploadToMux: false skips S3 config check
+  const editOptions = {
+    replacements: [{ find: "foo", replace: "bar" }],
+    uploadToMux: false as const,
+  };
+
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => editCaptions(mockAsset, "track-id", editOptions),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => editCaptions("asset-abc", "track-id", editOptions),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// askQuestions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("askQuestions", () => {
+  const questions = [{ question: "What is this video about?" }];
+
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => askQuestions(mockAsset, questions),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => askQuestions("asset-abc", questions),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// generateEmbeddings
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("generateEmbeddings", () => {
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => generateEmbeddings(mockAsset),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => generateEmbeddings("asset-abc"),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// translateAudio
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("translateAudio", () => {
+  // uploadToMux: false skips S3 config validation
+  const audioOptions = { uploadToMux: false as const };
+
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => translateAudio(mockAsset, "es", audioOptions),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => translateAudio("asset-abc", "es", audioOptions),
+      { expectAssetObject: false },
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// translateCaptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("translateCaptions", () => {
+  // uploadToMux: false skips S3 config validation
+  const captionsOptions = { provider: "openai" as const, uploadToMux: false as const };
+
+  it("calls toPlaybackAsset when given a MuxAsset object", async () => {
+    await runAndAssertAssetResolution(
+      () => translateCaptions(mockAsset, "track-id", "es", captionsOptions),
+      { expectAssetObject: true },
+    );
+  });
+
+  it("calls getPlaybackIdForAsset when given a string asset ID", async () => {
+    await runAndAssertAssetResolution(
+      () => translateCaptions("asset-abc", "track-id", "es", captionsOptions),
+      { expectAssetObject: false },
+    );
+  });
+});

--- a/tests/unit/moderation-coverage.test.ts
+++ b/tests/unit/moderation-coverage.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../src/lib/mux-assets", () => ({
   getVideoTrackDurationSecondsFromAsset: vi.fn(),
   getVideoTrackMaxFrameRateFromAsset: vi.fn(),
   isAudioOnlyAsset: vi.fn(),
+  toPlaybackAsset: vi.fn(),
 }));
 
 vi.mock("../../src/lib/workflow-credentials", () => ({
@@ -27,6 +28,7 @@ const {
   getVideoTrackDurationSecondsFromAsset,
   getVideoTrackMaxFrameRateFromAsset,
   isAudioOnlyAsset,
+  toPlaybackAsset,
 } = await import("../../src/lib/mux-assets");
 const { resolveMuxSigningContext } = await import("../../src/lib/workflow-credentials");
 const { getThumbnailUrls } = await import("../../src/primitives/thumbnails");
@@ -63,6 +65,11 @@ beforeEach(() => {
     playbackId: "playback-123",
     policy: "public",
   } as any);
+  vi.mocked(toPlaybackAsset).mockReturnValue({
+    asset: { id: "asset-123" } as any,
+    playbackId: "playback-123",
+    policy: "public",
+  });
   vi.mocked(getVideoTrackDurationSecondsFromAsset).mockReturnValue(40);
   vi.mocked(getAssetDurationSecondsFromAsset).mockReturnValue(40);
   vi.mocked(getVideoTrackMaxFrameRateFromAsset).mockReturnValue(30);
@@ -167,5 +174,53 @@ describe("getModerationScores coverage metadata", () => {
       isLowConfidence: false,
     });
     expect(result.exceedsThreshold).toBe(false);
+  });
+});
+
+describe("getModerationScores asset-object input", () => {
+  const mockAsset = {
+    id: "asset-123",
+    playback_ids: [{ id: "playback-123", policy: "public" }],
+  } as any;
+
+  beforeEach(() => {
+    vi.mocked(getThumbnailUrls).mockResolvedValue([
+      { url: "https://thumb.test/1.png", time: 0 },
+    ]);
+    mockFetch.mockResolvedValue(
+      mockOpenAIModerationResponse({
+        status: 200,
+        body: { results: [{ category_scores: { sexual: 0.01, violence: 0.02 } }] },
+      }),
+    );
+  });
+
+  it("skips the Mux API call and uses the provided asset object", async () => {
+    await getModerationScores(mockAsset, {
+      provider: "openai",
+      model: "omni-moderation-latest",
+    });
+
+    expect(getPlaybackIdForAsset).not.toHaveBeenCalled();
+    expect(toPlaybackAsset).toHaveBeenCalledWith(mockAsset);
+  });
+
+  it("resolves assetId from asset.id in the result", async () => {
+    const result = await getModerationScores(mockAsset, {
+      provider: "openai",
+      model: "omni-moderation-latest",
+    });
+
+    expect(result.assetId).toBe("asset-123");
+  });
+
+  it("accepts a string ID and calls getPlaybackIdForAsset as before", async () => {
+    await getModerationScores("asset-123", {
+      provider: "openai",
+      model: "omni-moderation-latest",
+    });
+
+    expect(getPlaybackIdForAsset).toHaveBeenCalledWith("asset-123", undefined);
+    expect(toPlaybackAsset).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/mux-assets.test.ts
+++ b/tests/unit/mux-assets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isAudioOnlyAsset } from "../../src/lib/mux-assets";
+import { isAudioOnlyAsset, toPlaybackAsset } from "../../src/lib/mux-assets";
 import type { MuxAsset } from "../../src/types";
 
 describe("isAudioOnlyAsset", () => {
@@ -91,5 +91,68 @@ describe("isAudioOnlyAsset", () => {
     };
 
     expect(isAudioOnlyAsset(audioTextAsset as MuxAsset)).toBe(true);
+  });
+});
+
+describe("toPlaybackAsset", () => {
+  it("returns playbackId and policy from a public playback ID", () => {
+    const asset: Partial<MuxAsset> = {
+      id: "asset-abc",
+      playback_ids: [{ id: "pub-123", policy: "public" }],
+    };
+
+    const result = toPlaybackAsset(asset as MuxAsset);
+
+    expect(result.asset).toBe(asset);
+    expect(result.playbackId).toBe("pub-123");
+    expect(result.policy).toBe("public");
+  });
+
+  it("falls back to signed playback ID when no public ID exists", () => {
+    const asset: Partial<MuxAsset> = {
+      id: "asset-abc",
+      playback_ids: [{ id: "sig-456", policy: "signed" }],
+    };
+
+    const result = toPlaybackAsset(asset as MuxAsset);
+
+    expect(result.playbackId).toBe("sig-456");
+    expect(result.policy).toBe("signed");
+  });
+
+  it("prefers public playback ID over signed when both exist", () => {
+    const asset: Partial<MuxAsset> = {
+      id: "asset-abc",
+      playback_ids: [
+        { id: "sig-456", policy: "signed" },
+        { id: "pub-123", policy: "public" },
+      ],
+    };
+
+    const result = toPlaybackAsset(asset as MuxAsset);
+
+    expect(result.playbackId).toBe("pub-123");
+    expect(result.policy).toBe("public");
+  });
+
+  it("throws when no public or signed playback ID exists", () => {
+    const asset: Partial<MuxAsset> = {
+      id: "asset-abc",
+      playback_ids: [],
+    };
+
+    expect(() => toPlaybackAsset(asset as MuxAsset)).toThrow(
+      "No public or signed playback ID found",
+    );
+  });
+
+  it("throws when playback_ids is undefined", () => {
+    const asset: Partial<MuxAsset> = {
+      id: "asset-abc",
+    };
+
+    expect(() => toPlaybackAsset(asset as MuxAsset)).toThrow(
+      "No public or signed playback ID found",
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Broadly changes public workflow function signatures to accept either an asset ID or a pre-fetched `MuxAsset`, which could break callers and alters how playback IDs/policies are resolved. Runtime risk is moderated by added unit tests covering the new branching logic.
> 
> **Overview**
> Allows callers to pass a full `MuxAsset` into major workflows (e.g. `getSummaryAndTags`, `generateChapters`, `askQuestions`, moderation, translations, embeddings) to **bypass the Mux Video API fetch** when the asset is already available.
> 
> Adds `toPlaybackAsset` (now exported) to derive `playbackId`/`policy` directly from an asset object, updates workflows to branch on `string` vs `MuxAsset`, and introduces unit tests asserting the correct path is taken (Mux fetch vs local resolution), including extra moderation coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb77d0f0f713ab5bbaf2fb28cc5ad4905c58c70c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->