### PR TITLE
chore: Bump to 0.20.0 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping change that only updates package metadata (no runtime code changes).
> 
> **Overview**
> Bumps the published `@mux/ai` version from `0.19.0` to `0.20.0`, updating both `package.json` and `package-lock.json` for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebcb7258e890213fc9e87cd3c745744b72c54fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->