### PR TITLE
chore: Fix evals, and slim down publish workflows

### DIFF
--- a/.github/workflows/publish-evalite-results.yml
+++ b/.github/workflows/publish-evalite-results.yml
@@ -39,6 +39,7 @@ jobs:
           ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
           HIVE_API_KEY: ${{ secrets.HIVE_API_KEY }}
           GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_VISION_API_KEY: ${{ secrets.GOOGLE_VISION_API_KEY }}
           S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
           S3_REGION: ${{ secrets.S3_REGION }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,29 +32,5 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run tests
-        run: npm test
-        env:
-          MUX_TOKEN_ID: ${{ secrets.MUX_TOKEN_ID }}
-          MUX_TOKEN_SECRET: ${{ secrets.MUX_TOKEN_SECRET }}
-          MUX_SIGNING_KEY: ${{ secrets.MUX_SIGNING_KEY }}
-          MUX_PRIVATE_KEY: ${{ secrets.MUX_PRIVATE_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
-          HIVE_API_KEY: ${{ secrets.HIVE_API_KEY }}
-          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
-          S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
-          S3_REGION: ${{ secrets.S3_REGION }}
-          S3_BUCKET: ${{ secrets.S3_BUCKET }}
-          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
-          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
-
-      - name: Run type check
-        run: npm run typecheck
-
-      - name: Run linter
-        run: npm run lint
-
       - name: Publish to npm
         run: npm publish --access public


### PR DESCRIPTION
* Fixes Eval publishing by adding secret passthrough
* Trims back the publish workflow to just the basics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because the `publish.yml` workflow no longer runs tests/typecheck/lint before publishing, increasing the chance of releasing broken builds. The Evalite change is low risk but depends on correct secret configuration.
> 
> **Overview**
> Fixes Evalite result publishing by passing through the `GOOGLE_VISION_API_KEY` secret in `publish-evalite-results.yml`.
> 
> Simplifies the npm release workflow (`publish.yml`) to only install, build, and publish, removing the prior test/typecheck/lint steps (and their associated secret env wiring).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff603e139d20de13e4a3d631103253cb9b9d3518. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->