### PR TITLE
chore: Deprecate gemini-3.1-flash-lite-preview in favour of gemini-3.1-flash-lite

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -790,7 +790,7 @@ const result = await getSummaryAndTags(assetId, {
 // Use a faster/cheaper model
 const fastResult = await getSummaryAndTags(assetId, {
   provider: "google",
-  model: "gemini-3.1-flash-lite-preview" // Smallest/fastest Gemini
+  model: "gemini-3.1-flash-lite" // Smallest/fastest Gemini
 });
 ```
 

--- a/examples/ask-questions/audio-only-example.ts
+++ b/examples/ask-questions/audio-only-example.ts
@@ -10,7 +10,7 @@ type Provider = "openai" | "anthropic" | "google";
 const DEFAULT_MODELS: Record<Provider, string> = {
   openai: "gpt-5.1",
   anthropic: "claude-sonnet-4-5",
-  google: "gemini-3.1-flash-lite-preview",
+  google: "gemini-3.1-flash-lite",
 };
 
 const DEFAULT_QUESTION = "Is there spoken dialogue in this content?";

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -62,7 +62,7 @@ const DEFAULT_EMBEDDING_MODELS: { [K in SupportedEmbeddingProvider]: EmbeddingMo
 export const LANGUAGE_MODELS: { [K in SupportedProvider]: ModelIdByProvider[K][] } = {
   openai: ["gpt-5.1", "gpt-5-mini"],
   anthropic: ["claude-sonnet-4-5"],
-  google: ["gemini-3-flash-preview", "gemini-3.1-flash-lite-preview", "gemini-2.5-flash"],
+  google: ["gemini-3-flash-preview", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview", "gemini-2.5-flash"],
 };
 
 export type ModelDeprecationPhase = "warn" | "blocked";
@@ -92,11 +92,20 @@ export const LANGUAGE_MODEL_DEPRECATIONS: LanguageModelDeprecation[] = [
   {
     provider: "google",
     modelId: "gemini-2.5-flash",
-    replacementModelId: "gemini-3.1-flash-lite-preview",
+    replacementModelId: "gemini-3.1-flash-lite",
     phase: "warn",
     deprecatedOn: "2026-03-03",
-    sunsetOn: "2026-06-30",
-    reason: "Gemini 3.1 Flash-Lite Preview offers better quality/latency/cost balance in current evals.",
+    sunsetOn: "2026-06-17",
+    reason: "Gemini 3.1 Flash-Lite offers better quality/latency/cost balance in current evals.",
+  },
+  {
+    provider: "google",
+    modelId: "gemini-3.1-flash-lite-preview",
+    replacementModelId: "gemini-3.1-flash-lite",
+    phase: "warn",
+    deprecatedOn: "2026-05-12",
+    sunsetOn: "2026-05-25",
+    reason: "Preview model graduated to the stable Gemini 3.1 Flash-Lite release.",
   },
 ];
 
@@ -353,6 +362,12 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
 
   // Google models
   // Reference: https://ai.google.dev/pricing
+  "gemini-3.1-flash-lite": {
+    inputPerMillion: 0.25,
+    outputPerMillion: 1.50,
+    cachedInputPerMillion: 0.025,
+    pricingUrl: "https://ai.google.dev/gemini-api/docs/pricing",
+  },
   "gemini-3.1-flash-lite-preview": {
     inputPerMillion: 0.25,
     outputPerMillion: 1.50,

--- a/tests/unit/providers.test.ts
+++ b/tests/unit/providers.test.ts
@@ -17,7 +17,7 @@ describe("language model deprecations", () => {
     expect(deprecation).toMatchObject({
       provider: "google",
       modelId: "gemini-2.5-flash",
-      replacementModelId: "gemini-3.1-flash-lite-preview",
+      replacementModelId: "gemini-3.1-flash-lite",
       phase: "warn",
     });
   });
@@ -37,7 +37,7 @@ describe("language model deprecations", () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const firstWarning = String(warnSpy.mock.calls[0]?.[0]);
     expect(firstWarning).toContain("provider=\"google\" model=\"gemini-2.5-flash\"");
-    expect(firstWarning).toContain("provider=\"google\" model=\"gemini-3.1-flash-lite-preview\"");
+    expect(firstWarning).toContain("provider=\"google\" model=\"gemini-3.1-flash-lite\"");
     expect(firstWarning).toContain("Planned removal date");
   });
 
@@ -46,7 +46,7 @@ describe("language model deprecations", () => {
 
     resolveLanguageModelConfig({
       provider: "google",
-      model: "gemini-3.1-flash-lite-preview",
+      model: "gemini-3.1-flash-lite",
     });
 
     expect(warnSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: model-id/catalog and documentation/test updates only, with deprecation warnings guiding migration and no changes to default provider selection or core workflow logic.
> 
> **Overview**
> Shifts Google model guidance and examples from `gemini-3.1-flash-lite-preview` to the stable `gemini-3.1-flash-lite`.
> 
> Updates the provider model catalog to include `gemini-3.1-flash-lite`, adds pricing for it, and introduces a new *warn-phase* deprecation entry for `gemini-3.1-flash-lite-preview` (also adjusting the `gemini-2.5-flash` replacement/sunset metadata).
> 
> Adjusts unit tests to expect the new replacement model and to treat `gemini-3.1-flash-lite` as non-deprecated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 428dd33b56e8644c33b3858ed83d0d2443c29125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->