### PR TITLE
feat: Export language code related functions, and bump package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.21.2",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,23 @@
 import { version } from "../package.json";
 
+// Language code utilities
+export {
+  getLanguageCodePair,
+  getLanguageName,
+  isUndeterminedLanguageCode,
+  isValidISO639_1,
+  isValidISO639_3,
+  toISO639_1,
+  toISO639_3,
+} from "./lib/language-codes.ts";
+export type {
+  ISO639_1,
+  ISO639_3,
+  LanguageCodePair,
+  SupportedISO639_1,
+  SupportedISO639_3,
+} from "./lib/language-codes.ts";
+
 // Error types
 export { MuxAiError, wrapError } from "./lib/mux-ai-error.ts";
 export type { MuxAiErrorType } from "./lib/mux-ai-error.ts";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this is a public API surface change (new exports) plus a version bump, with no behavioral changes to existing workflows beyond enabling new import paths.
> 
> **Overview**
> Bumps the package version from `0.21.2` to `0.22.0` (including `package-lock.json`).
> 
> Exports the language code helpers and related types (e.g. `toISO639_1`, `toISO639_3`, `getLanguageName`, `LanguageCodePair`) from `src/index.ts`, making them available via the main package entrypoint instead of only internal imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14772ea789ef8956672e19fcf70b8db4c987b986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->