### PR TITLE
chore: remove timestamp field from Engagement Insights

### DIFF
--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -71,8 +71,6 @@ export interface MomentInsight {
   startMs: number;
   /** End time in milliseconds */
   endMs: number;
-  /** Human-readable timestamp (e.g., "2:15") */
-  timestamp: string;
   /** Normalized engagement score (0-1) */
   engagementScore: number;
   /** Primary insight explaining the engagement pattern */
@@ -635,7 +633,7 @@ async function generateInsightsWithAI(
  * });
  *
  * result.momentInsights.forEach(m => {
- *   console.log(`${m.timestamp}: ${m.insight}`);
+ *   console.log(`${m.startMs}ms: ${m.insight}`);
  * });
  * ```
  */
@@ -873,7 +871,6 @@ export async function generateEngagementInsights(
     momentInsights.push({
       startMs: hotspot.startMs,
       endMs: hotspot.endMs,
-      timestamp: secondsToTimestamp(hotspot.startMs / 1000),
       engagementScore: hotspot.score,
       insight: insightScrub.leaked ? "Insight suppressed by safety filter." : insightScrub.text,
     });

--- a/tests/integration/engagement-insights.test.ts
+++ b/tests/integration/engagement-insights.test.ts
@@ -84,7 +84,6 @@ describe("engagement Insights Integration Tests", () => {
     result.momentInsights.forEach((insight) => {
       expect(insight).toHaveProperty("startMs");
       expect(insight).toHaveProperty("endMs");
-      expect(insight).toHaveProperty("timestamp");
       expect(insight).toHaveProperty("engagementScore");
       expect(insight).toHaveProperty("insight");
       expect(typeof insight.insight).toBe("string");


### PR DESCRIPTION
Remove the `timestamp` field from `generate-engagement-insights`, as it's unnecessary information that customers could calculate themselves if they need it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change for consumers that read `momentInsights[].timestamp`; behavior is otherwise unchanged since times remain available as milliseconds.
> 
> **Overview**
> Removes the **`timestamp`** string from the public **`MomentInsight`** shape returned by **`generateEngagementInsights`**, so each moment only exposes **`startMs`**, **`endMs`**, **`engagementScore`**, and **`insight`**.
> 
> The workflow no longer derives a display time via **`secondsToTimestamp`** when building **`momentInsights`** from hotspot ground truth. The JSDoc example and integration test were updated to use **`startMs`** instead of **`timestamp`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d0e7e0d24dcd1a3baccfd8aa95d01ad4a70fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->