### PR TITLE
feat: add uploads for chapter generation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -497,6 +497,13 @@ Generates AI-powered chapter markers by analyzing video or audio transcripts. Cr
   - `titleGuidelines?: string` - Override chapter title style guidelines
 - `minChaptersPerHour?: number` - Minimum chapters to generate per hour of content (default: 3)
 - `maxChaptersPerHour?: number` - Maximum chapters to generate per hour of content (default: 8)
+- `uploadToMux?: boolean` - Serialize the chapters to WebVTT and attach them as a `chapters` text track on the Mux asset (default: **false** — writeback is opt-in). Implies `uploadToS3: true`.
+- `uploadToS3?: boolean` - Upload the chapters VTT to S3-compatible storage and return a `presignedUrl` (default: the value of `uploadToMux`)
+- `s3Endpoint?: string` - S3-compatible storage endpoint
+- `s3Region?: string` - S3 region (default: 'auto')
+- `s3Bucket?: string` - S3 bucket name
+- `storageAdapter?: StorageAdapter` - Optional adapter with `putObject` and `createPresignedGetUrl` methods
+- `s3SignedUrlExpirySeconds?: number` - Expiry duration in seconds for S3 presigned GET URLs (default: 86400 / 24 hours)
 
 **Returns:**
 
@@ -508,9 +515,14 @@ Generates AI-powered chapter markers by analyzing video or audio transcripts. Cr
     startTime: number; // Chapter start time in seconds
     title: string; // Descriptive chapter title
   }>;
+  uploadedTrackId?: string; // Mux chapters track ID (when uploadToMux succeeded)
+  presignedUrl?: string; // Presigned GET URL of the uploaded VTT (when uploaded)
+  chaptersVtt?: string; // WebVTT serialization of the chapters (when uploaded)
   usage?: TokenUsage; // Token usage from the AI provider
 }
 ```
+
+**Writeback:** When `uploadToMux: true`, the chapters are serialized to a WebVTT chapters file (one cue per chapter, each ending at the next chapter's start; the last cue ends at the asset duration), uploaded to S3, and attached to the asset via the Mux CreateTrack API with `text_type: "chapters"`. Storage configuration (`s3Endpoint`/`s3Bucket` plus credentials, or a `storageAdapter`) is required when uploading.
 
 **Requirements:**
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -396,6 +396,17 @@ const player = document.querySelector("mux-player");
 player.addChapters(result.chapters);
 ```
 
+To write the chapters back to the asset as a `chapters` text track, opt in with `uploadToMux` (off by default):
+
+```typescript
+const result = await generateChapters("your-mux-asset-id", {
+  provider: "openai",
+  uploadToMux: true, // Serialize to WebVTT and attach a chapters track (default: false)
+});
+
+console.log(result.uploadedTrackId); // ID of the new chapters track on the Mux asset
+```
+
 ### Requirements
 
 - Asset must have a ready caption/transcript track

--- a/src/lib/mux-tracks.ts
+++ b/src/lib/mux-tracks.ts
@@ -37,3 +37,31 @@ export async function createTextTrackOnMux(
 
   return trackResponse.id;
 }
+
+export async function createChaptersTrackOnMux(
+  assetId: string,
+  languageCode: string,
+  trackName: string,
+  presignedUrl: string,
+  credentials?: WorkflowCredentialsInput,
+): Promise<string> {
+  "use step";
+  const muxClient = await resolveMuxClient(credentials);
+  const mux = await muxClient.createClient();
+  const trackResponse = await mux.video.assets.createTrack(assetId, {
+    type: "text",
+    // The Mux SDK's published types only declare `text_type: "subtitles"`,
+    // but the CreateTrack API accepts `chapters` (same code path captions
+    // use). Cast through `string` to reach the supported value.
+    text_type: "chapters" as unknown as "subtitles",
+    language_code: languageCode,
+    name: trackName,
+    url: presignedUrl,
+  });
+
+  if (!trackResponse.id) {
+    throw new Error("Failed to create chapters track: no track ID returned from Mux");
+  }
+
+  return trackResponse.id;
+}

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -451,6 +451,55 @@ export function secondsToTimestamp(seconds: number): string {
   return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
 }
 
+/**
+ * Formats a time in seconds as a WebVTT cue timestamp (`HH:MM:SS.mmm`).
+ *
+ * Unlike {@link secondsToTimestamp} (a human-facing `M:SS` / `HH:MM:SS`
+ * label), this emits the millisecond-precision form the WebVTT spec
+ * requires for the `-->` timing line. Mux track ingestion and
+ * web-native players both reject cue timings without the `.mmm` suffix.
+ */
+export function secondsToVttTimestamp(seconds: number): string {
+  const clamped = Math.max(0, seconds);
+  const totalMs = Math.round(clamped * 1000);
+  const hours = Math.floor(totalMs / 3_600_000);
+  const minutes = Math.floor((totalMs % 3_600_000) / 60_000);
+  const secs = Math.floor((totalMs % 60_000) / 1000);
+  const ms = totalMs % 1000;
+
+  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}.${ms.toString().padStart(3, "0")}`;
+}
+
+/**
+ * Serialises an ordered list of chapters into a WebVTT chapters file.
+ *
+ * Emits one cue per chapter: the cue spans from the chapter's start to
+ * the next chapter's start, and the final cue runs to
+ * `assetDurationSeconds` (falling back to a one-second cue when the
+ * duration is unknown or not after the last chapter's start). The cue
+ * payload is the chapter title.
+ *
+ * Chapters are expected to arrive sorted with non-decreasing start
+ * times (as `generateChapters` returns them). Any chapter whose
+ * computed end would not be strictly after its start is nudged forward
+ * by one millisecond so every cue stays well-formed.
+ */
+export function buildChaptersVtt(
+  chapters: Array<{ startTime: number; title: string }>,
+  assetDurationSeconds?: number,
+): string {
+  const cueBlocks = chapters.map((chapter, index) => {
+    const nextStart = index < chapters.length - 1 ?
+      chapters[index + 1].startTime :
+        (assetDurationSeconds ?? chapter.startTime + 1);
+    const end = nextStart > chapter.startTime ? nextStart : chapter.startTime + 0.001;
+
+    return `${secondsToVttTimestamp(chapter.startTime)} --> ${secondsToVttTimestamp(end)}\n${chapter.title}`;
+  });
+
+  return buildVttFromCueBlocks(cueBlocks);
+}
+
 export function extractTimestampedTranscript(vttContent: string): string {
   if (!vttContent.trim()) {
     return "";

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -2,6 +2,7 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
+import env from "../env.ts";
 import { getLanguageName } from "../lib/language-codes.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
 import {
@@ -9,6 +10,7 @@ import {
   getPlaybackIdForAsset,
   isAudioOnlyAsset,
 } from "../lib/mux-assets.ts";
+import { createChaptersTrackOnMux } from "../lib/mux-tracks.ts";
 import { createSafetyReporter, detectUnexpectedKeys, detectUnexpectedKeysFromRawText } from "../lib/output-safety.ts";
 import type { SafetyReport } from "../lib/output-safety.ts";
 import type { PromptOverrides, PromptSection } from "../lib/prompt-builder.ts";
@@ -21,14 +23,19 @@ import {
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "../lib/providers.ts";
 import type { ModelIdByProvider, SupportedProvider } from "../lib/providers.ts";
 import { withRetry } from "../lib/retry.ts";
+import {
+  createPresignedGetUrlWithStorageAdapter,
+  putObjectWithStorageAdapter,
+} from "../lib/storage-adapter.ts";
 import { resolveMuxSigningContext } from "../lib/workflow-credentials.ts";
 import {
+  buildChaptersVtt,
   extractTimestampedTranscript,
   fetchTranscriptForAsset,
   getReadyTextTracks,
   getReliableLanguageCode,
 } from "../primitives/transcripts.ts";
-import type { MuxAIOptions, TokenUsage, WorkflowCredentialsInput } from "../types.ts";
+import type { MuxAIOptions, StorageAdapter, TokenUsage, WorkflowCredentialsInput } from "../types.ts";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -69,6 +76,18 @@ export interface ChaptersResult {
   assetId: string;
   languageCode: string;
   chapters: Chapter[];
+  /**
+   * ID of the chapters text track created on the Mux asset.
+   * Present only when `uploadToMux` was enabled and track creation succeeded.
+   */
+  uploadedTrackId?: string;
+  /**
+   * Presigned GET URL of the uploaded chapters VTT.
+   * Present only when `uploadToS3` (or `uploadToMux`) was enabled.
+   */
+  presignedUrl?: string;
+  /** WebVTT serialisation of the chapters. Present when an upload was requested. */
+  chaptersVtt?: string;
   /** Token usage from the AI provider (for efficiency/cost analysis). */
   usage?: TokenUsage;
   /**
@@ -135,6 +154,35 @@ export interface ChaptersOptions extends MuxAIOptions {
    * Falls back to unconstrained (LLM decides) if no language metadata is available.
    */
   outputLanguageCode?: string;
+  /** Optional override for the S3-compatible endpoint used for uploads. */
+  s3Endpoint?: string;
+  /** S3 region (defaults to env.S3_REGION or 'auto'). */
+  s3Region?: string;
+  /** Bucket that will store the chapters VTT files. */
+  s3Bucket?: string;
+  /**
+   * When `true` the chapters VTT is uploaded to the configured
+   * S3-compatible bucket and a `presignedUrl` is returned.
+   * Defaults to the value of `uploadToMux` when omitted.
+   * Ignored (treated as `true`) when `uploadToMux` is `true`,
+   * since Mux track creation requires a presigned URL.
+   */
+  uploadToS3?: boolean;
+  /**
+   * When `true` the generated chapters are serialised to WebVTT and
+   * attached as a `chapters` text track on the Mux asset. Implies
+   * `uploadToS3: true` because a presigned URL is required for track
+   * creation.
+   *
+   * Defaults to `false`: unlike caption translation, chaptering is
+   * commonly used to read structured data back without mutating the
+   * asset, so writeback is opt-in.
+   */
+  uploadToMux?: boolean;
+  /** Optional storage adapter override for upload + presign operations. */
+  storageAdapter?: StorageAdapter;
+  /** Expiry duration in seconds for S3 presigned GET URLs. Defaults to 86400 (24 hours). */
+  s3SignedUrlExpirySeconds?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -363,6 +411,52 @@ function buildUserPrompt({
   return chaptersPromptBuilder.buildWithContext(mergedOverrides, contextSections);
 }
 
+async function uploadChaptersVttToS3({
+  chaptersVtt,
+  assetId,
+  s3Endpoint,
+  s3Region,
+  s3Bucket,
+  storageAdapter,
+  s3SignedUrlExpirySeconds,
+}: {
+  chaptersVtt: string;
+  assetId: string;
+  s3Endpoint: string;
+  s3Region: string;
+  s3Bucket: string;
+  storageAdapter?: StorageAdapter;
+  s3SignedUrlExpirySeconds?: number;
+}): Promise<string> {
+  "use step";
+
+  const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
+  const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
+
+  const vttKey = `chapters/${assetId}/${Date.now()}.vtt`;
+
+  await putObjectWithStorageAdapter({
+    accessKeyId: s3AccessKeyId,
+    secretAccessKey: s3SecretAccessKey,
+    endpoint: s3Endpoint,
+    region: s3Region,
+    bucket: s3Bucket,
+    key: vttKey,
+    body: chaptersVtt,
+    contentType: "text/vtt",
+  }, storageAdapter);
+
+  return createPresignedGetUrlWithStorageAdapter({
+    accessKeyId: s3AccessKeyId,
+    secretAccessKey: s3SecretAccessKey,
+    endpoint: s3Endpoint,
+    region: s3Region,
+    bucket: s3Bucket,
+    key: vttKey,
+    expiresInSeconds: s3SignedUrlExpirySeconds ?? 86400,
+  }, storageAdapter);
+}
+
 export async function generateChapters(
   assetId: string,
   options: ChaptersOptions = {},
@@ -377,7 +471,30 @@ export async function generateChapters(
     maxChaptersPerHour,
     credentials,
     outputLanguageCode,
+    s3Endpoint: providedS3Endpoint,
+    s3Region: providedS3Region,
+    s3Bucket: providedS3Bucket,
+    uploadToS3: uploadToS3Option,
+    uploadToMux: uploadToMuxOption,
+    storageAdapter,
+    s3SignedUrlExpirySeconds,
   } = options;
+
+  // Writeback is opt-in for chapters (default false), unlike caption
+  // translation. uploadToMux implies uploadToS3 because Mux track
+  // creation requires a presigned URL.
+  const uploadToMux = uploadToMuxOption === true;
+  const uploadToS3 = uploadToS3Option || uploadToMux;
+
+  const s3Endpoint = providedS3Endpoint ?? env.S3_ENDPOINT;
+  const s3Region = providedS3Region ?? env.S3_REGION ?? "auto";
+  const s3Bucket = providedS3Bucket ?? env.S3_BUCKET;
+  const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
+  const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
+
+  if (uploadToS3 && (!s3Endpoint || !s3Bucket || (!storageAdapter && (!s3AccessKeyId || !s3SecretAccessKey)))) {
+    throw new MuxAiError("Storage configuration is required for uploading. Provide s3Endpoint and s3Bucket. If no storageAdapter is supplied, also provide s3AccessKeyId and s3SecretAccessKey in options or set S3_ENDPOINT, S3_BUCKET, S3_ACCESS_KEY_ID, and S3_SECRET_ACCESS_KEY environment variables.", { type: "validation_error" });
+  }
 
   const modelConfig = resolveLanguageModelConfig({
     ...options,
@@ -535,10 +652,57 @@ export async function generateChapters(
     },
   };
 
+  const returnLanguageCode = languageCode ?? getReliableLanguageCode(transcriptResult.track) ?? "en";
+
+  // Optionally serialise the chapters to WebVTT, upload to S3, and
+  // attach them as a `chapters` track on the Mux asset. Mirrors the
+  // writeback path in translate-captions / edit-captions.
+  let chaptersVtt: string | undefined;
+  let presignedUrl: string | undefined;
+  let uploadedTrackId: string | undefined;
+
+  if (uploadToS3) {
+    chaptersVtt = buildChaptersVtt(scrubbedChapters, assetDurationSeconds);
+
+    try {
+      presignedUrl = await uploadChaptersVttToS3({
+        chaptersVtt,
+        assetId,
+        s3Endpoint: s3Endpoint!,
+        s3Region,
+        s3Bucket: s3Bucket!,
+        storageAdapter,
+        s3SignedUrlExpirySeconds,
+      });
+    } catch (error) {
+      wrapError(error, "Failed to upload chapters VTT to S3");
+    }
+
+    if (uploadToMux) {
+      try {
+        const languageName = getLanguageName(returnLanguageCode) ?? returnLanguageCode.toUpperCase();
+        const trackName = `${languageName} (auto-generated chapters)`;
+
+        uploadedTrackId = await createChaptersTrackOnMux(
+          assetId,
+          returnLanguageCode,
+          trackName,
+          presignedUrl,
+          credentials,
+        );
+      } catch (error) {
+        console.warn(`Failed to add chapters track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+      }
+    }
+  }
+
   return {
     assetId,
-    languageCode: languageCode ?? getReliableLanguageCode(transcriptResult.track) ?? "en",
+    languageCode: returnLanguageCode,
     chapters: scrubbedChapters,
+    uploadedTrackId,
+    presignedUrl,
+    chaptersVtt,
     usage: usageWithMetadata,
     safety: safety.report(),
   };

--- a/tests/unit/transcripts.test.ts
+++ b/tests/unit/transcripts.test.ts
@@ -2,6 +2,7 @@ import dedent from "dedent";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildChaptersVtt,
   buildVttFromCueBlocks,
   buildVttFromTranslatedCueBlocks,
   concatenateVttSegments,
@@ -11,6 +12,7 @@ import {
   LOW_CONFIDENCE_THRESHOLD,
   parseVTTCues,
   secondsToTimestamp,
+  secondsToVttTimestamp,
   splitVttPreambleAndCueBlocks,
   stripVttMetadataBlocks,
   vttTimestampToSeconds,
@@ -79,6 +81,63 @@ describe("secondsToTimestamp", () => {
     expect(secondsToTimestamp(60)).toBe("1:00");
     expect(secondsToTimestamp(120)).toBe("2:00");
     expect(secondsToTimestamp(180)).toBe("3:00");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// secondsToVttTimestamp
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("secondsToVttTimestamp", () => {
+  it("formats with millisecond precision and zero-padded hours", () => {
+    expect(secondsToVttTimestamp(0)).toBe("00:00:00.000");
+    expect(secondsToVttTimestamp(65)).toBe("00:01:05.000");
+    expect(secondsToVttTimestamp(45.5)).toBe("00:00:45.500");
+    expect(secondsToVttTimestamp(3661.25)).toBe("01:01:01.250");
+  });
+
+  it("clamps negatives to zero", () => {
+    expect(secondsToVttTimestamp(-5)).toBe("00:00:00.000");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildChaptersVtt
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildChaptersVtt", () => {
+  it("emits one cue per chapter, ending each at the next chapter's start", () => {
+    const vtt = buildChaptersVtt(
+      [
+        { startTime: 0, title: "Introduction" },
+        { startTime: 45.5, title: "Main Topic" },
+        { startTime: 120, title: "Conclusion" },
+      ],
+      180,
+    );
+
+    expect(vtt).toBe(`${dedent`
+      WEBVTT
+
+      00:00:00.000 --> 00:00:45.500
+      Introduction
+
+      00:00:45.500 --> 00:02:00.000
+      Main Topic
+
+      00:02:00.000 --> 00:03:00.000
+      Conclusion
+    `}\n`);
+  });
+
+  it("falls back to a one-second final cue when duration is unknown", () => {
+    const vtt = buildChaptersVtt([{ startTime: 0, title: "Only" }]);
+    expect(vtt).toContain("00:00:00.000 --> 00:00:01.000");
+  });
+
+  it("nudges the end forward when duration is not after the last start", () => {
+    const vtt = buildChaptersVtt([{ startTime: 10, title: "Late" }], 5);
+    expect(vtt).toContain("00:00:10.000 --> 00:00:10.001");
   });
 });
 


### PR DESCRIPTION
# Overview

Adds optional Mux Video writeback to the `generateChapters` workflow. Previously `generateChapters` only returned structured `{startTime, title}` data; it can now serialize those chapters to WebVTT and attach them to the asset as a `chapters` text track, mirroring the existing writeback path in `translateCaptions` / `editCaptions`.

Writeback is **opt-in** (`uploadToMux` defaults to `false`) to preserve backward compatibility — existing callers without S3 config are unaffected. All changes live in `@mux/ai`; no Mux Video API changes are required.

# What was changed

- **`src/primitives/transcripts.ts`** — The only genuinely new logic:
  - `secondsToVttTimestamp()`: millisecond-precision `HH:MM:SS.mmm` formatter (the existing `secondsToTimestamp` emits human labels like `1:05`, invalid for VTT cue timing).
  - `buildChaptersVtt()`: serializes chapters to a WebVTT chapters file — one cue per chapter, each ending at the next chapter's start; the last cue ends at asset duration (1s fallback when duration is unknown/invalid).
- **`src/lib/mux-tracks.ts`** — `createChaptersTrackOnMux()`: calls Mux CreateTrack with `text_type: "chapters"`. The SDK's TS type only declares `'subtitles'`, so the required cast is isolated here with a comment.
- **`src/workflows/chapters.ts`** — Threads `uploadToMux` / `uploadToS3` / S3 config / `storageAdapter` through `ChaptersOptions`; adds the `uploadChaptersVttToS3` step; surfaces `uploadedTrackId`, `presignedUrl`, and `chaptersVtt` on `ChaptersResult`. `uploadToMux` implies `uploadToS3`; storage config is validated up front when uploading.
- **`tests/unit/transcripts.test.ts`** — Unit coverage for `secondsToVttTimestamp` and `buildChaptersVtt`, including the duration-fallback and degenerate-end edge cases.
- **`docs/API.md`, `docs/WORKFLOWS.md`** — Document the new options, return fields, and an opt-in writeback example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mutates Mux assets and depends on S3 credentials when opted in; Mux track creation can fail silently while still returning chapters, which callers should handle.
> 
> **Overview**
> **`generateChapters`** can now optionally persist AI chapters instead of only returning `{ startTime, title }` arrays. Writeback is **opt-in** (`uploadToMux` defaults to `false`), so existing callers without storage config stay unchanged.
> 
> When **`uploadToS3`** and/or **`uploadToMux`** is enabled, the workflow serializes scrubbed chapters to WebVTT, uploads to S3 (with the same endpoint/bucket/`storageAdapter` pattern as caption workflows), and can attach a **`chapters`** text track on the asset via Mux CreateTrack. **`uploadToMux`** implies S3 upload because track ingestion needs a presigned URL. New return fields: `chaptersVtt`, `presignedUrl`, and `uploadedTrackId` (Mux track creation failures are logged, not thrown).
> 
> New primitives **`secondsToVttTimestamp`** and **`buildChaptersVtt`** produce spec-valid cue timings and chapter spans (next chapter start / asset duration, with edge-case nudges). **`createChaptersTrackOnMux`** isolates the SDK type cast for `text_type: "chapters"`. Docs and unit tests cover the VTT builders and API options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674ba451e1b0da1fff4b705d294cd1cb2993f31d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->