### PR TITLE
chore: support edit captions grammar corrections

### DIFF
--- a/src/primitives/heatmap.ts
+++ b/src/primitives/heatmap.ts
@@ -122,7 +122,7 @@ async function fetchHeatmap(
 
   // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
   const path = `/data/v1/engagement/${identifierType}/${id}/heatmap?${queryParams.toString()}`;
-  const response = await mux.get<unknown, HeatmapApiResponse>(path);
+  const response = await mux.get(path) as HeatmapApiResponse;
 
   return transformHeatmapResponse(response);
 }

--- a/src/primitives/heatmap.ts
+++ b/src/primitives/heatmap.ts
@@ -122,7 +122,7 @@ async function fetchHeatmap(
 
   // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
   const path = `/data/v1/engagement/${identifierType}/${id}/heatmap?${queryParams.toString()}`;
-  const response = await mux.get<HeatmapApiResponse>(path);
+  const response = await mux.get<unknown, HeatmapApiResponse>(path);
 
   return transformHeatmapResponse(response);
 }

--- a/src/primitives/hotspots.ts
+++ b/src/primitives/hotspots.ts
@@ -146,7 +146,7 @@ async function fetchHotspots(
 
   // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
   const path = `/data/v1/engagement/${identifierType}/${id}/hotspots?${queryParams.toString()}`;
-  const response = await mux.get<HotspotApiResponse>(path);
+  const response = await mux.get<unknown, HotspotApiResponse>(path);
 
   return transformHotspotResponse(response);
 }

--- a/src/primitives/hotspots.ts
+++ b/src/primitives/hotspots.ts
@@ -146,7 +146,7 @@ async function fetchHotspots(
 
   // Use the raw HTTP method since the SDK doesn't have typed engagement methods yet
   const path = `/data/v1/engagement/${identifierType}/${id}/hotspots?${queryParams.toString()}`;
-  const response = await mux.get<unknown, HotspotApiResponse>(path);
+  const response = await mux.get(path) as HotspotApiResponse;
 
   return transformHotspotResponse(response);
 }

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -184,7 +184,7 @@ export async function requestShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.post<ShotsApiResponse>(
+  const response = await mux.post<Record<string, never>, ShotsApiResponse>(
     getShotsPath(assetId),
     { body: {} },
   );
@@ -214,7 +214,7 @@ export async function getShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.get<ShotsApiResponse>(
+  const response = await mux.get<unknown, ShotsApiResponse>(
     getShotsPath(assetId),
   );
 

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -184,10 +184,10 @@ export async function requestShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.post<Record<string, never>, ShotsApiResponse>(
+  const response = await mux.post(
     getShotsPath(assetId),
     { body: {} },
-  );
+  ) as ShotsApiResponse;
   const result = await transformShotsResponse(response);
 
   if (result.status !== "pending") {
@@ -214,9 +214,9 @@ export async function getShotsForAsset(
   const { credentials } = options;
   const muxClient = await getMuxClientFromEnv(credentials);
   const mux = await muxClient.createClient();
-  const response = await mux.get<unknown, ShotsApiResponse>(
+  const response = await mux.get(
     getShotsPath(assetId),
-  );
+  ) as ShotsApiResponse;
 
   return await transformShotsResponse(response);
 }

--- a/src/primitives/transcripts.ts
+++ b/src/primitives/transcripts.ts
@@ -6,6 +6,10 @@ import { normalizeUntrustedUnicode } from "../lib/output-safety.ts";
 import { signUrl } from "../lib/url-signing.ts";
 import type { AssetTextTrack, MuxAsset, WorkflowCredentialsInput } from "../types.ts";
 
+type TrackWithAutoLanguageConfidence = AssetTextTrack & {
+  auto_language_confidence?: number;
+};
+
 /** A single cue from a VTT file with timing info. */
 export interface VTTCue {
   startTime: number;
@@ -98,8 +102,9 @@ export function getReliableLanguageCode(
     return undefined;
   if (isUndeterminedLanguageCode(track.language_code))
     return undefined;
-  if (track.auto_language_confidence !== undefined &&
-    track.auto_language_confidence < confidenceThreshold) {
+  const { auto_language_confidence: autoLanguageConfidence } = track as TrackWithAutoLanguageConfidence;
+  if (autoLanguageConfidence !== undefined &&
+    autoLanguageConfidence < confidenceThreshold) {
     return undefined;
   }
   return track.language_code;

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -215,6 +215,74 @@ export function transformCueText(
   return transformed.join("\n");
 }
 
+function transformCueTextBlocks(
+  rawVtt: string,
+  transform: (cueText: string, cueStartTime: number) => string,
+): string {
+  const lines = rawVtt.split("\n");
+  const transformed: string[] = [];
+  let cueTextLines: string[] | undefined;
+  let currentCueStartTime = 0;
+
+  const flushCueText = () => {
+    if (!cueTextLines)
+      return;
+
+    if (cueTextLines.length > 0) {
+      transformed.push(...transform(cueTextLines.join("\n"), currentCueStartTime).split("\n"));
+    }
+    cueTextLines = undefined;
+  };
+
+  for (const line of lines) {
+    if (line.includes("-->")) {
+      flushCueText();
+      const startTimestamp = line.split("-->")[0].trim();
+      currentCueStartTime = vttTimestampToSeconds(startTimestamp);
+      transformed.push(line);
+      cueTextLines = [];
+      continue;
+    }
+
+    if (cueTextLines) {
+      if (line.trim() === "") {
+        flushCueText();
+        transformed.push(line);
+      } else {
+        cueTextLines.push(line);
+      }
+      continue;
+    }
+
+    transformed.push(line);
+  }
+
+  flushCueText();
+
+  return transformed.join("\n");
+}
+
+function escapeRegex(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function buildStaticReplacementRegex(find: string, caseSensitive?: boolean): RegExp {
+  const pattern = find
+    .split(/(\s+)/)
+    .map(part => /\s+/.test(part) ? "\\s+" : escapeRegex(part))
+    .join("");
+  const firstNonWhitespaceIndex = find.search(/\S/);
+  const firstNonWhitespace = firstNonWhitespaceIndex >= 0 ? find[firstNonWhitespaceIndex] : undefined;
+  const lastNonWhitespaceMatch = /\S(?=\s*$)/.exec(find);
+  const lastNonWhitespace = lastNonWhitespaceMatch?.[0];
+  const startsAtTextBoundary = firstNonWhitespaceIndex === 0 && !!firstNonWhitespace && /\w/.test(firstNonWhitespace);
+  const endsAtTextBoundary = !!lastNonWhitespace && find.trimEnd().length === find.length;
+  const prefix = startsAtTextBoundary ? "(?<!\\w)" : "";
+  const suffix = endsAtTextBoundary ? "(?!\\w)" : "";
+  const flags = caseSensitive === false ? "gi" : "g";
+  return new RegExp(`${prefix}${pattern}${suffix}`, flags);
+}
+
 /**
  * Builds a case-insensitive word-boundary regex from an array of profane words.
  * Words are sorted longest-first so multi-word phrases match before individual words.
@@ -228,7 +296,7 @@ export function buildReplacementRegex(words: string[]): RegExp | null {
   filtered.sort((a, b) => b.length - a.length);
 
   // Escape regex special characters in each word
-  const escaped = filtered.map(w => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const escaped = filtered.map(escapeRegex);
 
   const pattern = escaped.join("|");
   return new RegExp(`\\b(?:${pattern})\\b`, "gi");
@@ -308,12 +376,14 @@ export function applyOverrideLists(
 }
 
 /**
- * Applies static find/replace pairs to cue text lines in raw VTT content
- * using word-boundary regex. Defaults to case-sensitive matching since static
- * replacements typically target specific known strings; each entry may opt
- * into case-insensitive matching via `caseSensitive: false`. Headers,
- * timestamps, and cue identifiers are untouched. Returns the edited VTT and
- * the total number of replacements.
+ * Applies static find/replace pairs to cue text blocks in raw VTT content.
+ * Whitespace in the find string can match VTT line wrapping, and matches are
+ * constrained by text boundaries to avoid replacing substrings inside words.
+ * Defaults to case-sensitive matching since static replacements typically
+ * target specific known strings; each entry may opt into case-insensitive
+ * matching via `caseSensitive: false`. Headers, timestamps, and cue
+ * identifiers are untouched. Returns the edited VTT and the total number of
+ * replacements.
  */
 export function applyReplacements(
   rawVtt: string,
@@ -326,12 +396,10 @@ export function applyReplacements(
 
   const records: ReplacementRecord[] = [];
 
-  const editedVtt = transformCueText(rawVtt, (line, cueStartTime) => {
-    let result = line;
+  const editedVtt = transformCueTextBlocks(rawVtt, (cueText, cueStartTime) => {
+    let result = cueText;
     for (const { find, replace, caseSensitive } of filtered) {
-      const escaped = find.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      const flags = caseSensitive === false ? "gi" : "g";
-      const regex = new RegExp(`\\b${escaped}\\b`, flags);
+      const regex = buildStaticReplacementRegex(find, caseSensitive);
       result = result.replace(regex, (match) => {
         records.push({ cueStartTime, before: match, after: replace });
         return replace;

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -276,7 +276,7 @@ function buildStaticReplacementRegex(find: string, caseSensitive?: boolean): Reg
   const lastNonWhitespaceMatch = /\S(?=\s*$)/.exec(find);
   const lastNonWhitespace = lastNonWhitespaceMatch?.[0];
   const startsAtTextBoundary = firstNonWhitespaceIndex === 0 && !!firstNonWhitespace && /\w/.test(firstNonWhitespace);
-  const endsAtTextBoundary = !!lastNonWhitespace && find.trimEnd().length === find.length;
+  const endsAtTextBoundary = !!lastNonWhitespace && find.trimEnd().length === find.length && /\w/.test(lastNonWhitespace);
   const prefix = startsAtTextBoundary ? "(?<!\\w)" : "";
   const suffix = endsAtTextBoundary ? "(?!\\w)" : "";
   const flags = caseSensitive === false ? "gi" : "g";
@@ -377,8 +377,8 @@ export function applyOverrideLists(
 
 /**
  * Applies static find/replace pairs to cue text blocks in raw VTT content.
- * Whitespace in the find string can match VTT line wrapping, and matches are
- * constrained by text boundaries to avoid replacing substrings inside words.
+ * Whitespace in the find string can match VTT line wrapping, and word-character
+ * edges are constrained to avoid replacing substrings inside words.
  * Defaults to case-sensitive matching since static replacements typically
  * target specific known strings; each entry may opt into case-insensitive
  * matching via `caseSensitive: false`. Headers, timestamps, and cue

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -266,6 +266,11 @@ function escapeRegex(text: string): string {
   return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Matches the given text literally, treats whitespace flexibly, optionally
+ * ignores case, and avoids matching inside larger words when the search text
+ * starts or ends with word characters.
+ */
 function buildStaticReplacementRegex(find: string, caseSensitive?: boolean): RegExp {
   const pattern = find
     .split(/(\s+)/)

--- a/tests/unit/edit-captions.test.ts
+++ b/tests/unit/edit-captions.test.ts
@@ -499,6 +499,23 @@ describe("applyReplacements", () => {
     });
   });
 
+  it("matches punctuation-ended replacements followed immediately by letters", () => {
+    const vtt = [
+      "WEBVTT",
+      "",
+      "00:00:01.000 --> 00:00:04.000",
+      "This timeline,and this U.S.A mention Dr.Smith.",
+    ].join("\n");
+    const { editedVtt, replacements } = applyReplacements(vtt, [
+      { find: "timeline,", replace: "timeline:" },
+      { find: "U.S.", replace: "United States " },
+      { find: "Dr.", replace: "Doctor " },
+    ]);
+    expect(editedVtt).toContain("This timeline:and this United States A mention Doctor Smith.");
+    expect(replacements).toHaveLength(3);
+    expect(replacements.map(r => r.before)).toEqual(["timeline,", "U.S.", "Dr."]);
+  });
+
   it("matches phrase replacements across line-wrapped cue text", () => {
     const vtt = [
       "WEBVTT",

--- a/tests/unit/edit-captions.test.ts
+++ b/tests/unit/edit-captions.test.ts
@@ -480,6 +480,45 @@ describe("applyReplacements", () => {
     expect(replacements).toHaveLength(1);
   });
 
+  it("matches phrase replacements that end with punctuation", () => {
+    const vtt = [
+      "WEBVTT",
+      "",
+      "00:00:01.000 --> 00:00:04.000",
+      "This is one long timeline, and it needs punctuation fixed.",
+    ].join("\n");
+    const { editedVtt, replacements } = applyReplacements(vtt, [
+      { find: "one long timeline,", replace: "one long timeline:", caseSensitive: false },
+    ]);
+    expect(editedVtt).toContain("This is one long timeline: and it needs punctuation fixed.");
+    expect(replacements).toHaveLength(1);
+    expect(replacements[0]).toEqual({
+      cueStartTime: 1,
+      before: "one long timeline,",
+      after: "one long timeline:",
+    });
+  });
+
+  it("matches phrase replacements across line-wrapped cue text", () => {
+    const vtt = [
+      "WEBVTT",
+      "",
+      "00:00:01.000 --> 00:00:04.000",
+      "This is one long",
+      "timeline, and it needs punctuation fixed.",
+    ].join("\n");
+    const { editedVtt, replacements } = applyReplacements(vtt, [
+      { find: "one long timeline,", replace: "one long timeline:", caseSensitive: false },
+    ]);
+    expect(editedVtt).toContain("This is one long timeline: and it needs punctuation fixed.");
+    expect(replacements).toHaveLength(1);
+    expect(replacements[0]).toEqual({
+      cueStartTime: 1,
+      before: "one long\ntimeline,",
+      after: "one long timeline:",
+    });
+  });
+
   it("returns original when no replacements match", () => {
     const { editedVtt, replacements } = applyReplacements(sampleVtt, [
       { find: "nonexistent", replace: "something" },


### PR DESCRIPTION
# Overview

Improves static find/replace in the edit-captions workflow so grammar-style corrections work on multi-line cues and phrases that end with punctuation (e.g. `"one long timeline,"` → `"one long timeline:"`). Also includes small type-check fixes in Mux primitives and transcript language handling.

# What was changed

- **`src/workflows/edit-captions.ts`** — `applyReplacements` now operates on full cue text blocks instead of individual lines. New helpers: `transformCueTextBlocks` (joins wrapped cue lines before matching), `buildStaticReplacementRegex` (flexible whitespace + text-boundary matching for punctuation), and shared `escapeRegex`.
- **`tests/unit/edit-captions.test.ts`** — Two tests covering punctuation-ending phrases and matches across line-wrapped cue text.
- **`src/primitives/{heatmap,hotspots,shots}.ts`** — Replaced `mux.get<T>` / `mux.post<T>` generics with post-call `as T` assertions (SDK typing fix).
- **`src/primitives/transcripts.ts`** — Reads `auto_language_confidence` via a narrow intersection type instead of accessing it directly on `AssetTextTrack`.

# Suggested review order

1. `src/workflows/edit-captions.ts` — core logic: `transformCueTextBlocks`, `buildStaticReplacementRegex`, and the updated `applyReplacements`.
2. `tests/unit/edit-captions.test.ts` — new punctuation and line-wrap cases; confirm they match intended behavior.
3. `src/primitives/transcripts.ts` — small type-narrowing change for `auto_language_confidence`.
4. `src/primitives/{heatmap,hotspots,shots}.ts` — mechanical type-assertion swap; low risk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Caption replacement behavior changes are localized to static replacements with new unit tests; primitive changes are compile-time typing only.
> 
> **Overview**
> **Static find/replace in `editCaptions`** now runs on whole cue text blocks instead of single lines, so grammar-style fixes can match phrases that wrap across VTT lines and strings ending in punctuation (e.g. `one long timeline,` → `one long timeline:`). Matching uses flexible whitespace and boundary rules that only apply word edges when the search text starts/ends with word characters, so abbreviations like `Dr.` and `U.S.` still replace correctly.
> 
> **Tests** add coverage for punctuation-ended phrases, tight punctuation adjacency, and line-wrapped cues.
> 
> **Mux primitives** swap `mux.get<T>` / `mux.post<T>` for post-call `as T` on heatmap, hotspots, and shots. **`getReliableLanguageCode`** reads `auto_language_confidence` through a narrow intersection type on `AssetTextTrack`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a98dde0d1950e7a62b50d3c47b41c737a49ee69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->