### PR TITLE
chore: bump version to 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Overview


Bumping sdk version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no application or library code changes.
> 
> **Overview**
> Bumps the **`@mux/ai`** package version from **0.23.0** to **0.24.0** in `package.json` and `package-lock.json` for the next SDK release. No runtime, API, or dependency changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835ff82b093c4c7a890a5da0ed903a2123345d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->