### PR TITLE
chore: update shots naming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -72,7 +72,9 @@ interface ShotsApiResponse {
 interface ShotsManifestResponse {
   shots: Array<{
     start_time: number;
-    shot_preview_image_url: string;
+    shot_preview_image_url?: string;
+    /** @deprecated Replaced by shot_preview_image_url. Will be removed in a future manifest version. */
+    image_url?: string;
   }>;
 }
 
@@ -88,8 +90,15 @@ function getShotsPath(assetId: string): string {
 function mapManifestShots(
   shots: ShotsManifestResponse["shots"],
 ): Shot[] {
-  return shots.map((shot, index) => {
-    const { start_time: startTime, shot_preview_image_url: imageUrl } = shot;
+  let usedDeprecatedField = false;
+
+  const mapped = shots.map((shot, index) => {
+    const { start_time: startTime } = shot;
+    const imageUrl = shot.shot_preview_image_url ?? shot.image_url;
+
+    if (shot.shot_preview_image_url === undefined && shot.image_url !== undefined) {
+      usedDeprecatedField = true;
+    }
 
     if (typeof startTime !== "number" || !Number.isFinite(startTime)) {
       throw new TypeError(`Invalid shot start_time in shots manifest at index ${index}`);
@@ -104,6 +113,14 @@ function mapManifestShots(
       imageUrl,
     };
   });
+
+  if (usedDeprecatedField) {
+    console.warn(
+      "The 'image_url' field in the Mux shots manifest is deprecated and will be removed. Use 'shot_preview_image_url' instead.",
+    );
+  }
+
+  return mapped;
 }
 
 async function fetchShotsFromManifest(

--- a/src/primitives/shots.ts
+++ b/src/primitives/shots.ts
@@ -72,7 +72,7 @@ interface ShotsApiResponse {
 interface ShotsManifestResponse {
   shots: Array<{
     start_time: number;
-    image_url: string;
+    shot_preview_image_url: string;
   }>;
 }
 
@@ -89,14 +89,14 @@ function mapManifestShots(
   shots: ShotsManifestResponse["shots"],
 ): Shot[] {
   return shots.map((shot, index) => {
-    const { start_time: startTime, image_url: imageUrl } = shot;
+    const { start_time: startTime, shot_preview_image_url: imageUrl } = shot;
 
     if (typeof startTime !== "number" || !Number.isFinite(startTime)) {
       throw new TypeError(`Invalid shot start_time in shots manifest at index ${index}`);
     }
 
     if (typeof imageUrl !== "string" || imageUrl.length === 0) {
-      throw new TypeError(`Invalid shot image_url in shots manifest at index ${index}`);
+      throw new TypeError(`Invalid shot shot_preview_image_url in shots manifest at index ${index}`);
     }
 
     return {

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -36,11 +36,11 @@ const MOCK_SHOTS_MANIFEST = {
   shots: [
     {
       start_time: 0.0416667,
-      image_url: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=first",
+      shot_preview_image_url: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=first",
     },
     {
       start_time: 2.75,
-      image_url: "https://stream.mux.com/aicontext/test-asset/shot_1.webp?signature=second",
+      shot_preview_image_url: "https://stream.mux.com/aicontext/test-asset/shot_1.webp?signature=second",
     },
   ],
 };

--- a/tests/unit/shots.test.ts
+++ b/tests/unit/shots.test.ts
@@ -153,6 +153,36 @@ describe("getShotsForAsset", () => {
     });
   });
 
+  it("falls back to the deprecated image_url field with a warning", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockMuxGet.mockResolvedValue(MOCK_COMPLETED_RESPONSE);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        shots: [
+          {
+            start_time: 0.0416667,
+            image_url: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=legacy",
+          },
+        ],
+      }),
+    });
+
+    const result = await getShotsForAsset("test-asset-123");
+
+    expect(result).toEqual({
+      status: "completed",
+      createdAt: "1773108428",
+      shots: [
+        {
+          startTime: 0.0416667,
+          imageUrl: "https://stream.mux.com/aicontext/test-asset/shot_0.webp?signature=legacy",
+        },
+      ],
+    });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("image_url"));
+  });
+
   it("returns transformed errored result", async () => {
     mockMuxGet.mockResolvedValue(MOCK_ERRORED_RESPONSE);
 


### PR DESCRIPTION
Shots API response URL is changing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to manifest parsing with backward compatibility; no auth or API contract changes for consumers of `Shot.imageUrl`.
> 
> **Overview**
> Bumps **@mux/ai** to **0.25.0** and updates shots manifest parsing for Mux’s renamed preview URL field.
> 
> **`mapManifestShots`** now reads **`shot_preview_image_url`** from the manifest (with optional deprecated **`image_url`** fallback). Legacy manifests still work but emit a **`console.warn`**. The public **`Shot.imageUrl`** shape is unchanged; only manifest field names and validation/error messaging were updated.
> 
> Unit tests use the new field and add coverage for the deprecated **`image_url`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b310d6a623f7011c10e5dd70a05da03cd5c694ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->