### PR TITLE
feat: Normalize generated markdown descriptions

### DIFF
--- a/src/lib/markdown-normalization.ts
+++ b/src/lib/markdown-normalization.ts
@@ -1,0 +1,15 @@
+const ESCAPED_LINE_BREAK_REGEX = /\\r\\n|\\n|\\r/g;
+const MULTIPLE_BLANK_LINES_REGEX = /\n{3,}/g;
+
+/**
+ * Normalizes common markdown formatting defects seen in structured-output
+ * string fields. Some providers occasionally return literal escaped line
+ * breaks or collapse generated list items into a single paragraph.
+ */
+export function normalizeMarkdownDescription(description: string): string {
+  return description
+    .replace(ESCAPED_LINE_BREAK_REGEX, "\n")
+    .replace(/([^\n]) {2,}([*-]) (?=\S)/g, "$1\n$2 ")
+    .replace(/([.!?:;]) ([*-]) (?=\S)/g, "$1\n$2 ")
+    .replace(MULTIPLE_BLANK_LINES_REGEX, "\n\n");
+}

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { ImageDownloadOptions } from "../lib/image-download.ts";
 import { downloadImageAsBase64 } from "../lib/image-download.ts";
 import { getLanguageName } from "../lib/language-codes.ts";
+import { normalizeMarkdownDescription } from "../lib/markdown-normalization.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
 import {
   getAssetDurationSecondsFromAsset,
@@ -863,7 +864,8 @@ export async function getSummaryAndTags(
   }
 
   const scrubbedTitle = safety.scrub(analysisResponse.result.title, "title");
-  const scrubbedDescription = safety.scrub(analysisResponse.result.description, "description");
+  const normalizedDescription = normalizeMarkdownDescription(analysisResponse.result.description);
+  const scrubbedDescription = safety.scrub(normalizedDescription, "description");
   const scrubbedKeywords = (analysisResponse.result.keywords ?? [])
     .map((kw, i) => safety.scrubDetailed(kw, `keywords[${i}]`))
     .filter(result => !result.leaked)

--- a/tests/unit/markdown-normalization.test.ts
+++ b/tests/unit/markdown-normalization.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeMarkdownDescription } from "../../src/lib/markdown-normalization";
+
+describe("normalizeMarkdownDescription", () => {
+  it("converts literal escaped line breaks to real newlines", () => {
+    const description = "Overview.\\n\\n**Target groups:** core\\n\\n**Technique:**\\n* Brace\\n* Stand tall";
+
+    expect(normalizeMarkdownDescription(description)).toBe(
+      "Overview.\n\n**Target groups:** core\n\n**Technique:**\n* Brace\n* Stand tall",
+    );
+  });
+
+  it("restores obvious inline markdown bullet boundaries", () => {
+    const description = "Overview sentence.  * Target areas: shoulders and core. * Technique:  - Brace the torso. - Move smoothly. * Common mistakes: - Rushing reps.";
+
+    expect(normalizeMarkdownDescription(description)).toBe(
+      "Overview sentence.\n* Target areas: shoulders and core.\n* Technique:\n- Brace the torso.\n- Move smoothly.\n* Common mistakes:\n- Rushing reps.",
+    );
+  });
+
+  it("leaves ordinary prose and single-space hyphenated phrases alone", () => {
+    const description = "A low - impact movement with steady pacing. Equipment is optional.";
+
+    expect(normalizeMarkdownDescription(description)).toBe(description);
+  });
+});


### PR DESCRIPTION
# Overview

Fixes malformed markdown in summarization descriptions returned by some LLM providers. Structured-output fields sometimes arrive with literal `\n` escapes or bullet lists collapsed into a single line; this branch normalizes those before safety scrubbing so descriptions render correctly downstream.

# What was changed

- **`src/lib/markdown-normalization.ts`** — New `normalizeMarkdownDescription()` helper that:
  - Converts escaped line breaks (`\n`, `\r`, `\r\n`) to real newlines
  - Splits inline bullet markers (`*` / `-`) back onto their own lines when preceded by sentence punctuation or double spaces
  - Collapses runs of 3+ blank lines to a single paragraph break
- **`src/workflows/summarization.ts`** — Applies normalization to `analysisResponse.result.description` before `safety.scrub()` in `getSummaryAndTags()`.
- **`tests/unit/markdown-normalization.test.ts`** — Unit tests for escaped newlines, inline bullet restoration, and a negative case (hyphenated prose left untouched).

# Suggested review order

1. `tests/unit/markdown-normalization.test.ts` — Expected inputs/outputs define the intended behavior.
2. `src/lib/markdown-normalization.ts` — Regex logic; confirm heuristics don't over-split ordinary prose.
3. `src/workflows/summarization.ts` — Single integration point (normalize → scrub); verify ordering is correct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized post-processing on user-facing description text only; no auth, schema, or safety-rule changes beyond running scrub on normalized strings.
> 
> **Overview**
> Summarization **descriptions** are normalized before output-safety scrubbing so common LLM structured-output glitches render as real markdown downstream.
> 
> A new `normalizeMarkdownDescription` helper turns literal `\n`/`\r` escapes into newlines, splits collapsed `*`/`-` list markers back onto their own lines (after punctuation or double spaces), and trims runs of 3+ blank lines to a single paragraph break. `getSummaryAndTags` runs this on the model description, then passes the result to `safety.scrub()` as before.
> 
> Unit tests cover escaped newlines, inline bullet repair, and a case where hyphenated prose is left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c21efc21afee52242916bd85c2abbcd45e71b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->