### PR TITLE
chore: bump to v0.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
minor bump

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only manifest version fields change; no runtime or library behavior is modified.
> 
> **Overview**
> Bumps the published **`@mux/ai`** package version from **0.25.0** to **0.26.0** in `package.json` and the root entry in `package-lock.json`. No dependency, source, or API changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0612c1d71b651d34574a3c75c317935ac0fe2ec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->