### PR TITLE
chore: pin npm version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,10 @@ jobs:
           node-version: 22.22.1 # Pinned: 22.22.2 has broken npm (nodejs/node#62425)
           cache: npm
 
-      - name: Update npm to latest
-        run: npm install -g npm@latest
+      - name: Update npm to 11
+        # npm >= 11.5.1 required for OIDC trusted publishing; npm 12 requires node >= 22.22.2,
+        # which conflicts with the node pin above
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only npm version pinning plus a patch version bump; no runtime library code changes.
> 
> **Overview**
> The **publish** workflow no longer upgrades to `npm@latest`; it installs **`npm@11`** so releases meet **npm ≥ 11.5.1** for OIDC trusted publishing while staying compatible with the pinned **Node 22.22.1** (npm 12 would require Node ≥ 22.22.2, which is avoided because 22.22.2 ships a broken npm).
> 
> Package version is bumped **0.27.0 → 0.27.1** in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bcbefdd63a82d1e856a0f22fb29125fcbd445ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->