### PR TITLE
chore: update translate-audio timeout

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -550,6 +550,7 @@ Creates AI-dubbed audio tracks from existing media content using ElevenLabs voic
 - `s3Bucket?: string` - S3 bucket name
 - `storageAdapter?: StorageAdapter` - Optional adapter with `putObject` and `createPresignedGetUrl` methods
 - `s3SignedUrlExpirySeconds?: number` - Expiry duration in seconds for S3 presigned GET URLs (default: 86400 / 24 hours)
+- `dubbingPollTimeoutSeconds?: number` - Max time to wait for ElevenLabs to finish dubbing before timing out (default: 7200 / 2 hours). Raise for long-form content or when jobs queue behind the concurrency limit.
 
 **Returns:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.27.1",
+      "version": "0.28.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -77,13 +77,7 @@ export interface AudioTranslationOptions extends MuxAIOptions {
   storageAdapter?: StorageAdapter;
   /** Expiry duration in seconds for S3 presigned GET URLs. Defaults to 86400 (24 hours). */
   s3SignedUrlExpirySeconds?: number;
-  /**
-   * Maximum time in seconds to wait for ElevenLabs to finish dubbing before
-   * timing out. Long-form assets — and jobs queued behind ElevenLabs'
-   * concurrency limit — can take well over 30 minutes. Defaults to 7200
-   * (2 hours). Durable sleep makes waiting free, so raise this for very long
-   * content rather than letting a still-processing job fail.
-   */
+  /** Maximum time in seconds to wait before timing out. Defaults to 7200 (2 hours). */
   dubbingPollTimeoutSeconds?: number;
 }
 

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -77,6 +77,14 @@ export interface AudioTranslationOptions extends MuxAIOptions {
   storageAdapter?: StorageAdapter;
   /** Expiry duration in seconds for S3 presigned GET URLs. Defaults to 86400 (24 hours). */
   s3SignedUrlExpirySeconds?: number;
+  /**
+   * Maximum time in seconds to wait for ElevenLabs to finish dubbing before
+   * timing out. Long-form assets — and jobs queued behind ElevenLabs'
+   * concurrency limit — can take well over 30 minutes. Defaults to 7200
+   * (2 hours). Durable sleep makes waiting free, so raise this for very long
+   * content rather than letting a still-processing job fail.
+   */
+  dubbingPollTimeoutSeconds?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -85,6 +93,9 @@ export interface AudioTranslationOptions extends MuxAIOptions {
 
 const STATIC_RENDITION_POLL_INTERVAL_MS = 5000;
 const STATIC_RENDITION_MAX_ATTEMPTS = 36; // ~3 minutes
+
+const DUBBING_POLL_INTERVAL_MS = 10_000;
+const DEFAULT_DUBBING_POLL_TIMEOUT_SECONDS = 7200; // 2 hours; override via options.dubbingPollTimeoutSeconds
 
 function getReadyAudioStaticRendition(asset: any) {
   const files = asset.static_renditions?.files as any[] | undefined;
@@ -484,13 +495,15 @@ export async function translateAudio(
   // Poll for completion. ElevenLabs added intermediate dubbing states
   console.warn("⏳ Waiting for dubbing to complete...");
 
+  const dubbingPollTimeoutSeconds = options.dubbingPollTimeoutSeconds ?? DEFAULT_DUBBING_POLL_TIMEOUT_SECONDS;
+  const maxPollAttempts = Math.max(1, Math.ceil((dubbingPollTimeoutSeconds * 1000) / DUBBING_POLL_INTERVAL_MS));
+
   let dubbingStatus = "dubbing";
   let pollAttempts = 0;
-  const maxPollAttempts = 180; // 30 minutes at 10s intervals
   let targetLanguages: string[] = [];
 
   while (dubbingStatus !== "dubbed" && pollAttempts < maxPollAttempts) {
-    await sleep(10000); // Wait 10 seconds
+    await sleep(DUBBING_POLL_INTERVAL_MS);
     pollAttempts++;
 
     try {


### PR DESCRIPTION
# Overview

Makes the ElevenLabs dubbing wait in `translateAudio` longer and tunable. The poll loop had a hardcoded 30-minute cap (`maxPollAttempts = 180` at 10s intervals); long-form assets routinely need longer, so a still-processing job would fail with "Audio translation timed out or failed." Now that durable `sleep` makes waiting free (no compute held), the default is raised to 2 hours and callers can override it per-job without a library release. No behavior change for jobs that finish quickly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to how long the workflow waits before timing out; no auth, storage, or ElevenLabs API contract changes beyond longer default patience.
> 
> **Overview**
> **`translateAudio`** no longer caps ElevenLabs dubbing waits at a hardcoded **30 minutes**. The poll loop now uses a named **10s** interval and derives **`maxPollAttempts`** from a configurable timeout.
> 
> Callers can set **`dubbingPollTimeoutSeconds`** on **`AudioTranslationOptions`** (documented in **`docs/API.md`**). The default is **7200 seconds (2 hours)** instead of ~1800s, aimed at long-form assets and queued dubbing jobs. Jobs that finish quickly behave the same; only the ceiling and override path change.
> 
> Package version bumps **0.27.1 → 0.28.0** in **`package.json`** / lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53ae150bf1b712a443ba39b5766ddcd8ea55794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->