### PR TITLE
chore: bump 0.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.28.1",
+      "version": "0.29.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
to include scoped execution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime or API changes in the diff itself.
> 
> **Overview**
> **Release-only change:** bumps `@mux/ai` from **0.28.1** to **0.29.0** in `package.json` and `package-lock.json`.
> 
> No library code, APIs, or dependencies are modified in this diff—the version increment is meant to publish a release that includes **scoped execution** (time-range `scope` on workflows) already landed on the branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07c1368d1f1e3bd34448cdc316a171b969ce2153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->