### PR TITLE
feat: add optional upload of caption track in translate audio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -416,7 +416,13 @@ async function downloadAndUploadDubTranscript({
     throw new Error(`Failed to fetch dub transcript: ${transcriptResponse.statusText}`);
   }
 
-  const transcriptVtt = await transcriptResponse.text();
+  // The transcripts endpoint returns a JSON envelope (DubbingTranscriptsResponseModel)
+  // with the cue text in the field matching the requested format — not raw VTT.
+  const transcriptBody = await transcriptResponse.json() as { webvtt?: string | null };
+  const transcriptVtt = transcriptBody.webvtt;
+  if (!transcriptVtt) {
+    throw new Error("Dub transcript response did not include webvtt content");
+  }
 
   const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
   const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -6,6 +6,7 @@ import { getLanguageCodePair, toISO639_1, toISO639_3 } from "../lib/language-cod
 import type { LanguageCodePair, SupportedISO639_1 } from "../lib/language-codes.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
 import { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } from "../lib/mux-assets.ts";
+import { createTextTrackOnMux } from "../lib/mux-tracks.ts";
 import { getMuxStreamOrigin } from "../lib/mux-url.ts";
 import {
   createPresignedGetUrlWithStorageAdapter,
@@ -37,6 +38,10 @@ export interface AudioTranslationResult {
   dubbingId: string;
   uploadedTrackId?: string;
   presignedUrl?: string;
+  /** Mux text track ID for the dubbed captions, present when `uploadCaptionsToMux` is true and the upload succeeded. */
+  captionsTrackId?: string;
+  /** Presigned URL for the dub's translated transcript (WebVTT) staged to S3. */
+  captionsPresignedUrl?: string;
   /** Workflow usage metadata (asset duration, thumbnails, etc.). */
   usage?: TokenUsage;
 }
@@ -73,6 +78,13 @@ export interface AudioTranslationOptions extends MuxAIOptions {
    * required for track creation.
    */
   uploadToMux?: boolean;
+  /**
+   * When true the dub's translated transcript (the same translation that was
+   * voiced) is attached as a subtitles text track on the Mux asset. Implies
+   * `uploadToS3: true`. Defaults to false. The SDK does not check for existing
+   * text tracks — callers decide conflict semantics before enabling this.
+   */
+  uploadCaptionsToMux?: boolean;
   /** Optional storage adapter override for upload + presign operations. */
   storageAdapter?: StorageAdapter;
   /** Expiry duration in seconds for S3 presigned GET URLs. Defaults to 86400 (24 hours). */
@@ -362,6 +374,81 @@ async function downloadAndUploadDubbedAudio({
   return presignedUrl;
 }
 
+/**
+ * Download the dub's translated transcript (WebVTT) from ElevenLabs and stage it to S3,
+ * returning a presigned URL. Single step for the same event-log payload reason as
+ * `downloadAndUploadDubbedAudio`.
+ */
+async function downloadAndUploadDubTranscript({
+  dubbingId,
+  languageCode,
+  assetId,
+  toLanguageCode,
+  s3Endpoint,
+  s3Region,
+  s3Bucket,
+  storageAdapter,
+  s3SignedUrlExpirySeconds,
+  credentials,
+}: {
+  dubbingId: string;
+  languageCode: string;
+  assetId: string;
+  toLanguageCode: string;
+  s3Endpoint: string;
+  s3Region: string;
+  s3Bucket: string;
+  storageAdapter?: StorageAdapter;
+  s3SignedUrlExpirySeconds?: number;
+  credentials?: WorkflowCredentialsInput;
+}): Promise<string> {
+  "use step";
+  const elevenLabsApiKey = await getApiKeyFromEnv("elevenlabs", credentials);
+
+  const transcriptUrl = `https://api.elevenlabs.io/v1/dubbing/${dubbingId}/transcripts/${languageCode}/format/webvtt`;
+  const transcriptResponse = await fetch(transcriptUrl, {
+    headers: {
+      "xi-api-key": elevenLabsApiKey,
+    },
+  });
+
+  if (!transcriptResponse.ok) {
+    throw new Error(`Failed to fetch dub transcript: ${transcriptResponse.statusText}`);
+  }
+
+  const transcriptVtt = await transcriptResponse.text();
+
+  const s3AccessKeyId = env.S3_ACCESS_KEY_ID;
+  const s3SecretAccessKey = env.S3_SECRET_ACCESS_KEY;
+
+  const vttKey = `audio-translations/${assetId}/auto-to-${toLanguageCode}-${Date.now()}.vtt`;
+
+  await putObjectWithStorageAdapter({
+    accessKeyId: s3AccessKeyId,
+    secretAccessKey: s3SecretAccessKey,
+    endpoint: s3Endpoint,
+    region: s3Region,
+    bucket: s3Bucket,
+    key: vttKey,
+    body: transcriptVtt,
+    contentType: "text/vtt",
+  }, storageAdapter);
+
+  const presignedUrl = await createPresignedGetUrlWithStorageAdapter({
+    accessKeyId: s3AccessKeyId,
+    secretAccessKey: s3SecretAccessKey,
+    endpoint: s3Endpoint,
+    region: s3Region,
+    bucket: s3Bucket,
+    key: vttKey,
+    expiresInSeconds: s3SignedUrlExpirySeconds ?? 86400,
+  }, storageAdapter);
+
+  console.warn(`✅ Dub transcript uploaded successfully to: ${vttKey}`);
+
+  return presignedUrl;
+}
+
 async function createAudioTrackOnMux(
   assetId: string,
   languageCode: string,
@@ -401,6 +488,7 @@ export async function translateAudio(
     numSpeakers = 0, // 0 = auto-detect
     uploadToS3: uploadToS3Option,
     uploadToMux: uploadToMuxOption,
+    uploadCaptionsToMux = false,
     storageAdapter,
     credentials: providedCredentials,
   } = options;
@@ -413,7 +501,7 @@ export async function translateAudio(
   const effectiveStorageAdapter = storageAdapter;
 
   const uploadToMux = uploadToMuxOption !== false; // Default to true
-  const uploadToS3 = uploadToS3Option || uploadToMux; // Defaults to uploadToMux; uploadToMux: true forces S3 upload
+  const uploadToS3 = uploadToS3Option || uploadToMux || uploadCaptionsToMux; // Defaults to uploadToMux; Mux uploads force S3 staging
 
   // S3 configuration
   const s3Endpoint = options.s3Endpoint ?? env.S3_ENDPOINT;
@@ -521,17 +609,19 @@ export async function translateAudio(
 
   let presignedUrl: string | undefined;
   let uploadedTrackId: string | undefined;
+  let captionsPresignedUrl: string | undefined;
+  let captionsTrackId: string | undefined;
 
   if (uploadToS3) {
     console.warn("📥 Downloading dubbed audio from ElevenLabs and staging to S3...");
 
-    try {
-      // ElevenLabs reports target_languages in ISO 639-1 and the download
-      // endpoint expects one of those codes. A single-target dub yields exactly
-      // one entry, so use it directly; fall back to the ISO 639-1 form of the
-      // requested language if the array is unexpectedly empty.
-      const downloadLangCode = targetLanguages[0] ?? toISO639_1(toLanguageCode);
+    // ElevenLabs reports target_languages in ISO 639-1 and the download
+    // endpoint expects one of those codes. A single-target dub yields exactly
+    // one entry, so use it directly; fall back to the ISO 639-1 form of the
+    // requested language if the array is unexpectedly empty.
+    const downloadLangCode = targetLanguages[0] ?? toISO639_1(toLanguageCode);
 
+    try {
       presignedUrl = await downloadAndUploadDubbedAudio({
         dubbingId,
         languageCode: downloadLangCode,
@@ -567,6 +657,45 @@ export async function translateAudio(
         console.warn(presignedUrl);
       }
     }
+
+    // The dub's translated transcript is the same translation that was voiced, and
+    // fetching it costs nothing extra. Soft-fail everything here: a transcript problem
+    // must never fail a completed, paid-for dub.
+    try {
+      console.warn("📥 Downloading dub transcript from ElevenLabs and staging to S3...");
+      captionsPresignedUrl = await downloadAndUploadDubTranscript({
+        dubbingId,
+        languageCode: downloadLangCode,
+        assetId,
+        toLanguageCode,
+        s3Endpoint: s3Endpoint!,
+        s3Region,
+        s3Bucket: s3Bucket!,
+        storageAdapter: effectiveStorageAdapter,
+        s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
+        credentials,
+      });
+
+      if (uploadCaptionsToMux) {
+        console.warn("📹 Adding dubbed captions track to Mux asset...");
+        const muxLangCode = toISO639_1(toLanguageCode);
+        const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
+        captionsTrackId = await createTextTrackOnMux(
+          assetId,
+          muxLangCode,
+          `${languageName} (auto-dubbed)`,
+          captionsPresignedUrl,
+          credentials,
+        );
+        console.warn(`✅ Captions track added to Mux asset with ID: ${captionsTrackId}`);
+      }
+    } catch (error) {
+      console.warn(`⚠️ Failed to attach dubbed captions: ${error instanceof Error ? error.message : "Unknown error"}`);
+      if (captionsPresignedUrl) {
+        console.warn("🔗 You can manually add the captions track using this presigned URL:");
+        console.warn(captionsPresignedUrl);
+      }
+    }
   }
 
   const targetLanguage = getLanguageCodePair(toLanguageCode);
@@ -577,6 +706,8 @@ export async function translateAudio(
     dubbingId,
     uploadedTrackId,
     presignedUrl,
+    captionsTrackId,
+    captionsPresignedUrl,
     usage: {
       metadata: {
         assetDurationSeconds,


### PR DESCRIPTION
# Overview

`translateAudio` now also retrieves the dub's translated transcript from ElevenLabs and can attach it as a subtitles text track on the Mux asset. The transcript is the exact translation ElevenLabs voiced, and fetching it adds no provider cost — unlike running `translateCaptions` separately, which re-translates independently (extra spend) and can drift from the dubbed audio.

Two behaviors, independently gated:

- **Always** (whenever S3 staging runs): the transcript is fetched as WebVTT and staged to S3, so `captionsPresignedUrl` is returned even for callers not uploading to Mux.
- **Opt-in** (`uploadCaptionsToMux`, default `false`): the staged VTT is attached as a text track named `"{LanguageName} (auto-dubbed)"`, matching the audio track's naming.

The SDK deliberately does **no** existing-track conflict check — the consumer (robots) resolves conflict semantics before setting the flag. All captions work is soft-fail: a transcript fetch/stage/track-create failure logs a warning and never fails a completed, paid-for dub.

# What was changed

- `src/workflows/translate-audio.ts` — the only source change:
  - New option `AudioTranslationOptions.uploadCaptionsToMux?: boolean` (default `false`; forces `uploadToS3: true` like `uploadToMux` does).
  - New step `downloadAndUploadDubTranscript`: `GET /v1/dubbing/{id}/transcripts/{lang}/format/webvtt` → S3 at `audio-translations/{assetId}/auto-to-{lang}-{ts}.vtt` → presigned URL. Fetch + upload happen in a single step so the payload never crosses a step boundary (same rationale as the existing audio step).
  - New captions block after audio-track creation, wrapped in its own try/catch (soft-fail). Track creation reuses the existing `createTextTrackOnMux` helper from `src/lib/mux-tracks.ts` and the same ISO 639-1 language code as the audio track.
  - New result fields `AudioTranslationResult.captionsTrackId?` / `captionsPresignedUrl?`.
- `package.json` / `package-lock.json` — version bump `0.29.0` → `0.30.0`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds post-dub Mux text-track creation and always-on transcript staging when S3 upload runs; failures are isolated but callers may see new S3/Mux side effects and optional duplicate subtitle tracks if not gated upstream.
> 
> **Overview**
> **`translateAudio`** now pulls the dub’s **ElevenLabs transcript** (same text as the voiced dub) as WebVTT and can expose it on the Mux asset, avoiding a separate `translateCaptions` pass.
> 
> Whenever S3 staging runs, a new step **`downloadAndUploadDubTranscript`** fetches WebVTT from ElevenLabs, uploads to S3, and returns **`captionsPresignedUrl`**. Opt-in **`uploadCaptionsToMux`** (default `false`, implies S3) attaches a subtitles track via **`createTextTrackOnMux`** named like the audio track (`"{Language} (auto-dubbed)"`). Result adds **`captionsTrackId`** / **`captionsPresignedUrl`**. Transcript fetch, staging, and Mux text-track creation are **soft-fail** so a completed dub is not failed. Package version **0.29.0 → 0.30.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd4c385513065437bdac80dfe796c5535cb02bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->