### PR TITLE
fix: surface content policy errors from summaries

### DIFF
--- a/src/lib/content-policy-error.ts
+++ b/src/lib/content-policy-error.ts
@@ -28,6 +28,16 @@ const ContentPolicyResponseSchema = z.object({
   })).max(8).nullish(),
 });
 
+const ContentPolicyUsageResponseSchema = z.object({
+  usageMetadata: z.object({
+    promptTokenCount: z.number().finite().nonnegative().nullish(),
+    candidatesTokenCount: z.number().finite().nonnegative().nullish(),
+    totalTokenCount: z.number().finite().nonnegative().nullish(),
+    cachedContentTokenCount: z.number().finite().nonnegative().nullish(),
+    thoughtsTokenCount: z.number().finite().nonnegative().nullish(),
+  }).nullish(),
+});
+
 const CONTENT_POLICY_REASONS = new Set([
   "BLOCKLIST",
   "ESCALATION",
@@ -47,6 +57,13 @@ export interface ContentPolicyBlock {
   category?: string;
 }
 
+interface GeneratedOutput<T> {
+  finishReason: string;
+  rawFinishReason?: string;
+  output: T;
+  usage?: unknown;
+}
+
 export async function withContentPolicyErrorHandling<T>(operation: () => Promise<T>): Promise<T> {
   try {
     return await operation();
@@ -61,6 +78,29 @@ export function rethrowContentPolicyError(error: unknown): never {
     throw error;
   }
 
+  throwContentPolicyError(block, getContentPolicyTokenUsage(error));
+}
+
+/**
+ * Reads structured output only after checking for a successful provider
+ * response that stopped because of a content policy. AI SDK intentionally
+ * leaves output unresolved for non-`stop` finishes, so accessing `output`
+ * first would throw a metadata-free `NoOutputGeneratedError`.
+ */
+export function getGeneratedOutputWithContentPolicyHandling<T>(response: GeneratedOutput<T>): T {
+  if (response.finishReason === "content-filter") {
+    const rawReason = PolicyTokenSchema.safeParse(response.rawFinishReason);
+    const reason = rawReason.success && isContentPolicyReason(rawReason.data) ?
+      rawReason.data :
+      "CONTENT_FILTER";
+
+    throwContentPolicyError({ reason }, getErrorTokenUsage(response));
+  }
+
+  return response.output;
+}
+
+function throwContentPolicyError(block: ContentPolicyBlock, usage?: TokenUsage): never {
   const category = block.category ? `; category: ${block.category}` : "";
   const contentPolicyError = new MuxAiError(
     `The supplied content was blocked by a content policy (reason: ${block.reason}${category}).`,
@@ -69,7 +109,6 @@ export function rethrowContentPolicyError(error: unknown): never {
       retryable: false,
     },
   );
-  const usage = getErrorTokenUsage(error);
   if (usage) {
     (contentPolicyError as MuxAiError & { usage?: TokenUsage }).usage = usage;
   }
@@ -116,6 +155,41 @@ export function extractContentPolicyBlock(error: unknown): ContentPolicyBlock | 
 
 function isContentPolicyReason(reason: string | null | undefined): reason is string {
   return Boolean(reason && CONTENT_POLICY_REASONS.has(reason));
+}
+
+function getContentPolicyTokenUsage(error: unknown): TokenUsage | undefined {
+  const errorUsage = getErrorTokenUsage(error);
+  if (errorUsage) {
+    return errorUsage;
+  }
+
+  if (!APICallError.isInstance(error) || !error.responseBody) {
+    return undefined;
+  }
+
+  try {
+    const parsed = ContentPolicyUsageResponseSchema.safeParse(JSON.parse(error.responseBody));
+    const usage = parsed.success ? parsed.data.usageMetadata : undefined;
+    if (!usage) {
+      return undefined;
+    }
+
+    // Match @ai-sdk/google's normalization: reasoning tokens are included in
+    // output tokens, while cached input tokens are part of prompt tokens.
+    const inputTokens = usage.promptTokenCount ?? 0;
+    const reasoningTokens = usage.thoughtsTokenCount ?? 0;
+    const outputTokens = (usage.candidatesTokenCount ?? 0) + reasoningTokens;
+
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens: usage.totalTokenCount ?? inputTokens + outputTokens,
+      reasoningTokens,
+      cachedInputTokens: usage.cachedContentTokenCount ?? 0,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function findBlockedCategory(

--- a/src/lib/content-policy-error.ts
+++ b/src/lib/content-policy-error.ts
@@ -1,7 +1,10 @@
 import { APICallError, NoObjectGeneratedError } from "ai";
 import { z } from "zod";
 
+import type { TokenUsage } from "../types.ts";
+
 import { MuxAiError } from "./mux-ai-error.ts";
+import { getErrorTokenUsage } from "./token-usage.ts";
 
 const PolicyTokenSchema = z.string()
   .trim()
@@ -59,13 +62,18 @@ export function rethrowContentPolicyError(error: unknown): never {
   }
 
   const category = block.category ? `; category: ${block.category}` : "";
-  throw new MuxAiError(
+  const contentPolicyError = new MuxAiError(
     `The supplied content was blocked by a content policy (reason: ${block.reason}${category}).`,
     {
       type: "content_policy_error",
       retryable: false,
     },
   );
+  const usage = getErrorTokenUsage(error);
+  if (usage) {
+    (contentPolicyError as MuxAiError & { usage?: TokenUsage }).usage = usage;
+  }
+  throw contentPolicyError;
 }
 
 export function extractContentPolicyBlock(error: unknown): ContentPolicyBlock | undefined {

--- a/src/lib/content-policy-error.ts
+++ b/src/lib/content-policy-error.ts
@@ -1,0 +1,117 @@
+import { APICallError, NoObjectGeneratedError } from "ai";
+import { z } from "zod";
+
+import { MuxAiError } from "./mux-ai-error.ts";
+
+const PolicyTokenSchema = z.string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[A-Z0-9_]+$/);
+
+const SafetyRatingSchema = z.object({
+  category: PolicyTokenSchema.nullish(),
+  blocked: z.boolean().nullish(),
+});
+
+const ContentPolicyResponseSchema = z.object({
+  promptFeedback: z.object({
+    blockReason: PolicyTokenSchema.nullish(),
+    safetyRatings: z.array(SafetyRatingSchema).max(32).nullish(),
+  }).nullish(),
+  candidates: z.array(z.object({
+    finishReason: PolicyTokenSchema.nullish(),
+    safetyRatings: z.array(SafetyRatingSchema).max(32).nullish(),
+  })).max(8).nullish(),
+});
+
+const CONTENT_POLICY_REASONS = new Set([
+  "BLOCKLIST",
+  "ESCALATION",
+  "IMAGE_PROHIBITED_CONTENT",
+  "IMAGE_RECITATION",
+  "IMAGE_SAFETY",
+  "JAILBREAK",
+  "MODEL_ARMOR",
+  "PROHIBITED_CONTENT",
+  "RECITATION",
+  "SAFETY",
+  "SPII",
+]);
+
+export interface ContentPolicyBlock {
+  reason: string;
+  category?: string;
+}
+
+export async function withContentPolicyErrorHandling<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    rethrowContentPolicyError(error);
+  }
+}
+
+export function rethrowContentPolicyError(error: unknown): never {
+  const block = extractContentPolicyBlock(error);
+  if (!block) {
+    throw error;
+  }
+
+  const category = block.category ? `; category: ${block.category}` : "";
+  throw new MuxAiError(
+    `The supplied content was blocked by a content policy (reason: ${block.reason}${category}).`,
+    {
+      type: "content_policy_error",
+      retryable: false,
+    },
+  );
+}
+
+export function extractContentPolicyBlock(error: unknown): ContentPolicyBlock | undefined {
+  if (NoObjectGeneratedError.isInstance(error) && error.finishReason === "content-filter") {
+    return { reason: "CONTENT_FILTER" };
+  }
+
+  if (!APICallError.isInstance(error) || !error.responseBody) {
+    return undefined;
+  }
+
+  try {
+    const parsed = ContentPolicyResponseSchema.safeParse(JSON.parse(error.responseBody));
+    if (!parsed.success) {
+      return undefined;
+    }
+
+    const promptReason = parsed.data.promptFeedback?.blockReason;
+    if (isContentPolicyReason(promptReason)) {
+      return {
+        reason: promptReason,
+        category: findBlockedCategory(parsed.data.promptFeedback?.safetyRatings),
+      };
+    }
+
+    for (const candidate of parsed.data.candidates ?? []) {
+      if (isContentPolicyReason(candidate.finishReason)) {
+        return {
+          reason: candidate.finishReason,
+          category: findBlockedCategory(candidate.safetyRatings),
+        };
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function isContentPolicyReason(reason: string | null | undefined): reason is string {
+  return Boolean(reason && CONTENT_POLICY_REASONS.has(reason));
+}
+
+function findBlockedCategory(
+  ratings: Array<z.infer<typeof SafetyRatingSchema>> | null | undefined,
+): string | undefined {
+  return ratings?.find(rating => rating.blocked === true)?.category ?? undefined;
+}

--- a/src/lib/mux-ai-error.ts
+++ b/src/lib/mux-ai-error.ts
@@ -3,7 +3,10 @@ import type { TokenUsage } from "../types.ts";
 import { detectLeakReason } from "./output-safety.ts";
 import { getErrorTokenUsage } from "./token-usage.ts";
 
-export type MuxAiErrorType = "validation_error" | "processing_error" | "timeout_error";
+export type MuxAiErrorType = "validation_error" |
+  "processing_error" |
+  "timeout_error" |
+  "content_policy_error";
 
 /**
  * An error whose message is safe to surface verbatim to the customer.
@@ -40,6 +43,15 @@ export class MuxAiError extends Error {
     this.publicType = opts?.type ?? "processing_error";
     this.publicMessage = message;
     this.retryable = opts?.retryable ?? false;
+  }
+
+  static is(value: unknown): value is MuxAiError {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      "__robots_error" in value &&
+      value.__robots_error === true
+    );
   }
 }
 
@@ -95,7 +107,7 @@ function extractErrorDetail(error: unknown): string {
 }
 
 export function wrapError(error: unknown, message: string): never {
-  if (error instanceof MuxAiError) {
+  if (MuxAiError.is(error)) {
     throw error;
   }
   const rawDetail = extractErrorDetail(error);

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -42,26 +42,27 @@ export async function withRetry<T>(
     shouldRetry = defaultShouldRetry,
   }: RetryOptions = {},
 ): Promise<T> {
-  let lastError: Error | undefined;
+  let lastError: unknown;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
       return await fn();
     } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
+      lastError = error;
+      const retryError = error instanceof Error ? error : new Error(String(error));
 
       const isLastAttempt = attempt === maxRetries;
-      if (isLastAttempt || !shouldRetry(lastError, attempt + 1)) {
-        throw lastError;
+      if (isLastAttempt || !shouldRetry(retryError, attempt + 1)) {
+        throw error;
       }
 
       const delay = calculateDelay(attempt + 1, baseDelay, maxDelay);
       console.warn(
-        `Attempt ${attempt + 1} failed: ${lastError.message}. Retrying in ${Math.round(delay)}ms...`,
+        `Attempt ${attempt + 1} failed: ${retryError.message}. Retrying in ${Math.round(delay)}ms...`,
       );
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }
 
-  throw lastError || new Error("Retry failed with unknown error");
+  throw lastError ?? new Error("Retry failed with unknown error");
 }

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -2,6 +2,7 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
+import { withContentPolicyErrorHandling } from "../lib/content-policy-error.ts";
 import type { ImageDownloadOptions } from "../lib/image-download.ts";
 import { downloadImageAsBase64 } from "../lib/image-download.ts";
 import { getLanguageName } from "../lib/language-codes.ts";
@@ -550,7 +551,7 @@ async function analyzeStoryboard(
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
   const schema = buildSummarySchema(descriptionLength);
 
-  const response = await generateText({
+  const response = await withContentPolicyErrorHandling(() => generateText({
     model,
     output: Output.object({
       name: "summary_metadata",
@@ -570,7 +571,7 @@ async function analyzeStoryboard(
         ],
       },
     ],
-  });
+  }));
 
   if (!response.output) {
     throw new Error("Summarization output missing");
@@ -610,7 +611,7 @@ async function analyzeAudioOnly(
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
   const schema = buildSummarySchema(descriptionLength);
 
-  const response = await generateText({
+  const response = await withContentPolicyErrorHandling(() => generateText({
     model,
     output: Output.object({
       name: "summary_metadata",
@@ -627,7 +628,7 @@ async function analyzeAudioOnly(
         content: userPrompt,
       },
     ],
-  });
+  }));
 
   if (!response.output) {
     throw new Error("Summarization output missing");

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -2,7 +2,10 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
-import { withContentPolicyErrorHandling } from "../lib/content-policy-error.ts";
+import {
+  getGeneratedOutputWithContentPolicyHandling,
+  withContentPolicyErrorHandling,
+} from "../lib/content-policy-error.ts";
 import type { ImageDownloadOptions } from "../lib/image-download.ts";
 import { downloadImageAsBase64 } from "../lib/image-download.ts";
 import { getLanguageName } from "../lib/language-codes.ts";
@@ -573,11 +576,13 @@ async function analyzeStoryboard(
     ],
   }));
 
-  if (!response.output) {
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
+
+  if (!output) {
     throw new Error("Summarization output missing");
   }
 
-  const parsed = schema.parse(response.output);
+  const parsed = schema.parse(output);
 
   // Detect schema-smuggling. response.output has already been stripped;
   // re-parse response.text to see what the model actually emitted.
@@ -630,11 +635,13 @@ async function analyzeAudioOnly(
     ],
   }));
 
-  if (!response.output) {
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
+
+  if (!output) {
     throw new Error("Summarization output missing");
   }
 
-  const parsed = schema.parse(response.output);
+  const parsed = schema.parse(output);
 
   // Detect schema-smuggling. response.output has already been stripped;
   // re-parse response.text to see what the model actually emitted.

--- a/tests/unit/content-policy-error.test.ts
+++ b/tests/unit/content-policy-error.test.ts
@@ -1,0 +1,164 @@
+import { APICallError, NoObjectGeneratedError } from "ai";
+import { describe, expect, it } from "vitest";
+
+import {
+  extractContentPolicyBlock,
+  rethrowContentPolicyError,
+  withContentPolicyErrorHandling,
+} from "../../src/lib/content-policy-error.ts";
+import { wrapError } from "../../src/lib/mux-ai-error.ts";
+
+function createApiCallError(responseBody: string) {
+  return new APICallError({
+    message: "Invalid JSON response",
+    url: "https://example.com/generate-content",
+    requestBodyValues: {},
+    statusCode: 200,
+    responseBody,
+  });
+}
+
+function createNoObjectGeneratedError(finishReason: "content-filter" | "error") {
+  return new NoObjectGeneratedError({
+    message: "No object generated",
+    response: {
+      id: "response-id",
+      modelId: "model-id",
+      timestamp: new Date("2026-07-31T00:00:00.000Z"),
+    },
+    usage: {
+      inputTokens: 10,
+      outputTokens: 0,
+      totalTokens: 10,
+      inputTokenDetails: {
+        noCacheTokens: 10,
+        cacheReadTokens: 0,
+        cacheWriteTokens: undefined,
+      },
+      outputTokenDetails: {
+        textTokens: 0,
+        reasoningTokens: 0,
+      },
+    },
+    finishReason,
+  });
+}
+
+function captureThrown(operation: () => void): unknown {
+  try {
+    operation();
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected operation to throw");
+}
+
+describe("content policy errors", () => {
+  it("extracts a prompt block reason from an API call response body", () => {
+    const error = createApiCallError(JSON.stringify({
+      promptFeedback: {
+        blockReason: "PROHIBITED_CONTENT",
+        safetyRatings: [],
+      },
+      usageMetadata: {
+        promptTokenCount: 100,
+        totalTokenCount: 100,
+      },
+    }));
+
+    expect(extractContentPolicyBlock(error)).toEqual({
+      reason: "PROHIBITED_CONTENT",
+      category: undefined,
+    });
+  });
+
+  it("includes an explicitly blocked safety category", () => {
+    const error = createApiCallError(JSON.stringify({
+      promptFeedback: {
+        blockReason: "SAFETY",
+        safetyRatings: [
+          {
+            category: "HARM_CATEGORY_HARASSMENT",
+            probability: "NEGLIGIBLE",
+            blocked: false,
+          },
+          {
+            category: "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+            probability: "HIGH",
+            blocked: true,
+          },
+        ],
+      },
+    }));
+
+    expect(extractContentPolicyBlock(error)).toEqual({
+      reason: "SAFETY",
+      category: "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+    });
+  });
+
+  it("extracts candidate-side content policy finish reasons", () => {
+    const error = createApiCallError(JSON.stringify({
+      candidates: [
+        {
+          content: {},
+          finishReason: "PROHIBITED_CONTENT",
+          safetyRatings: [],
+        },
+      ],
+    }));
+
+    expect(extractContentPolicyBlock(error)).toEqual({
+      reason: "PROHIBITED_CONTENT",
+      category: undefined,
+    });
+  });
+
+  it("normalizes provider-agnostic content-filter finish reasons", () => {
+    expect(extractContentPolicyBlock(createNoObjectGeneratedError("content-filter"))).toEqual({
+      reason: "CONTENT_FILTER",
+    });
+  });
+
+  it("throws a provider-agnostic non-retryable content policy error", async () => {
+    const error = createApiCallError(JSON.stringify({
+      promptFeedback: {
+        blockReason: "PROHIBITED_CONTENT",
+      },
+    }));
+
+    await expect(withContentPolicyErrorHandling(async () => {
+      throw error;
+    })).rejects.toMatchObject({
+      name: "FatalError",
+      publicType: "content_policy_error",
+      publicMessage: "The supplied content was blocked by a content policy (reason: PROHIBITED_CONTENT).",
+      retryable: false,
+    });
+  });
+
+  it("preserves content policy metadata across a serialized workflow step boundary", () => {
+    const serializedError = {
+      __robots_error: true,
+      message: "The supplied content was blocked by a content policy (reason: PROHIBITED_CONTENT).",
+      publicMessage: "The supplied content was blocked by a content policy (reason: PROHIBITED_CONTENT).",
+      publicType: "content_policy_error",
+      retryable: false,
+    };
+
+    expect(captureThrown(() => wrapError(serializedError, "Failed to analyze video content")))
+      .toBe(serializedError);
+  });
+
+  it("preserves unrelated API failures", () => {
+    const error = createApiCallError("upstream temporarily unavailable");
+
+    expect(() => rethrowContentPolicyError(error)).toThrow(error);
+  });
+
+  it("preserves unrelated object generation failures", () => {
+    const error = createNoObjectGeneratedError("error");
+
+    expect(() => rethrowContentPolicyError(error)).toThrow(error);
+  });
+});

--- a/tests/unit/content-policy-error.test.ts
+++ b/tests/unit/content-policy-error.test.ts
@@ -7,6 +7,7 @@ import {
   withContentPolicyErrorHandling,
 } from "../../src/lib/content-policy-error.ts";
 import { wrapError } from "../../src/lib/mux-ai-error.ts";
+import { withRetry } from "../../src/lib/retry.ts";
 
 function createApiCallError(responseBody: string) {
   return new APICallError({
@@ -137,6 +138,23 @@ describe("content policy errors", () => {
     });
   });
 
+  it("preserves token usage when normalizing content policy errors", async () => {
+    const normalizedError = await withContentPolicyErrorHandling(async () => {
+      throw createNoObjectGeneratedError("content-filter");
+    }).catch(error => error);
+
+    expect(normalizedError).toMatchObject({
+      publicType: "content_policy_error",
+      usage: {
+        inputTokens: 10,
+        outputTokens: 0,
+        totalTokens: 10,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      },
+    });
+  });
+
   it("preserves content policy metadata across a serialized workflow step boundary", () => {
     const serializedError = {
       __robots_error: true,
@@ -147,6 +165,24 @@ describe("content policy errors", () => {
     };
 
     expect(captureThrown(() => wrapError(serializedError, "Failed to analyze video content")))
+      .toBe(serializedError);
+  });
+
+  it("preserves serialized content policy errors through the retry wrapper", async () => {
+    const serializedError = {
+      __robots_error: true,
+      message: "The supplied content was blocked by a content policy (reason: PROHIBITED_CONTENT).",
+      publicMessage: "The supplied content was blocked by a content policy (reason: PROHIBITED_CONTENT).",
+      publicType: "content_policy_error",
+      retryable: false,
+    };
+
+    const errorAfterRetry = await withRetry(async () => {
+      throw serializedError;
+    }).catch(error => error);
+
+    expect(errorAfterRetry).toBe(serializedError);
+    expect(captureThrown(() => wrapError(errorAfterRetry, "Failed to analyze video content")))
       .toBe(serializedError);
   });
 

--- a/tests/unit/content-policy-error.test.ts
+++ b/tests/unit/content-policy-error.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   extractContentPolicyBlock,
+  getGeneratedOutputWithContentPolicyHandling,
   rethrowContentPolicyError,
   withContentPolicyErrorHandling,
 } from "../../src/lib/content-policy-error.ts";
@@ -152,6 +153,65 @@ describe("content policy errors", () => {
         reasoningTokens: 0,
         cachedInputTokens: 0,
       },
+    });
+  });
+
+  it("preserves response-body usage when normalizing API content policy errors", async () => {
+    const normalizedError = await withContentPolicyErrorHandling(async () => {
+      throw createApiCallError(JSON.stringify({
+        promptFeedback: {
+          blockReason: "PROHIBITED_CONTENT",
+        },
+        usageMetadata: {
+          promptTokenCount: 100,
+          candidatesTokenCount: 4,
+          totalTokenCount: 106,
+          cachedContentTokenCount: 25,
+          thoughtsTokenCount: 2,
+        },
+      }));
+    }).catch(error => error);
+
+    expect(normalizedError).toMatchObject({
+      publicType: "content_policy_error",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 6,
+        totalTokens: 106,
+        reasoningTokens: 2,
+        cachedInputTokens: 25,
+      },
+    });
+  });
+
+  it("normalizes content-filter responses before reading structured output", () => {
+    let outputRead = false;
+    const response = {
+      finishReason: "content-filter",
+      rawFinishReason: "PROHIBITED_CONTENT",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 0,
+        totalTokens: 100,
+        reasoningTokens: 0,
+        cachedInputTokens: 20,
+      },
+      get output(): never {
+        outputRead = true;
+        throw new Error("structured output getter should not be read");
+      },
+    };
+
+    const normalizedError = captureThrown(() =>
+      getGeneratedOutputWithContentPolicyHandling(response),
+    );
+
+    expect(outputRead).toBe(false);
+    expect(normalizedError).toMatchObject({
+      publicType: "content_policy_error",
+      publicMessage: "The supplied content was blocked by a content policy (reason: PROHIBITED_CONTENT).",
+      retryable: false,
+      usage: response.usage,
     });
   });
 


### PR DESCRIPTION
# Overview

Surface content-policy failures from summary generation as explicit, non-retryable errors instead of the generic `Invalid JSON response`. Public messaging stays provider-agnostic and does not expose raw provider responses or submitted content.

# What was changed

- Normalize prompt blocks, candidate-side policy blocks, and AI SDK `content-filter` finishes into `content_policy_error`.
- Preserve branded errors across Workflow step serialization so downstream consumers receive the reason or category and repeated retries are skipped.
- Apply the handling to video and audio-only summaries, with focused coverage for blocked and unrelated failure paths.

# Suggested review order

1. `src/lib/content-policy-error.ts` — classification and safe public messaging.
2. `src/lib/mux-ai-error.ts` — error type and Workflow-boundary preservation.
3. `src/workflows/summarization.ts` — summary integration.
4. `tests/unit/content-policy-error.test.ts` — expected behavior and regressions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes customer-visible error classification and retry behavior for summarization LLM calls; scope is limited to error handling, not core data or auth paths.
> 
> **Overview**
> Summary generation now turns provider **content-policy blocks** into explicit, **non-retryable** `content_policy_error` responses instead of opaque failures like `Invalid JSON response`.
> 
> A new **`content-policy-error`** helper parses AI SDK `APICallError` bodies (prompt `blockReason`, candidate `finishReason`, blocked safety categories) and `NoObjectGeneratedError` with `content-filter`, then raises a branded **`MuxAiError`** with provider-agnostic messaging (reason/category only, no raw responses).
> 
> **`MuxAiError`** gains the `content_policy_error` type and a **`MuxAiError.is()`** duck-type check so **`wrapError`** still rethrows serialized workflow-step errors without wrapping them as internal failures. Both video storyboard and audio-only summary **`generateText`** paths use **`withContentPolicyErrorHandling`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ef82de89e213c26c086c43d09b3f60c13aae66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->