### PR TITLE
feat: support more content policy error handling

### DIFF
--- a/src/lib/content-policy-error.ts
+++ b/src/lib/content-policy-error.ts
@@ -1,4 +1,4 @@
-import { APICallError, NoObjectGeneratedError } from "ai";
+import { APICallError, NoObjectGeneratedError, RetryError } from "ai";
 import { z } from "zod";
 
 import type { TokenUsage } from "../types.ts";
@@ -116,6 +116,10 @@ function throwContentPolicyError(block: ContentPolicyBlock, usage?: TokenUsage):
 }
 
 export function extractContentPolicyBlock(error: unknown): ContentPolicyBlock | undefined {
+  if (RetryError.isInstance(error)) {
+    return extractContentPolicyBlock(error.lastError);
+  }
+
   if (NoObjectGeneratedError.isInstance(error) && error.finishReason === "content-filter") {
     return { reason: "CONTENT_FILTER" };
   }
@@ -161,6 +165,10 @@ function getContentPolicyTokenUsage(error: unknown): TokenUsage | undefined {
   const errorUsage = getErrorTokenUsage(error);
   if (errorUsage) {
     return errorUsage;
+  }
+
+  if (RetryError.isInstance(error)) {
+    return getContentPolicyTokenUsage(error.lastError);
   }
 
   if (!APICallError.isInstance(error) || !error.responseBody) {

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -2,6 +2,10 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
+import {
+  getGeneratedOutputWithContentPolicyHandling,
+  withContentPolicyErrorHandling,
+} from "../lib/content-policy-error.ts";
 import type { ImageDownloadOptions } from "../lib/image-download.ts";
 import { downloadImageAsBase64 } from "../lib/image-download.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
@@ -659,7 +663,7 @@ async function analyzeQuestions({
     maxFreeFormAnswerLength,
   );
 
-  const response = await generateText({
+  const response = await withContentPolicyErrorHandling(() => generateText({
     model,
     output: Output.object({ schema: responseSchema }),
     experimental_telemetry: { isEnabled: true },
@@ -678,13 +682,14 @@ async function analyzeQuestions({
           userPrompt,
       },
     ],
-  });
+  }));
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
 
-  if (!response.output) {
+  if (!output) {
     throw new Error("Ask-questions output missing");
   }
 
-  const parsed = responseSchema.parse(response.output);
+  const parsed = responseSchema.parse(output);
 
   // Detect schema-smuggling attempts. `response.output` has already
   // been through zod.strip(), so any extras are gone from it — we

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -2,6 +2,10 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
+import {
+  getGeneratedOutputWithContentPolicyHandling,
+  withContentPolicyErrorHandling,
+} from "../lib/content-policy-error.ts";
 import type { ImageDownloadOptions } from "../lib/image-download.ts";
 import { downloadImageAsBase64 } from "../lib/image-download.ts";
 import {
@@ -282,7 +286,7 @@ async function analyzeStoryboard({
 
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
-  const response = await generateText({
+  const response = await withContentPolicyErrorHandling(() => generateText({
     model,
     output: Output.object({ schema: burnedInCaptionsSchema }),
     experimental_telemetry: { isEnabled: true },
@@ -299,7 +303,8 @@ async function analyzeStoryboard({
         ],
       },
     ],
-  });
+  }));
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
 
   // Detect schema-smuggling attempts. `response.output` has already
   // been through zod.strip(), so any extras the model emitted are gone
@@ -315,8 +320,8 @@ async function analyzeStoryboard({
 
   return {
     result: {
-      ...response.output,
-      confidence: Math.min(1, Math.max(0, response.output.confidence)),
+      ...output,
+      confidence: Math.min(1, Math.max(0, output.confidence)),
     },
     usage: {
       inputTokens: response.usage.inputTokens,

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -2,6 +2,10 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
+import {
+  getGeneratedOutputWithContentPolicyHandling,
+  withContentPolicyErrorHandling,
+} from "../lib/content-policy-error.ts";
 import { getLanguageName } from "../lib/language-codes.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
 import {
@@ -168,21 +172,24 @@ async function generateChaptersWithAI({
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
   const response = await withRetry(() =>
-    generateText({
-      model,
-      output: Output.object({ schema: chaptersSchema }),
-      messages: [
-        {
-          role: "system",
-          content: systemPrompt,
-        },
-        {
-          role: "user",
-          content: userPrompt,
-        },
-      ],
-    }),
+    withContentPolicyErrorHandling(() =>
+      generateText({
+        model,
+        output: Output.object({ schema: chaptersSchema }),
+        messages: [
+          {
+            role: "system",
+            content: systemPrompt,
+          },
+          {
+            role: "user",
+            content: userPrompt,
+          },
+        ],
+      }),
+    ),
   );
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
 
   // Detect schema-smuggling. response.output has already been stripped;
   // re-parse response.text to see what the model actually emitted.
@@ -207,7 +214,7 @@ async function generateChaptersWithAI({
   }
 
   return {
-    chapters: response.output,
+    chapters: output,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -2,6 +2,10 @@ import { generateText, Output } from "ai";
 import { z } from "zod";
 
 import env from "../env.ts";
+import {
+  getGeneratedOutputWithContentPolicyHandling,
+  withContentPolicyErrorHandling,
+} from "../lib/content-policy-error.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
 import {
   getAssetDurationSecondsFromAsset,
@@ -447,7 +451,7 @@ async function identifyProfanityWithAI({
     content: plainText,
   });
 
-  const response = await generateText({
+  const response = await withContentPolicyErrorHandling(() => generateText({
     model,
     output: Output.object({ schema: profanityDetectionSchema }),
     messages: [
@@ -461,7 +465,8 @@ async function identifyProfanityWithAI({
           `Identify all profane words and phrases in the following subtitle transcript. Return each unique profane word or phrase exactly as it appears in the text.\n\n${transcriptSection}`,
       },
     ],
-  });
+  }));
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
 
   // Detect schema-smuggling (an extra key alongside `profanity`).
   const unexpectedKeys = detectUnexpectedKeysFromRawText(
@@ -470,7 +475,7 @@ async function identifyProfanityWithAI({
   );
 
   return {
-    profanity: response.output.profanity,
+    profanity: output.profanity,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -2,6 +2,10 @@ import { generateText, Output } from "ai";
 import dedent from "dedent";
 import { z } from "zod";
 
+import {
+  getGeneratedOutputWithContentPolicyHandling,
+  withContentPolicyErrorHandling,
+} from "../lib/content-policy-error.ts";
 import { MuxAiError } from "../lib/mux-ai-error.ts";
 import {
   getAssetDurationSecondsFromAsset,
@@ -543,27 +547,30 @@ async function generateInsightsWithAI(
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
   const response = await withRetry(() =>
-    generateText({
-      model,
-      output: Output.object({ schema: engagementInsightsSchema }),
-      experimental_telemetry: { isEnabled: true },
-      messages: [
-        {
-          role: "system",
-          content: systemPrompt,
-        },
-        {
-          role: "user",
-          content: [
-            { type: "text", text: userPrompt },
-            ...imageUrls.map(url => ({ type: "image" as const, image: url })),
-          ],
-        },
-      ],
-    }),
+    withContentPolicyErrorHandling(() =>
+      generateText({
+        model,
+        output: Output.object({ schema: engagementInsightsSchema }),
+        experimental_telemetry: { isEnabled: true },
+        messages: [
+          {
+            role: "system",
+            content: systemPrompt,
+          },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: userPrompt },
+              ...imageUrls.map(url => ({ type: "image" as const, image: url })),
+            ],
+          },
+        ],
+      }),
+    ),
   );
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
 
-  if (!response.output) {
+  if (!output) {
     throw new Error("AI returned empty or unparseable response");
   }
 
@@ -597,7 +604,7 @@ async function generateInsightsWithAI(
   }
 
   return {
-    result: response.output,
+    result: output,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -9,6 +9,10 @@ import {
 import { z } from "zod";
 
 import env from "../env.ts";
+import {
+  getGeneratedOutputWithContentPolicyHandling,
+  withContentPolicyErrorHandling,
+} from "../lib/content-policy-error.ts";
 import { getLanguageCodePair, getLanguageName } from "../lib/language-codes.ts";
 import type { LanguageCodePair, SupportedISO639_1 } from "../lib/language-codes.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
@@ -602,7 +606,7 @@ async function translateVttWithAI({
   // blocks implicitly.
   const sanitisedVttContent = stripVttMetadataBlocks(vttContent);
 
-  const response = await generateText({
+  const response = await withContentPolicyErrorHandling(() => generateText({
     model,
     output: Output.object({ schema: translationSchema }),
     messages: [
@@ -615,7 +619,8 @@ async function translateVttWithAI({
         content: `Translate from ${fromLanguageCode} to ${toLanguageCode}:\n\n${sanitisedVttContent}`,
       },
     ],
-  });
+  }));
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
 
   // Whole-VTT path: scan the entire translated blob for leaks. This is
   // coarser than the cue-by-cue path below because the non-chunked path
@@ -628,7 +633,7 @@ async function translateVttWithAI({
   // up-front means the scrubber sees clean VTT (fewer spurious tag
   // hits) and downstream consumers (Mux track ingestion, players) get
   // the exact header they require.
-  const translated = normalizeTranslatedVtt(response.output.translation);
+  const translated = normalizeTranslatedVtt(output.translation);
   const leakReason = detectLeakReason(translated);
   const safeTranslated = leakReason !== null ? vttContent : translated;
   if (leakReason !== null) {
@@ -710,7 +715,7 @@ async function translateCueChunkWithAI({
     text: cue.text,
   }));
 
-  const response = await generateText({
+  const response = await withContentPolicyErrorHandling(() => generateText({
     model,
     output: Output.object({ schema }),
     messages: [
@@ -723,7 +728,8 @@ async function translateCueChunkWithAI({
         content: `Translate from ${fromLanguageCode} to ${toLanguageCode}.\nReturn exactly ${cues.length} translated cues in the same order as the input.\n\n${JSON.stringify(cuePayload, null, 2)}`,
       },
     ],
-  });
+  }));
+  const output = getGeneratedOutputWithContentPolicyHandling(response);
 
   // Schema-smuggling detection for the cue envelope. Any extras on the
   // root envelope were stripped by zod; log + bubble count to aggregate.
@@ -740,7 +746,7 @@ async function translateCueChunkWithAI({
   }
 
   return {
-    translations: response.output.translations,
+    translations: output.translations,
     usage: {
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,

--- a/tests/unit/content-policy-error.test.ts
+++ b/tests/unit/content-policy-error.test.ts
@@ -1,4 +1,4 @@
-import { APICallError, NoObjectGeneratedError } from "ai";
+import { APICallError, NoObjectGeneratedError, RetryError } from "ai";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -184,6 +184,46 @@ describe("content policy errors", () => {
     });
   });
 
+  it("normalizes a content policy error returned after an AI SDK retry", async () => {
+    const transientError = new APICallError({
+      message: "Service unavailable",
+      url: "https://example.com/generate-content",
+      requestBodyValues: {},
+      statusCode: 503,
+    });
+    const contentPolicyError = createApiCallError(JSON.stringify({
+      promptFeedback: {
+        blockReason: "PROHIBITED_CONTENT",
+      },
+      usageMetadata: {
+        promptTokenCount: 100,
+        totalTokenCount: 100,
+      },
+    }));
+    const retryError = new RetryError({
+      message: "Failed after retrying",
+      reason: "errorNotRetryable",
+      errors: [transientError, contentPolicyError],
+    });
+
+    const normalizedError = await withContentPolicyErrorHandling(async () => {
+      throw retryError;
+    }).catch(error => error);
+
+    expect(normalizedError).toMatchObject({
+      publicType: "content_policy_error",
+      publicMessage: "The supplied content was blocked by a content policy (reason: PROHIBITED_CONTENT).",
+      retryable: false,
+      usage: {
+        inputTokens: 100,
+        outputTokens: 0,
+        totalTokens: 100,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+      },
+    });
+  });
+
   it("normalizes content-filter responses before reading structured output", () => {
     let outputRead = false;
     const response = {
@@ -256,5 +296,16 @@ describe("content policy errors", () => {
     const error = createNoObjectGeneratedError("error");
 
     expect(() => rethrowContentPolicyError(error)).toThrow(error);
+  });
+
+  it("preserves unrelated retry failures", () => {
+    const apiError = createApiCallError("upstream temporarily unavailable");
+    const retryError = new RetryError({
+      message: "Retries exhausted",
+      reason: "maxRetriesExceeded",
+      errors: [apiError],
+    });
+
+    expect(() => rethrowContentPolicyError(retryError)).toThrow(retryError);
   });
 });


### PR DESCRIPTION
# Overview

Extends the shared content-policy error handling introduced for summarization to every remaining structured `generateText` workflow. Provider policy rejections now surface consistently as `content_policy_error` instead of being folded into generic processing failures, and response-level `content-filter` finishes are handled before structured output is read.

# What was changed

- Wrapped generation in ask questions, burned-in captions, edit captions, and both translate-captions paths with `withContentPolicyErrorHandling`.
- Applied the same normalization inside the existing retry boundaries for chapters and engagement insights so policy failures keep their non-retryable error contract.
- Routed each changed workflow through `getGeneratedOutputWithContentPolicyHandling` before accessing structured output, so response-level content filters are normalized before the lazy output getter can discard their metadata.

# Suggested review order

1. `src/workflows/chapters.ts` and `src/workflows/engagement-insights.ts` — verify normalization is placed inside the existing retry boundary.
2. `src/workflows/ask-questions.ts`, `src/workflows/burned-in-captions.ts`, and `src/workflows/edit-captions.ts` — review the direct structured-generation pattern and guarded output reads.
3. `src/workflows/translate-captions.ts` — confirm both whole-VTT and cue-chunk translation paths use the same handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad change to error handling on many customer-facing AI workflows; behavior shifts from generic failures to explicit non-retryable `content_policy_error`, which is desirable but affects callers and retry semantics.
> 
> **Overview**
> **Provider policy rejections** now map to a consistent `content_policy_error` across ask-questions, burned-in captions, chapters, edit captions, engagement insights, and translate-captions (whole-VTT and cue-chunk paths), instead of generic processing failures.
> 
> `content-policy-error` **unwraps `RetryError`** when extracting block reasons and token usage, so a content-policy failure on the last retry attempt is still normalized. **`withContentPolicyErrorHandling`** wraps each `generateText` call; **`getGeneratedOutputWithContentPolicyHandling`** runs before reading structured output so `content-filter` finishes are handled before the lazy output getter drops metadata. Chapters and engagement insights nest that wrapper **inside** existing `withRetry` boundaries.
> 
> Unit tests cover RetryError-wrapped policy errors and unrelated retry failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a07b7fdc115125f71a3e62c370747ea17a1e85a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->