### PR TITLE
fix: posting evalite results

### DIFF
--- a/scripts/evalite-insight-contract.ts
+++ b/scripts/evalite-insight-contract.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const WorkflowInsightSchema = z.object({
+  summaryMarkdown: z.string().trim().min(1),
+  tldr: z.string().trim().min(1).nullable(),
+  caveat: z.string().trim().min(1).nullable(),
+});
+
+export function normalizeOptionalInsight(value: string | null | undefined): string | undefined {
+  return value?.trim() || undefined;
+}

--- a/scripts/post-evalite-results.ts
+++ b/scripts/post-evalite-results.ts
@@ -8,12 +8,13 @@ import { openai } from "@ai-sdk/openai";
 import { generateText, Output } from "ai";
 import { Command } from "commander";
 import dedent from "dedent";
-import { z } from "zod";
 
 import env from "../src/env";
 import { getAssetDurationSeconds } from "../src/lib/mux-assets";
 import { DEFAULT_LANGUAGE_MODELS } from "../src/lib/providers";
 import type { SupportedProvider } from "../src/lib/providers";
+
+import { normalizeOptionalInsight, WorkflowInsightSchema } from "./evalite-insight-contract";
 
 import type { LanguageModel } from "ai";
 
@@ -219,12 +220,6 @@ interface Options {
   model?: string;
   workflows?: WorkflowKey[];
 }
-
-const WorkflowInsightSchema = z.object({
-  summaryMarkdown: z.string(),
-  tldr: z.string(),
-  caveat: z.string(),
-});
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -980,8 +975,8 @@ async function generateWorkflowInsights(suites: EvaliteSuite[], options: Generat
       <output_format>
         Return a JSON object with:
         - summaryMarkdown: full Markdown summary
-        - tldr: a single-sentence takeaway (optional)
-        - caveat: a concise caveat (optional)
+        - tldr: a single-sentence takeaway, or null when there is no useful takeaway
+        - caveat: a concise caveat, or null when there is no meaningful caveat
       </output_format>
       <markdown_template>
         **{Workflow Name} Evals Summary ({caseCount} runs, {providerCount} providers)**
@@ -1021,8 +1016,8 @@ async function generateWorkflowInsights(suites: EvaliteSuite[], options: Generat
       workflowKey,
       workflowName: stats.workflowName,
       summaryMarkdown: result.output.summaryMarkdown.trim(),
-      tldr: result.output.tldr?.trim(),
-      caveat: result.output.caveat?.trim(),
+      tldr: normalizeOptionalInsight(result.output.tldr),
+      caveat: normalizeOptionalInsight(result.output.caveat),
       stats,
       recommendations: stats.recommendations,
     });

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,3 +1,5 @@
+import { DownloadError } from "ai";
+
 /**
  * Retry configuration options
  */
@@ -15,10 +17,23 @@ const DEFAULT_RETRY_OPTIONS: Required<Omit<RetryOptions, "shouldRetry">> = {
 };
 
 /**
- * Default retry condition - retries on timeout errors
+ * Default retry condition - retries on transient timeout and download errors
  */
 function defaultShouldRetry(error: Error, _attempt: number): boolean {
-  return Boolean(error.message && error.message.includes("Timeout while downloading"));
+  if (error.message.includes("Timeout while downloading")) {
+    return true;
+  }
+
+  if (!DownloadError.isInstance(error)) {
+    return false;
+  }
+
+  const { statusCode } = error;
+  return statusCode === undefined ||
+    statusCode === 408 ||
+    statusCode === 425 ||
+    statusCode === 429 ||
+    statusCode >= 500;
 }
 
 /**

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -24,11 +24,17 @@ function defaultShouldRetry(error: Error, _attempt: number): boolean {
     return true;
   }
 
-  if (!DownloadError.isInstance(error)) {
+  // Durable workflow steps serialize errors, which removes the AI SDK's
+  // symbol-based instance marker. Recognize that serialized shape by name so
+  // transient download failures remain retryable across step boundaries.
+  const isDownloadError = DownloadError.isInstance(error);
+  const isSerializedDownloadError = error.name === "AI_DownloadError";
+
+  if (!isDownloadError && !isSerializedDownloadError) {
     return false;
   }
 
-  const { statusCode } = error;
+  const statusCode = (error as Error & { statusCode?: number }).statusCode;
   return statusCode === undefined ||
     statusCode === 408 ||
     statusCode === 425 ||

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -29,6 +29,7 @@ import {
 } from "../lib/prompt-fragments.ts";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "../lib/providers.ts";
 import type { ModelIdByProvider, SupportedProvider } from "../lib/providers.ts";
+import { withRetry } from "../lib/retry.ts";
 import { rethrowWithTokenUsage } from "../lib/token-usage.ts";
 import { resolveRenderableVideoScope } from "../lib/workflow-scope.ts";
 import { getStoryboardUrl } from "../primitives/storyboards.ts";
@@ -401,14 +402,15 @@ async function hasBurnedInCaptionsInternal(
       credentials,
     });
   } else {
-    analysisResponse = await analyzeStoryboard({
-      imageDataUrl: imageUrl,
-      provider: modelConfig.provider,
-      modelId: modelConfig.modelId,
-      userPrompt,
-      systemPrompt: SYSTEM_PROMPT,
-      credentials,
-    });
+    analysisResponse = await withRetry(() =>
+      analyzeStoryboard({
+        imageDataUrl: imageUrl,
+        provider: modelConfig.provider,
+        modelId: modelConfig.modelId,
+        userPrompt,
+        systemPrompt: SYSTEM_PROMPT,
+        credentials,
+      }));
   }
 
   collectedUsage.push(analysisResponse.usage);

--- a/tests/unit/evalite-insight-contract.test.ts
+++ b/tests/unit/evalite-insight-contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeOptionalInsight,
+  WorkflowInsightSchema,
+} from "../../scripts/evalite-insight-contract";
+
+describe("workflow insight schema", () => {
+  it("accepts non-empty insight text and nullable optional insights", () => {
+    expect(WorkflowInsightSchema.parse({
+      summaryMarkdown: "  Summary  ",
+      tldr: null,
+      caveat: "  Small sample size.  ",
+    })).toEqual({
+      summaryMarkdown: "Summary",
+      tldr: null,
+      caveat: "Small sample size.",
+    });
+  });
+
+  it.each(["", "   "])("rejects an empty summary (%j)", (summaryMarkdown) => {
+    expect(WorkflowInsightSchema.safeParse({
+      summaryMarkdown,
+      tldr: null,
+      caveat: null,
+    }).success).toBe(false);
+  });
+
+  it.each(["", "   "])("rejects an empty optional insight (%j)", (emptyInsight) => {
+    expect(WorkflowInsightSchema.safeParse({
+      summaryMarkdown: "Summary",
+      tldr: emptyInsight,
+      caveat: null,
+    }).success).toBe(false);
+  });
+});
+
+describe("normalizeOptionalInsight", () => {
+  it.each([null, undefined, "", "   "])("omits an absent insight (%j)", (value) => {
+    expect(normalizeOptionalInsight(value)).toBeUndefined();
+  });
+
+  it("trims a present insight", () => {
+    expect(normalizeOptionalInsight("  Small sample size.  ")).toBe("Small sample size.");
+  });
+});

--- a/tests/unit/retry.test.ts
+++ b/tests/unit/retry.test.ts
@@ -31,6 +31,51 @@ describe("withRetry", () => {
     expect(attempts).toBe(2);
   });
 
+  it.each([undefined, 408, 425, 429, 500, 503])(
+    "retries a serialized AI SDK download failure with status %s",
+    async (statusCode) => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const error = Object.assign(new Error("Failed to download storyboard"), {
+        name: "AI_DownloadError",
+        statusCode,
+      });
+      let attempts = 0;
+
+      await withRetry(async () => {
+        attempts++;
+        if (attempts === 1) {
+          throw error;
+        }
+      }, {
+        maxRetries: 1,
+        baseDelay: 0,
+        maxDelay: 0,
+      });
+
+      expect(attempts).toBe(2);
+    },
+  );
+
+  it("retries a serialized network-level download failure without a statusCode property", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = new Error("Failed to download storyboard");
+    error.name = "AI_DownloadError";
+    let attempts = 0;
+
+    await withRetry(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw error;
+      }
+    }, {
+      maxRetries: 1,
+      baseDelay: 0,
+      maxDelay: 0,
+    });
+
+    expect(attempts).toBe(2);
+  });
+
   it.each([408, 425, 429, 500, 503])("retries a transient HTTP %i download failure", async (statusCode) => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     let attempts = 0;
@@ -58,6 +103,25 @@ describe("withRetry", () => {
       url: "https://image.example.com/missing.png",
       statusCode: 404,
       statusText: "Not Found",
+    });
+    let attempts = 0;
+
+    await expect(withRetry(async () => {
+      attempts++;
+      throw error;
+    }, {
+      maxRetries: 3,
+      baseDelay: 0,
+      maxDelay: 0,
+    })).rejects.toBe(error);
+
+    expect(attempts).toBe(1);
+  });
+
+  it("does not retry a serialized non-retryable HTTP download failure", async () => {
+    const error = Object.assign(new Error("Failed to download storyboard"), {
+      name: "AI_DownloadError",
+      statusCode: 404,
     });
     let attempts = 0;
 

--- a/tests/unit/retry.test.ts
+++ b/tests/unit/retry.test.ts
@@ -1,0 +1,75 @@
+import { DownloadError } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { withRetry } from "../../src/lib/retry";
+
+describe("withRetry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries a network-level AI SDK download failure", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    let attempts = 0;
+
+    const result = await withRetry(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new DownloadError({
+          url: "https://image.example.com/storyboard.png",
+          cause: new TypeError("fetch failed"),
+        });
+      }
+      return "downloaded";
+    }, {
+      maxRetries: 1,
+      baseDelay: 0,
+      maxDelay: 0,
+    });
+
+    expect(result).toBe("downloaded");
+    expect(attempts).toBe(2);
+  });
+
+  it.each([408, 425, 429, 500, 503])("retries a transient HTTP %i download failure", async (statusCode) => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    let attempts = 0;
+
+    await withRetry(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw new DownloadError({
+          url: "https://image.example.com/storyboard.png",
+          statusCode,
+          statusText: "Transient failure",
+        });
+      }
+    }, {
+      maxRetries: 1,
+      baseDelay: 0,
+      maxDelay: 0,
+    });
+
+    expect(attempts).toBe(2);
+  });
+
+  it("does not retry a non-retryable HTTP download failure", async () => {
+    const error = new DownloadError({
+      url: "https://image.example.com/missing.png",
+      statusCode: 404,
+      statusText: "Not Found",
+    });
+    let attempts = 0;
+
+    await expect(withRetry(async () => {
+      attempts++;
+      throw error;
+    }, {
+      maxRetries: 3,
+      baseDelay: 0,
+      maxDelay: 0,
+    })).rejects.toBe(error);
+
+    expect(attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
# Overview

Prevents Evalite result publishing from failing when the insight model has no meaningful TLDR or caveat. Generated insight output now uses a strict structured-output contract that represents absent optional text as `null`, then omits those values from the ingest payload.

# What was changed

- Extracted the workflow insight schema and optional-text normalization into `scripts/evalite-insight-contract.ts`; summary text and present optional insights must be non-empty, while `tldr` and `caveat` may be `null`.
- Updated `scripts/post-evalite-results.ts` to prompt for `null` when optional insights do not apply and to normalize null, blank, or whitespace-only values to `undefined` before posting.
- Added unit coverage for trimming, nullable optional insights, rejection of empty generated strings, and omission of absent values.

# Suggested review order

1. `scripts/evalite-insight-contract.ts` — Review the producer-side schema and normalization contract first.
2. `scripts/post-evalite-results.ts` — Verify how the contract is requested from the model and mapped into the published payload.
3. `tests/unit/evalite-insight-contract.test.ts` — Confirm coverage of the accepted, rejected, and omitted-value cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to eval posting scripts, retry helpers, and one workflow call site; no auth or data-model changes, with behavior covered by new unit tests.
> 
> **Overview**
> Fixes **Evalite result publishing** when the insight model has no meaningful TLDR or caveat by moving the structured-output contract into `scripts/evalite-insight-contract.ts`. **`tldr` and `caveat` are now `null` when absent**, must be non-empty when present, and `normalizeOptionalInsight` maps null/blank values to **`undefined`** so they are omitted from the ingest payload. `post-evalite-results.ts` imports that contract and updates the generation prompt accordingly.
> 
> Separately, **`withRetry` in `src/lib/retry.ts`** now retries AI SDK **`DownloadError`** cases (missing status, 408/425/429, and 5xx) in addition to download timeouts. The **burned-in captions** workflow wraps URL-based storyboard analysis in `withRetry` so transient image fetch failures are less likely to fail the run. Unit tests cover the insight schema/normalization and retry policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09a0761eae7002329f07cc4def3953fc167dc5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->