### PR TITLE
chore: 0.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest-only version change with no runtime or dependency updates in the diff.
> 
> **Overview**
> Bumps the published **`@mux/ai`** package version from **0.30.0** to **0.31.0** in `package.json` and the root entry in `package-lock.json`. No source, dependency, or API changes are included in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3edc935b6e456b93372506b08294d6b340f0b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->