### PR TITLE
fix: stop retrying content policy errors

### DIFF
--- a/src/lib/content-policy-error.ts
+++ b/src/lib/content-policy-error.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 import type { TokenUsage } from "../types.ts";
 
 import { MuxAiError } from "./mux-ai-error.ts";
+import { withRetry } from "./retry.ts";
+import type { RetryOptions } from "./retry.ts";
 import { getErrorTokenUsage } from "./token-usage.ts";
 
 const PolicyTokenSchema = z.string()
@@ -70,6 +72,21 @@ export async function withContentPolicyErrorHandling<T>(operation: () => Promise
   } catch (error) {
     rethrowContentPolicyError(error);
   }
+}
+
+/**
+ * Owns provider retries outside the AI SDK so content-policy errors can be
+ * normalized to a non-retryable MuxAiError before another request is made.
+ * Callers must pass `maxRetries: 0` to the AI SDK operation.
+ */
+export async function withContentPolicyAwareRetry<T>(
+  operation: () => Promise<T>,
+  retryOptions?: RetryOptions,
+): Promise<T> {
+  return withRetry(
+    () => withContentPolicyErrorHandling(operation),
+    retryOptions,
+  );
 }
 
 export function rethrowContentPolicyError(error: unknown): never {

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,4 +1,4 @@
-import { DownloadError } from "ai";
+import { APICallError, DownloadError, NoOutputGeneratedError } from "ai";
 
 /**
  * Retry configuration options
@@ -22,6 +22,34 @@ const DEFAULT_RETRY_OPTIONS: Required<Omit<RetryOptions, "shouldRetry">> = {
 function defaultShouldRetry(error: Error, _attempt: number): boolean {
   if (error.message.includes("Timeout while downloading")) {
     return true;
+  }
+
+  // Some models intermittently emit degenerate output (empty or truncated
+  // JSON) on an otherwise-healthy request; a fresh sample usually succeeds.
+  // Content-policy blocks are converted to MuxAiError before output access,
+  // so this never retries a refusal. Match by name as well because durable
+  // workflow steps serialize errors, dropping the instance marker.
+  if (
+    NoOutputGeneratedError.isInstance(error) ||
+    error.name === "AI_NoOutputGeneratedError" ||
+    error.name === "AI_NoObjectGeneratedError"
+  ) {
+    return true;
+  }
+
+  // AI SDK generation helpers normally retry these internally. Workflows set
+  // maxRetries: 0 so content-policy responses can be normalized before any
+  // retry, then delegate genuinely transient provider failures here instead.
+  if (APICallError.isInstance(error) || error.name === "AI_APICallError") {
+    const apiError = error as Error & { isRetryable?: boolean; statusCode?: number };
+    if (typeof apiError.isRetryable === "boolean") {
+      return apiError.isRetryable;
+    }
+
+    return apiError.statusCode === 408 ||
+      apiError.statusCode === 409 ||
+      apiError.statusCode === 429 ||
+      (apiError.statusCode !== undefined && apiError.statusCode >= 500);
   }
 
   // Durable workflow steps serialize errors, which removes the AI SDK's

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import {
   getGeneratedOutputWithContentPolicyHandling,
-  withContentPolicyErrorHandling,
+  withContentPolicyAwareRetry,
 } from "../lib/content-policy-error.ts";
 import type { ImageDownloadOptions } from "../lib/image-download.ts";
 import { downloadImageAsBase64 } from "../lib/image-download.ts";
@@ -33,7 +33,6 @@ import {
 } from "../lib/prompt-fragments.ts";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "../lib/providers.ts";
 import type { ModelIdByProvider, SupportedProvider } from "../lib/providers.ts";
-import { withRetry } from "../lib/retry.ts";
 import { rethrowWithTokenUsage } from "../lib/token-usage.ts";
 import { resolveMuxSigningContext } from "../lib/workflow-credentials.ts";
 import {
@@ -699,8 +698,9 @@ async function analyzeQuestions({
     maxFreeFormAnswerLength,
   );
 
-  const response = await withContentPolicyErrorHandling(() => generateText({
+  const response = await withContentPolicyAwareRetry(() => generateText({
     model,
+    maxRetries: 0,
     output: Output.object({ schema: responseSchema }),
     experimental_telemetry: { isEnabled: true },
     messages: [
@@ -997,19 +997,16 @@ async function askQuestionsInternal(
           credentials,
         });
       } else {
-        // URL-based submission with retry
-        analysisResponse = await withRetry(() =>
-          analyzeQuestions({
-            provider: modelConfig.provider,
-            modelId: modelConfig.modelId,
-            userPrompt,
-            systemPrompt,
-            normalizedQuestions,
-            maxFreeFormAnswerLength,
-            imageDataUrl: storyboardUrl,
-            credentials,
-          }),
-        );
+        analysisResponse = await analyzeQuestions({
+          provider: modelConfig.provider,
+          modelId: modelConfig.modelId,
+          userPrompt,
+          systemPrompt,
+          normalizedQuestions,
+          maxFreeFormAnswerLength,
+          imageDataUrl: storyboardUrl,
+          credentials,
+        });
       }
     }
   } catch (error: unknown) {

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import {
   getGeneratedOutputWithContentPolicyHandling,
-  withContentPolicyErrorHandling,
+  withContentPolicyAwareRetry,
 } from "../lib/content-policy-error.ts";
 import type { ImageDownloadOptions } from "../lib/image-download.ts";
 import { downloadImageAsBase64 } from "../lib/image-download.ts";
@@ -29,7 +29,6 @@ import {
 } from "../lib/prompt-fragments.ts";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "../lib/providers.ts";
 import type { ModelIdByProvider, SupportedProvider } from "../lib/providers.ts";
-import { withRetry } from "../lib/retry.ts";
 import { rethrowWithTokenUsage } from "../lib/token-usage.ts";
 import { resolveRenderableVideoScope } from "../lib/workflow-scope.ts";
 import { getStoryboardUrl } from "../primitives/storyboards.ts";
@@ -287,8 +286,9 @@ async function analyzeStoryboard({
 
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
-  const response = await withContentPolicyErrorHandling(() => generateText({
+  const response = await withContentPolicyAwareRetry(() => generateText({
     model,
+    maxRetries: 0,
     output: Output.object({ schema: burnedInCaptionsSchema }),
     experimental_telemetry: { isEnabled: true },
     messages: [
@@ -402,15 +402,14 @@ async function hasBurnedInCaptionsInternal(
       credentials,
     });
   } else {
-    analysisResponse = await withRetry(() =>
-      analyzeStoryboard({
-        imageDataUrl: imageUrl,
-        provider: modelConfig.provider,
-        modelId: modelConfig.modelId,
-        userPrompt,
-        systemPrompt: SYSTEM_PROMPT,
-        credentials,
-      }));
+    analysisResponse = await analyzeStoryboard({
+      imageDataUrl: imageUrl,
+      provider: modelConfig.provider,
+      modelId: modelConfig.modelId,
+      userPrompt,
+      systemPrompt: SYSTEM_PROMPT,
+      credentials,
+    });
   }
 
   collectedUsage.push(analysisResponse.usage);

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import {
   getGeneratedOutputWithContentPolicyHandling,
-  withContentPolicyErrorHandling,
+  withContentPolicyAwareRetry,
 } from "../lib/content-policy-error.ts";
 import { getLanguageName } from "../lib/language-codes.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
@@ -24,7 +24,6 @@ import {
 } from "../lib/prompt-fragments.ts";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "../lib/providers.ts";
 import type { ModelIdByProvider, SupportedProvider } from "../lib/providers.ts";
-import { withRetry } from "../lib/retry.ts";
 import { rethrowWithTokenUsage } from "../lib/token-usage.ts";
 import { resolveMuxSigningContext } from "../lib/workflow-credentials.ts";
 import { hasWorkflowScopeBoundaries, resolveWorkflowScope } from "../lib/workflow-scope.ts";
@@ -171,24 +170,21 @@ async function generateChaptersWithAI({
 
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
-  const response = await withRetry(() =>
-    withContentPolicyErrorHandling(() =>
-      generateText({
-        model,
-        output: Output.object({ schema: chaptersSchema }),
-        messages: [
-          {
-            role: "system",
-            content: systemPrompt,
-          },
-          {
-            role: "user",
-            content: userPrompt,
-          },
-        ],
-      }),
-    ),
-  );
+  const response = await withContentPolicyAwareRetry(() => generateText({
+    model,
+    maxRetries: 0,
+    output: Output.object({ schema: chaptersSchema }),
+    messages: [
+      {
+        role: "system",
+        content: systemPrompt,
+      },
+      {
+        role: "user",
+        content: userPrompt,
+      },
+    ],
+  }));
   const output = getGeneratedOutputWithContentPolicyHandling(response);
 
   // Detect schema-smuggling. response.output has already been stripped;

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import env from "../env.ts";
 import {
   getGeneratedOutputWithContentPolicyHandling,
-  withContentPolicyErrorHandling,
+  withContentPolicyAwareRetry,
 } from "../lib/content-policy-error.ts";
 import { MuxAiError, wrapError } from "../lib/mux-ai-error.ts";
 import {
@@ -451,8 +451,9 @@ async function identifyProfanityWithAI({
     content: plainText,
   });
 
-  const response = await withContentPolicyErrorHandling(() => generateText({
+  const response = await withContentPolicyAwareRetry(() => generateText({
     model,
+    maxRetries: 0,
     output: Output.object({ schema: profanityDetectionSchema }),
     messages: [
       {

--- a/src/workflows/embeddings.ts
+++ b/src/workflows/embeddings.ts
@@ -1,12 +1,12 @@
 import { embed } from "ai";
 
+import { withContentPolicyAwareRetry } from "../lib/content-policy-error.ts";
 import {
   getAssetDurationSecondsFromAsset,
   getPlaybackIdForAsset,
 } from "../lib/mux-assets.ts";
 import type { EmbeddingModelIdByProvider, SupportedEmbeddingProvider } from "../lib/providers.ts";
 import { createEmbeddingModelFromConfig, resolveEmbeddingModelConfig } from "../lib/providers.ts";
-import { withRetry } from "../lib/retry.ts";
 import { getErrorTokenUsage, rethrowWithTokenUsage } from "../lib/token-usage.ts";
 import { resolveMuxSigningContext } from "../lib/workflow-credentials.ts";
 import { hasWorkflowScopeBoundaries, resolveWorkflowScope } from "../lib/workflow-scope.ts";
@@ -98,9 +98,10 @@ async function generateSingleChunkEmbedding({
   "use step";
 
   const model = await createEmbeddingModelFromConfig(provider, modelId, credentials);
-  const response = await withRetry(() =>
+  const response = await withContentPolicyAwareRetry(() =>
     embed({
       model,
+      maxRetries: 0,
       value: chunk.text,
     }),
   );

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import {
   getGeneratedOutputWithContentPolicyHandling,
-  withContentPolicyErrorHandling,
+  withContentPolicyAwareRetry,
 } from "../lib/content-policy-error.ts";
 import { MuxAiError } from "../lib/mux-ai-error.ts";
 import {
@@ -29,7 +29,6 @@ import {
 } from "../lib/prompt-fragments.ts";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "../lib/providers.ts";
 import type { ModelIdByProvider, SupportedProvider } from "../lib/providers.ts";
-import { withRetry } from "../lib/retry.ts";
 import { rethrowWithTokenUsage } from "../lib/token-usage.ts";
 import { signUrl } from "../lib/url-signing.ts";
 import { resolveMuxSigningContext } from "../lib/workflow-credentials.ts";
@@ -546,28 +545,25 @@ async function generateInsightsWithAI(
 
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
 
-  const response = await withRetry(() =>
-    withContentPolicyErrorHandling(() =>
-      generateText({
-        model,
-        output: Output.object({ schema: engagementInsightsSchema }),
-        experimental_telemetry: { isEnabled: true },
-        messages: [
-          {
-            role: "system",
-            content: systemPrompt,
-          },
-          {
-            role: "user",
-            content: [
-              { type: "text", text: userPrompt },
-              ...imageUrls.map(url => ({ type: "image" as const, image: url })),
-            ],
-          },
+  const response = await withContentPolicyAwareRetry(() => generateText({
+    model,
+    maxRetries: 0,
+    output: Output.object({ schema: engagementInsightsSchema }),
+    experimental_telemetry: { isEnabled: true },
+    messages: [
+      {
+        role: "system",
+        content: systemPrompt,
+      },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: userPrompt },
+          ...imageUrls.map(url => ({ type: "image" as const, image: url })),
         ],
-      }),
-    ),
-  );
+      },
+    ],
+  }));
   const output = getGeneratedOutputWithContentPolicyHandling(response);
 
   if (!output) {

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 import {
   getGeneratedOutputWithContentPolicyHandling,
-  withContentPolicyErrorHandling,
+  withContentPolicyAwareRetry,
 } from "../lib/content-policy-error.ts";
 import type { ImageDownloadOptions } from "../lib/image-download.ts";
 import { downloadImageAsBase64 } from "../lib/image-download.ts";
@@ -43,7 +43,6 @@ import {
 } from "../lib/prompt-fragments.ts";
 import { createLanguageModelFromConfig, resolveLanguageModelConfig } from "../lib/providers.ts";
 import type { ModelIdByProvider, SupportedProvider } from "../lib/providers.ts";
-import { withRetry } from "../lib/retry.ts";
 import { rethrowWithTokenUsage } from "../lib/token-usage.ts";
 import {
   resolveMuxSigningContext,
@@ -554,8 +553,9 @@ async function analyzeStoryboard(
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
   const schema = buildSummarySchema(descriptionLength);
 
-  const response = await withContentPolicyErrorHandling(() => generateText({
+  const response = await withContentPolicyAwareRetry(() => generateText({
     model,
+    maxRetries: 0,
     output: Output.object({
       name: "summary_metadata",
       description: "Structured summary with title, description, and keywords.",
@@ -617,8 +617,9 @@ async function analyzeAudioOnly(
   const model = await createLanguageModelFromConfig(provider, modelId, credentials);
   const schema = buildSummarySchema(descriptionLength);
 
-  const response = await withContentPolicyErrorHandling(() => generateText({
+  const response = await withContentPolicyAwareRetry(() => generateText({
     model,
+    maxRetries: 0,
     output: Output.object({
       name: "summary_metadata",
       description: "Structured summary with title, description, and keywords.",
@@ -860,17 +861,15 @@ async function getSummaryAndTagsInternal(
           workflowCredentials,
         );
       } else {
-        // URL-based submission with retry logic
-        analysisResponse = await withRetry(() =>
-          analyzeStoryboard(
-            storyboardUrl,
-            modelConfig.provider,
-            modelConfig.modelId,
-            userPrompt,
-            systemPrompt,
-            effectiveDescriptionLength,
-            workflowCredentials,
-          ));
+        analysisResponse = await analyzeStoryboard(
+          storyboardUrl,
+          modelConfig.provider,
+          modelConfig.modelId,
+          userPrompt,
+          systemPrompt,
+          effectiveDescriptionLength,
+          workflowCredentials,
+        );
       }
     }
   } catch (error: unknown) {

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import env from "../env.ts";
 import {
   getGeneratedOutputWithContentPolicyHandling,
-  withContentPolicyErrorHandling,
+  withContentPolicyAwareRetry,
 } from "../lib/content-policy-error.ts";
 import { getLanguageCodePair, getLanguageName } from "../lib/language-codes.ts";
 import type { LanguageCodePair, SupportedISO639_1 } from "../lib/language-codes.ts";
@@ -606,8 +606,9 @@ async function translateVttWithAI({
   // blocks implicitly.
   const sanitisedVttContent = stripVttMetadataBlocks(vttContent);
 
-  const response = await withContentPolicyErrorHandling(() => generateText({
+  const response = await withContentPolicyAwareRetry(() => generateText({
     model,
+    maxRetries: 0,
     output: Output.object({ schema: translationSchema }),
     messages: [
       {
@@ -716,8 +717,9 @@ async function translateCueChunkWithAI({
     text: cue.text,
   }));
 
-  const response = await withContentPolicyErrorHandling(() => generateText({
+  const response = await withContentPolicyAwareRetry(() => generateText({
     model,
+    maxRetries: 0,
     output: Output.object({ schema }),
     messages: [
       {

--- a/tests/unit/content-policy-error.test.ts
+++ b/tests/unit/content-policy-error.test.ts
@@ -1,10 +1,13 @@
-import { APICallError, NoObjectGeneratedError, RetryError } from "ai";
+import { APICallError, generateText, NoObjectGeneratedError, Output, RetryError } from "ai";
+import { MockLanguageModelV3 } from "ai/test";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import {
   extractContentPolicyBlock,
   getGeneratedOutputWithContentPolicyHandling,
   rethrowContentPolicyError,
+  withContentPolicyAwareRetry,
   withContentPolicyErrorHandling,
 } from "../../src/lib/content-policy-error.ts";
 import { wrapError } from "../../src/lib/mux-ai-error.ts";
@@ -137,6 +140,97 @@ describe("content policy errors", () => {
       publicMessage: "The supplied content was blocked by a content policy (reason: PROHIBITED_CONTENT).",
       retryable: false,
     });
+  });
+
+  it("does not retry a content-policy API error marked retryable by the provider", async () => {
+    const error = new APICallError({
+      message: "Provider rejected the content",
+      url: "https://example.com/generate-content",
+      requestBodyValues: {},
+      statusCode: 500,
+      isRetryable: true,
+      responseBody: JSON.stringify({
+        promptFeedback: {
+          blockReason: "PROHIBITED_CONTENT",
+        },
+      }),
+    });
+    let attempts = 0;
+
+    await expect(withContentPolicyAwareRetry(async () => {
+      attempts++;
+      throw error;
+    }, {
+      maxRetries: 3,
+      baseDelay: 0,
+      maxDelay: 0,
+    })).rejects.toMatchObject({
+      publicType: "content_policy_error",
+      retryable: false,
+    });
+
+    expect(attempts).toBe(1);
+  });
+
+  it("continues retrying transient provider API errors", async () => {
+    const error = new APICallError({
+      message: "Service unavailable",
+      url: "https://example.com/generate-content",
+      requestBodyValues: {},
+      statusCode: 503,
+      isRetryable: true,
+    });
+    let attempts = 0;
+
+    const result = await withContentPolicyAwareRetry(async () => {
+      attempts++;
+      if (attempts === 1) {
+        throw error;
+      }
+      return "generated";
+    }, {
+      maxRetries: 1,
+      baseDelay: 0,
+      maxDelay: 0,
+    });
+
+    expect(result).toBe("generated");
+    expect(attempts).toBe(2);
+  });
+
+  it("retries invalid structured JSON and returns the recovered output", async () => {
+    let attempts = 0;
+    const model = new MockLanguageModelV3({
+      doGenerate: async () => {
+        attempts++;
+        return {
+          content: [{
+            type: "text",
+            text: attempts === 1 ? "{\"result\":" : "{\"result\":\"recovered\"}",
+          }],
+          finishReason: { unified: "stop", raw: "STOP" },
+          usage: {
+            inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+            outputTokens: { total: 5, text: 5, reasoning: 0 },
+          },
+          warnings: [],
+        };
+      },
+    });
+
+    const response = await withContentPolicyAwareRetry(() => generateText({
+      model,
+      maxRetries: 0,
+      output: Output.object({ schema: z.object({ result: z.string() }) }),
+      prompt: "Return structured output",
+    }), {
+      maxRetries: 1,
+      baseDelay: 0,
+      maxDelay: 0,
+    });
+
+    expect(response.output).toEqual({ result: "recovered" });
+    expect(attempts).toBe(2);
   });
 
   it("preserves token usage when normalizing content policy errors", async () => {


### PR DESCRIPTION
# Overview

Prevents permanent content-policy rejections from making repeated provider requests while preserving recovery for transient provider failures and malformed structured output. Retry ownership moves outside the AI SDK so content-policy responses are normalized to non-retryable `MuxAiError`s before another attempt is considered.

# What was changed

- Added a content-policy-aware retry wrapper that normalizes policy failures before applying the shared retry policy.
- Expanded the shared retry classifier to recover from retryable AI SDK API failures and missing or invalid structured output, including serialized workflow-step errors.
- Routed language-generation and embedding workflows through the shared wrapper and disabled the AI SDK's nested retries with `maxRetries: 0`, avoiding duplicate retry layers.
- Added focused coverage proving content-policy errors make one attempt while transient API errors and invalid structured JSON still recover on retry.

# Suggested review order

1. `src/lib/content-policy-error.ts` and `src/lib/retry.ts` — review the retry ownership and permanent-versus-transient error classification first.
2. `src/workflows/` generation and embedding call sites — verify each workflow delegates retries to the shared wrapper without changing its prompts or output contracts.
3. `tests/unit/content-policy-error.test.ts` — confirm the non-retryable policy path and retained recovery paths are covered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches retry behavior across all LLM/embedding workflow steps; misclassification could either waste calls on policy blocks or drop legitimate transient recovery, though new tests cover the main paths.
> 
> **Overview**
> **Moves provider retries out of the AI SDK** so content-policy failures are normalized to non-retryable `MuxAiError`s before any follow-up request. Workflows now call `withContentPolicyAwareRetry` around `generateText` / `embed` with **`maxRetries: 0`**, replacing ad-hoc `withRetry` + `withContentPolicyErrorHandling` stacks and outer URL-only retries.
> 
> **`defaultShouldRetry` in `retry.ts`** now also retries transient `APICallError`s (including serialized `AI_APICallError`), and degenerate structured output (`NoOutputGeneratedError` / `AI_NoObjectGeneratedError`), while policy blocks stay single-attempt after normalization.
> 
> Unit tests assert policy errors never retry even when the provider marks them retryable, and that transient API / bad JSON still recover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a87453e316ab93f3a42f6f81f040eb2030addb9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->