### PR TITLE
fix: Fix missing language guides in ask-questions

### DIFF
--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -21,6 +21,7 @@ import { createTranscriptSection, renderSection } from "../lib/prompt-builder.ts
 import {
   CANARY_TRIPWIRE,
   CONFIDENCE_SCORING_RUBRIC,
+  createLanguageGuidelines,
   METADATA_BOUNDARY_WARNING,
   NO_FABRICATION_CONSTRAINT,
   NON_DISCLOSURE_CONSTRAINT,
@@ -342,11 +343,9 @@ const SYSTEM_PROMPT = promptDedent`
   </constraints>
 
   <language_guidelines>
-    When explaining reasoning:
-    - Describe content directly, not the medium
-    - BAD: "The video shows a person running"
-    - GOOD: "A person runs through a park"
-    - Be specific and evidence-based
+    When explaining reasoning, be specific and evidence-based.
+
+    ${createLanguageGuidelines("video")}
   </language_guidelines>`;
 
 const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
@@ -440,11 +439,9 @@ const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
   </constraints>
 
   <language_guidelines>
-    When explaining reasoning:
-    - Describe content directly, not the medium
-    - BAD: "The audio says someone is running"
-    - GOOD: "The speaker describes running through a park"
-    - Be specific and evidence-based
+    When explaining reasoning, be specific and evidence-based.
+
+    ${createLanguageGuidelines("audio")}
   </language_guidelines>`;
 
 // Appended to the system prompt only when free-form mode is in use.


### PR DESCRIPTION
## Summary

The `askQuestions` prompts keep producing meta-descriptive reasoning like "The storyboard shows the rabbit setting up traps…" despite guidance to describe content directly.

Turns out ask-questions never got the full anti-meta-description avoid-list — when #174 consolidated shared prompt text into `createLanguageGuidelines()`, only summarization adopted it, and ask-questions kept its original weak three-line block whose only example was "The video shows…".

This swaps both the video and audio-only system prompts over to the shared fragment, which explicitly bans "The storyboard shows…", "The image shows…", "The frames depict…" etc., while keeping the "be specific and evidence-based" instruction.

## Example

Before: "The storyboard shows the rabbit setting up traps that result in the bullies getting caught."
After: "The rabbit sets up traps that catch the bullies by the end of the sequence."

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Prompt-only change that reuses an existing shared fragment; no logic, API, or security-path changes.
> 
> **Overview**
> Restores the fuller anti-meta-description language guidance in `askQuestions` by swapping the short inline examples for the shared `createLanguageGuidelines` helper.
> 
> Both the video and audio-only system prompts now call `createLanguageGuidelines("video")` / `createLanguageGuidelines("audio")`, matching the richer avoid-lists already used in summarization, while keeping the “be specific and evidence-based” lead-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fea9bf3c08d09583fb69f3bbafc83d3736fa0105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
