### PR TITLE
fix: Update translateAudio to automatically clean up static renditions after runs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -575,6 +575,7 @@ Creates AI-dubbed audio tracks from existing media content using ElevenLabs voic
 - `storageAdapter?: StorageAdapter` - Optional adapter with `putObject` and `createPresignedGetUrl` methods
 - `s3SignedUrlExpirySeconds?: number` - Expiry duration in seconds for S3 presigned GET URLs (default: 86400 / 24 hours)
 - `dubbingPollTimeoutSeconds?: number` - Max time to wait for ElevenLabs to finish dubbing before timing out (default: 7200 / 2 hours). Raise for long-form content or when jobs queue behind the concurrency limit.
+- `staticRenditionCleanup?: 'delete' | 'keep'` - What to do with an `audio.m4a` static rendition the workflow created as dubbing input (default: 'delete'). A rendition that already existed on the asset is never deleted.
 
 **Returns:**
 
@@ -586,13 +587,15 @@ interface TranslateAudioResult {
   dubbingId: string; // ElevenLabs dubbing job ID
   uploadedTrackId?: string; // Mux audio track ID (if uploaded)
   presignedUrl?: string; // S3 presigned URL (default expiry: 24 hours)
+  createdStaticRenditionId?: string; // Static rendition ID this run created (undefined if one already existed)
+  staticRenditionCleanup: "deleted" | "delete_failed" | "kept" | "not_created";
   usage?: TokenUsage; // Workflow usage metadata
 }
 ```
 
 **Requirements:**
 
-- Asset must have an `audio.m4a` static rendition (auto-requested if missing)
+- Asset must have an `audio.m4a` static rendition (auto-requested if missing, and deleted again afterwards by default — see `staticRenditionCleanup`)
 - ElevenLabs API key with Creator plan or higher
 - S3-compatible storage for Mux ingestion
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -575,7 +575,7 @@ Creates AI-dubbed audio tracks from existing media content using ElevenLabs voic
 - `storageAdapter?: StorageAdapter` - Optional adapter with `putObject` and `createPresignedGetUrl` methods
 - `s3SignedUrlExpirySeconds?: number` - Expiry duration in seconds for S3 presigned GET URLs (default: 86400 / 24 hours)
 - `dubbingPollTimeoutSeconds?: number` - Max time to wait for ElevenLabs to finish dubbing before timing out (default: 7200 / 2 hours). Raise for long-form content or when jobs queue behind the concurrency limit.
-- `staticRenditionCleanup?: 'delete' | 'keep'` - What to do with an `audio.m4a` static rendition the workflow created as dubbing input (default: 'delete'). A rendition that already existed on the asset is never deleted.
+- `staticRenditionCleanup?: 'delete' | 'keep'` - What to do with an `audio.m4a` static rendition the workflow created as dubbing input (default: 'delete'). A rendition that already existed on the asset is never deleted. When dubbing multiple languages concurrently on one asset, create the rendition before fanning out or pass 'keep' — the creating run's delete can otherwise race a concurrent run's source fetch.
 
 **Returns:**
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -731,7 +731,7 @@ console.log(result.presignedUrl); // S3 audio file URL
 
 ### Requirements
 
-- Asset must have an `audio.m4a` static rendition
+- Asset must have an `audio.m4a` static rendition (auto-requested if missing; a rendition the workflow creates is deleted afterwards by default, configurable via `staticRenditionCleanup: "delete" | "keep"`)
 - ElevenLabs API key with Creator plan or higher
 - S3-compatible storage (same as caption translation)
 
@@ -741,7 +741,7 @@ ElevenLabs supports 32+ languages with automatic language name detection via `In
 
 ### Audio Dubbing Workflow
 
-1. Checks asset has audio.m4a static rendition
+1. Checks asset has audio.m4a static rendition (requests one if missing)
 2. Downloads default audio track from Mux
 3. Creates ElevenLabs dubbing job (source language auto-detected unless `fromLanguageCode` is set)
 4. Polls for completion (up to 30 minutes)
@@ -750,6 +750,7 @@ ElevenLabs supports 32+ languages with automatic language name detection via `In
 7. Generates presigned URL (default 24-hour expiry, configurable via `s3SignedUrlExpirySeconds`)
 8. Adds new audio track to Mux asset
 9. Track name: "{Language} (auto-dubbed)"
+10. Deletes the static rendition if this run created it (default; set `staticRenditionCleanup: "keep"` to retain it). Runs on failure paths too, and the outcome is reported in `result.staticRenditionCleanup`.
 
 ## Multi-Provider Support
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -752,6 +752,9 @@ ElevenLabs supports 32+ languages with automatic language name detection via `In
 9. Track name: "{Language} (auto-dubbed)"
 10. Deletes the static rendition if this run created it (default; set `staticRenditionCleanup: "keep"` to retain it). Runs on failure paths too, and the outcome is reported in `result.staticRenditionCleanup`.
 
+> [!WARNING]
+> Concurrent `translateAudio` runs on the same asset share one static rendition, and the run that created it deletes it without knowing about its peers — the delete can race another run's ElevenLabs source fetch and fail that dub. When dubbing multiple languages concurrently, either create the `audio.m4a` rendition before fanning out (a pre-existing rendition is never deleted) or pass `staticRenditionCleanup: "keep"` and clean up after the batch.
+
 ## Multi-Provider Support
 
 All workflows support multiple AI providers with consistent interfaces.

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -93,17 +93,11 @@ export interface AudioTranslationOptions extends MuxAIOptions {
    */
   uploadCaptionsToMux?: boolean;
   /**
-   * What to do with an audio-only static rendition this workflow created as
-   * dubbing input. `"delete"` (default) removes it once the workflow finishes,
-   * on both success and failure. `"keep"` leaves it on the asset. A rendition
-   * that already existed on the asset is never deleted regardless of this setting.
-   *
-   * Concurrent runs on the same asset share one rendition, and the run that
-   * created it deletes it without knowing about its peers — the delete can race
-   * a peer's ElevenLabs source fetch and fail that dub. When dubbing multiple
-   * languages concurrently, either create the rendition before fanning out
-   * (a pre-existing rendition is never deleted) or pass `"keep"` and clean up
-   * after the batch.
+   * Cleanup for the audio-only static rendition this run created as dubbing
+   * input: `"delete"` (default) removes it when the workflow finishes, success
+   * or failure; `"keep"` leaves it. A pre-existing rendition is never deleted.
+   * Concurrent dubs of one asset share a rendition, so create it up front or
+   * pass `"keep"` — one run's delete can race a peer's source fetch.
    */
   staticRenditionCleanup?: "delete" | "keep";
   /** Optional storage adapter override for upload + presign operations. */

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -25,6 +25,9 @@ import type {
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
 
+/** What happened to the audio-only static rendition `translateAudio` created as dubbing input. */
+export type StaticRenditionCleanupOutcome = "deleted" | "delete_failed" | "kept" | "not_created";
+
 /** Output returned from `translateAudio`. */
 export interface AudioTranslationResult {
   assetId: string;
@@ -42,6 +45,10 @@ export interface AudioTranslationResult {
   captionsTrackId?: string;
   /** Presigned URL for the dub's translated transcript (WebVTT) staged to S3. */
   captionsPresignedUrl?: string;
+  /** ID of the audio-only static rendition this run created, `undefined` when a usable rendition already existed. */
+  createdStaticRenditionId?: string;
+  /** Outcome of cleaning up the static rendition this run created (`not_created` when it reused an existing one). */
+  staticRenditionCleanup: StaticRenditionCleanupOutcome;
   /** Workflow usage metadata (asset duration, thumbnails, etc.). */
   usage?: TokenUsage;
 }
@@ -85,6 +92,13 @@ export interface AudioTranslationOptions extends MuxAIOptions {
    * text tracks — callers decide conflict semantics before enabling this.
    */
   uploadCaptionsToMux?: boolean;
+  /**
+   * What to do with an audio-only static rendition this workflow created as
+   * dubbing input. `"delete"` (default) removes it once the workflow finishes,
+   * on both success and failure. `"keep"` leaves it on the asset. A rendition
+   * that already existed on the asset is never deleted regardless of this setting.
+   */
+  staticRenditionCleanup?: "delete" | "keep";
   /** Optional storage adapter override for upload + presign operations. */
   storageAdapter?: StorageAdapter;
   /** Expiry duration in seconds for S3 presigned GET URLs. Defaults to 86400 (24 hours). */
@@ -132,17 +146,23 @@ function getAudioStaticRenditionStatus(asset: any): string {
   return asset.static_renditions ? "requested" : "not_requested";
 }
 
+/**
+ * Requests an audio-only static rendition and returns its ID when this call
+ * created it. Returns `undefined` when the rendition was already defined on
+ * the asset (409/"already defined"), so callers know not to clean it up.
+ */
 async function requestStaticRenditionCreation(
   assetId: string,
   credentials?: WorkflowCredentialsInput,
-) {
+): Promise<string | undefined> {
   "use step";
   const muxClient = await resolveMuxClient(credentials);
   const mux = await muxClient.createClient();
   try {
-    await mux.video.assets.createStaticRendition(assetId, {
+    const rendition = await mux.video.assets.createStaticRendition(assetId, {
       resolution: "audio-only",
     });
+    return rendition.id;
   } catch (error: any) {
     const statusCode = error?.status ?? error?.statusCode;
     const messages: string[] | undefined = error?.error?.messages;
@@ -151,10 +171,41 @@ async function requestStaticRenditionCreation(
       error?.message?.toLowerCase().includes("already defined");
 
     if (statusCode === 409 || alreadyDefined) {
-      return;
+      return undefined;
     }
 
     wrapError(error, "Failed to request static rendition from Mux");
+  }
+}
+
+/**
+ * Deletes the static rendition this run created. Never throws: a failed
+ * cleanup must not mask the workflow's real outcome, and a throwing step
+ * would trigger Workflow DevKit retries. Every outcome is logged.
+ */
+async function deleteCreatedStaticRendition(
+  assetId: string,
+  staticRenditionId: string,
+  credentials?: WorkflowCredentialsInput,
+): Promise<"deleted" | "delete_failed"> {
+  "use step";
+  try {
+    const muxClient = await resolveMuxClient(credentials);
+    const mux = await muxClient.createClient();
+    await mux.video.assets.deleteStaticRendition(assetId, staticRenditionId);
+    console.warn(`🧹 Deleted static rendition ${staticRenditionId} created on asset ${assetId}`);
+    return "deleted";
+  } catch (error: any) {
+    const statusCode = error?.status ?? error?.statusCode;
+    if (statusCode === 404) {
+      console.warn(`🧹 Static rendition ${staticRenditionId} on asset ${assetId} was already deleted`);
+      return "deleted";
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `⚠️ Failed to delete static rendition ${staticRenditionId} on asset ${assetId} (status: ${statusCode ?? "unknown"}): ${message}`,
+    );
+    return "delete_failed";
   }
 }
 
@@ -170,6 +221,8 @@ async function retrieveAsset(
 
 // Orchestration-level (not a step): the poll loop must call the durable `sleep`,
 // which suspends the workflow between retries without holding the function open.
+// Requesting creation happens in the workflow body before this is called, so the
+// created rendition's ID is known (and can be cleaned up) even if this times out.
 async function waitForAudioStaticRendition({
   assetId,
   initialAsset,
@@ -183,16 +236,6 @@ async function waitForAudioStaticRendition({
 
   if (hasReadyAudioStaticRendition(currentAsset)) {
     return currentAsset;
-  }
-
-  const status = currentAsset.static_renditions?.status ?? "not_requested";
-
-  if (status === "not_requested" || status === undefined) {
-    await requestStaticRenditionCreation(assetId, credentials);
-  } else if (status === "errored") {
-    await requestStaticRenditionCreation(assetId, credentials);
-  } else {
-    console.warn(`ℹ️ Static rendition already ${status}. Waiting for it to finish...`);
   }
 
   for (let attempt = 1; attempt <= STATIC_RENDITION_MAX_ATTEMPTS; attempt++) {
@@ -495,6 +538,7 @@ export async function translateAudio(
     uploadToS3: uploadToS3Option,
     uploadToMux: uploadToMuxOption,
     uploadCaptionsToMux = false,
+    staticRenditionCleanup: staticRenditionCleanupOption = "delete",
     storageAdapter,
     credentials: providedCredentials,
   } = options;
@@ -524,182 +568,212 @@ export async function translateAudio(
   const { asset: initialAsset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(initialAsset);
 
-  // Check for audio-only static rendition
-
+  // Check for audio-only static rendition. Requesting creation happens here
+  // (not inside the poll helper) so the created rendition's ID is captured
+  // before any waiting begins and cleanup covers every exit path after this,
+  // including poll timeouts.
   let currentAsset = initialAsset;
+  let createdStaticRenditionId: string | undefined;
   if (!hasReadyAudioStaticRendition(currentAsset)) {
     console.warn("❌ No ready audio static rendition found. Requesting one now...");
-    currentAsset = await waitForAudioStaticRendition({
-      assetId,
-      initialAsset: currentAsset,
-      credentials,
-    });
-  }
-
-  const audioRendition = getReadyAudioStaticRendition(currentAsset);
-
-  if (!audioRendition) {
-    throw new MuxAiError(
-      "Unable to obtain an audio-only static rendition for this asset. Please verify static renditions are enabled in Mux.",
-      { type: "validation_error" },
-    );
-  }
-
-  // Build audio URL (signed if needed)
-  let audioUrl = `${getMuxStreamOrigin()}/${playbackId}/audio.m4a`;
-  if (policy === "signed") {
-    audioUrl = await signUrl(audioUrl, playbackId, "video", undefined, credentials);
-  }
-
-  // Create dubbing job in ElevenLabs
-  console.warn("🎙️ Creating dubbing job in ElevenLabs...");
-
-  // ElevenLabs uses ISO 639-3 (3-letter) codes, so normalize the input
-  const elevenLabsLangCode = toISO639_3(toLanguageCode);
-  const normalizedFromLanguageCode = fromLanguageCode?.trim();
-  const elevenLabsSourceLangCode = normalizedFromLanguageCode ? toISO639_3(normalizedFromLanguageCode) : undefined;
-  console.warn(
-    `🔍 Creating dubbing job for asset ${assetId}: ${elevenLabsSourceLangCode ?? "auto"} -> ${elevenLabsLangCode}`,
-  );
-
-  let dubbingId: string;
-  try {
-    dubbingId = await createElevenLabsDubbingJob({
-      sourceUrl: audioUrl,
-      assetId,
-      elevenLabsLangCode,
-      elevenLabsSourceLangCode,
-      numSpeakers,
-      credentials,
-    });
-    console.warn(`✅ Dubbing job created with ID: ${dubbingId}`);
-  } catch (error) {
-    wrapError(error, "Failed to create ElevenLabs dubbing job");
-  }
-
-  // Poll for completion. ElevenLabs added intermediate dubbing states
-  console.warn("⏳ Waiting for dubbing to complete...");
-
-  const dubbingPollTimeoutSeconds = options.dubbingPollTimeoutSeconds ?? DEFAULT_DUBBING_POLL_TIMEOUT_SECONDS;
-  const maxPollAttempts = Math.max(1, Math.ceil((dubbingPollTimeoutSeconds * 1000) / DUBBING_POLL_INTERVAL_MS));
-
-  let dubbingStatus = "dubbing";
-  let pollAttempts = 0;
-  let targetLanguages: string[] = [];
-
-  while (dubbingStatus !== "dubbed" && pollAttempts < maxPollAttempts) {
-    await sleep(DUBBING_POLL_INTERVAL_MS);
-    pollAttempts++;
-
-    try {
-      const statusResult = await checkElevenLabsDubbingStatus({
-        dubbingId,
-        credentials,
-      });
-      dubbingStatus = statusResult.status;
-      targetLanguages = statusResult.targetLanguages;
-    } catch (error) {
-      wrapError(error, "Failed to check dubbing status");
-    }
-
-    if (dubbingStatus === "failed") {
-      throw new MuxAiError("ElevenLabs reported that the dubbing job failed.", { type: "processing_error" });
+    const renditionStatus = currentAsset.static_renditions?.status ?? "not_requested";
+    if (renditionStatus === "not_requested" || renditionStatus === "errored") {
+      // Re-requesting over an errored rendition counts as created by this run:
+      // the resulting rendition only exists because we asked for it.
+      createdStaticRenditionId = await requestStaticRenditionCreation(assetId, credentials);
+    } else {
+      console.warn(`ℹ️ Static rendition already ${renditionStatus}. Waiting for it to finish...`);
     }
   }
 
-  if (dubbingStatus !== "dubbed") {
-    throw new MuxAiError("Audio translation timed out or failed. Please try again.", { type: "timeout_error", retryable: true });
-  }
-
-  console.warn("✅ Dubbing completed successfully!");
-
+  let staticRenditionCleanup: StaticRenditionCleanupOutcome = "not_created";
+  let dubbingId!: string;
   let presignedUrl: string | undefined;
   let uploadedTrackId: string | undefined;
   let captionsPresignedUrl: string | undefined;
   let captionsTrackId: string | undefined;
 
-  if (uploadToS3) {
-    console.warn("📥 Downloading dubbed audio from ElevenLabs and staging to S3...");
-
-    // ElevenLabs reports target_languages in ISO 639-1 and the download
-    // endpoint expects one of those codes. A single-target dub yields exactly
-    // one entry, so use it directly; fall back to the ISO 639-1 form of the
-    // requested language if the array is unexpectedly empty.
-    const downloadLangCode = targetLanguages[0] ?? toISO639_1(toLanguageCode);
-
-    try {
-      presignedUrl = await downloadAndUploadDubbedAudio({
-        dubbingId,
-        languageCode: downloadLangCode,
+  try {
+    if (!hasReadyAudioStaticRendition(currentAsset)) {
+      currentAsset = await waitForAudioStaticRendition({
         assetId,
-        toLanguageCode,
-        s3Endpoint: s3Endpoint!,
-        s3Region,
-        s3Bucket: s3Bucket!,
-        storageAdapter: effectiveStorageAdapter,
-        s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
+        initialAsset: currentAsset,
         credentials,
       });
-      console.warn("✅ Dubbed audio staged to S3 successfully!");
-    } catch (error) {
-      wrapError(error, "Failed to download and upload dubbed audio");
     }
 
-    // Add translated audio track to Mux asset (only when uploadToMux is true)
-    if (uploadToMux) {
-      console.warn("📹 Adding dubbed audio track to Mux asset...");
-      // Mux uses ISO 639-1 (2-letter) codes for track language_code
-      const muxLangCode = toISO639_1(toLanguageCode);
+    const audioRendition = getReadyAudioStaticRendition(currentAsset);
+
+    if (!audioRendition) {
+      throw new MuxAiError(
+        "Unable to obtain an audio-only static rendition for this asset. Please verify static renditions are enabled in Mux.",
+        { type: "validation_error" },
+      );
+    }
+
+    // Build audio URL (signed if needed)
+    let audioUrl = `${getMuxStreamOrigin()}/${playbackId}/audio.m4a`;
+    if (policy === "signed") {
+      audioUrl = await signUrl(audioUrl, playbackId, "video", undefined, credentials);
+    }
+
+    // Create dubbing job in ElevenLabs
+    console.warn("🎙️ Creating dubbing job in ElevenLabs...");
+
+    // ElevenLabs uses ISO 639-3 (3-letter) codes, so normalize the input
+    const elevenLabsLangCode = toISO639_3(toLanguageCode);
+    const normalizedFromLanguageCode = fromLanguageCode?.trim();
+    const elevenLabsSourceLangCode = normalizedFromLanguageCode ? toISO639_3(normalizedFromLanguageCode) : undefined;
+    console.warn(
+      `🔍 Creating dubbing job for asset ${assetId}: ${elevenLabsSourceLangCode ?? "auto"} -> ${elevenLabsLangCode}`,
+    );
+
+    try {
+      dubbingId = await createElevenLabsDubbingJob({
+        sourceUrl: audioUrl,
+        assetId,
+        elevenLabsLangCode,
+        elevenLabsSourceLangCode,
+        numSpeakers,
+        credentials,
+      });
+      console.warn(`✅ Dubbing job created with ID: ${dubbingId}`);
+    } catch (error) {
+      wrapError(error, "Failed to create ElevenLabs dubbing job");
+    }
+
+    // Poll for completion. ElevenLabs added intermediate dubbing states
+    console.warn("⏳ Waiting for dubbing to complete...");
+
+    const dubbingPollTimeoutSeconds = options.dubbingPollTimeoutSeconds ?? DEFAULT_DUBBING_POLL_TIMEOUT_SECONDS;
+    const maxPollAttempts = Math.max(1, Math.ceil((dubbingPollTimeoutSeconds * 1000) / DUBBING_POLL_INTERVAL_MS));
+
+    let dubbingStatus = "dubbing";
+    let pollAttempts = 0;
+    let targetLanguages: string[] = [];
+
+    while (dubbingStatus !== "dubbed" && pollAttempts < maxPollAttempts) {
+      await sleep(DUBBING_POLL_INTERVAL_MS);
+      pollAttempts++;
 
       try {
-        uploadedTrackId = await createAudioTrackOnMux(assetId, muxLangCode, presignedUrl!, credentials);
-        const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
-        const trackName = `${languageName} (auto-dubbed)`;
-        console.warn(`✅ Track added to Mux asset with ID: ${uploadedTrackId}`);
-        console.warn(`📋 Track name: "${trackName}"`);
+        const statusResult = await checkElevenLabsDubbingStatus({
+          dubbingId,
+          credentials,
+        });
+        dubbingStatus = statusResult.status;
+        targetLanguages = statusResult.targetLanguages;
       } catch (error) {
-        console.warn(`⚠️ Failed to add audio track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
-        console.warn("🔗 You can manually add the track using this presigned URL:");
-        console.warn(presignedUrl);
+        wrapError(error, "Failed to check dubbing status");
+      }
+
+      if (dubbingStatus === "failed") {
+        throw new MuxAiError("ElevenLabs reported that the dubbing job failed.", { type: "processing_error" });
       }
     }
 
-    // The dub's translated transcript is the same translation that was voiced, and
-    // fetching it costs nothing extra. Soft-fail everything here: a transcript problem
-    // must never fail a completed, paid-for dub.
-    try {
-      console.warn("📥 Downloading dub transcript from ElevenLabs and staging to S3...");
-      captionsPresignedUrl = await downloadAndUploadDubTranscript({
-        dubbingId,
-        languageCode: downloadLangCode,
-        assetId,
-        toLanguageCode,
-        s3Endpoint: s3Endpoint!,
-        s3Region,
-        s3Bucket: s3Bucket!,
-        storageAdapter: effectiveStorageAdapter,
-        s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
-        credentials,
-      });
+    if (dubbingStatus !== "dubbed") {
+      throw new MuxAiError("Audio translation timed out or failed. Please try again.", { type: "timeout_error", retryable: true });
+    }
 
-      if (uploadCaptionsToMux) {
-        console.warn("📹 Adding dubbed captions track to Mux asset...");
-        const muxLangCode = toISO639_1(toLanguageCode);
-        const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
-        captionsTrackId = await createTextTrackOnMux(
+    console.warn("✅ Dubbing completed successfully!");
+
+    if (uploadToS3) {
+      console.warn("📥 Downloading dubbed audio from ElevenLabs and staging to S3...");
+
+      // ElevenLabs reports target_languages in ISO 639-1 and the download
+      // endpoint expects one of those codes. A single-target dub yields exactly
+      // one entry, so use it directly; fall back to the ISO 639-1 form of the
+      // requested language if the array is unexpectedly empty.
+      const downloadLangCode = targetLanguages[0] ?? toISO639_1(toLanguageCode);
+
+      try {
+        presignedUrl = await downloadAndUploadDubbedAudio({
+          dubbingId,
+          languageCode: downloadLangCode,
           assetId,
-          muxLangCode,
-          `${languageName} (auto-dubbed)`,
-          captionsPresignedUrl,
+          toLanguageCode,
+          s3Endpoint: s3Endpoint!,
+          s3Region,
+          s3Bucket: s3Bucket!,
+          storageAdapter: effectiveStorageAdapter,
+          s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
           credentials,
-        );
-        console.warn(`✅ Captions track added to Mux asset with ID: ${captionsTrackId}`);
+        });
+        console.warn("✅ Dubbed audio staged to S3 successfully!");
+      } catch (error) {
+        wrapError(error, "Failed to download and upload dubbed audio");
       }
-    } catch (error) {
-      console.warn(`⚠️ Failed to attach dubbed captions: ${error instanceof Error ? error.message : "Unknown error"}`);
-      if (captionsPresignedUrl) {
-        console.warn("🔗 You can manually add the captions track using this presigned URL:");
-        console.warn(captionsPresignedUrl);
+
+      // Add translated audio track to Mux asset (only when uploadToMux is true)
+      if (uploadToMux) {
+        console.warn("📹 Adding dubbed audio track to Mux asset...");
+        // Mux uses ISO 639-1 (2-letter) codes for track language_code
+        const muxLangCode = toISO639_1(toLanguageCode);
+
+        try {
+          uploadedTrackId = await createAudioTrackOnMux(assetId, muxLangCode, presignedUrl!, credentials);
+          const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
+          const trackName = `${languageName} (auto-dubbed)`;
+          console.warn(`✅ Track added to Mux asset with ID: ${uploadedTrackId}`);
+          console.warn(`📋 Track name: "${trackName}"`);
+        } catch (error) {
+          console.warn(`⚠️ Failed to add audio track to Mux asset: ${error instanceof Error ? error.message : "Unknown error"}`);
+          console.warn("🔗 You can manually add the track using this presigned URL:");
+          console.warn(presignedUrl);
+        }
+      }
+
+      // The dub's translated transcript is the same translation that was voiced, and
+      // fetching it costs nothing extra. Soft-fail everything here: a transcript problem
+      // must never fail a completed, paid-for dub.
+      try {
+        console.warn("📥 Downloading dub transcript from ElevenLabs and staging to S3...");
+        captionsPresignedUrl = await downloadAndUploadDubTranscript({
+          dubbingId,
+          languageCode: downloadLangCode,
+          assetId,
+          toLanguageCode,
+          s3Endpoint: s3Endpoint!,
+          s3Region,
+          s3Bucket: s3Bucket!,
+          storageAdapter: effectiveStorageAdapter,
+          s3SignedUrlExpirySeconds: options.s3SignedUrlExpirySeconds,
+          credentials,
+        });
+
+        if (uploadCaptionsToMux) {
+          console.warn("📹 Adding dubbed captions track to Mux asset...");
+          const muxLangCode = toISO639_1(toLanguageCode);
+          const languageName = new Intl.DisplayNames(["en"], { type: "language" }).of(muxLangCode) || muxLangCode.toUpperCase();
+          captionsTrackId = await createTextTrackOnMux(
+            assetId,
+            muxLangCode,
+            `${languageName} (auto-dubbed)`,
+            captionsPresignedUrl,
+            credentials,
+          );
+          console.warn(`✅ Captions track added to Mux asset with ID: ${captionsTrackId}`);
+        }
+      } catch (error) {
+        console.warn(`⚠️ Failed to attach dubbed captions: ${error instanceof Error ? error.message : "Unknown error"}`);
+        if (captionsPresignedUrl) {
+          console.warn("🔗 You can manually add the captions track using this presigned URL:");
+          console.warn(captionsPresignedUrl);
+        }
+      }
+    }
+  } finally {
+    // Reap the rendition this run created on both success and failure paths.
+    // A pre-existing rendition (createdStaticRenditionId undefined) is never touched.
+    if (createdStaticRenditionId) {
+      if (staticRenditionCleanupOption === "keep") {
+        console.warn(
+          `ℹ️ Keeping static rendition ${createdStaticRenditionId} on asset ${assetId} (staticRenditionCleanup: "keep")`,
+        );
+        staticRenditionCleanup = "kept";
+      } else {
+        staticRenditionCleanup = await deleteCreatedStaticRendition(assetId, createdStaticRenditionId, credentials);
       }
     }
   }
@@ -714,6 +788,8 @@ export async function translateAudio(
     presignedUrl,
     captionsTrackId,
     captionsPresignedUrl,
+    createdStaticRenditionId,
+    staticRenditionCleanup,
     usage: {
       metadata: {
         assetDurationSeconds,

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -97,6 +97,13 @@ export interface AudioTranslationOptions extends MuxAIOptions {
    * dubbing input. `"delete"` (default) removes it once the workflow finishes,
    * on both success and failure. `"keep"` leaves it on the asset. A rendition
    * that already existed on the asset is never deleted regardless of this setting.
+   *
+   * Concurrent runs on the same asset share one rendition, and the run that
+   * created it deletes it without knowing about its peers — the delete can race
+   * a peer's ElevenLabs source fetch and fail that dub. When dubbing multiple
+   * languages concurrently, either create the rendition before fanning out
+   * (a pre-existing rendition is never deleted) or pass `"keep"` and clean up
+   * after the batch.
    */
   staticRenditionCleanup?: "delete" | "keep";
   /** Optional storage adapter override for upload + presign operations. */

--- a/tests/unit/translate-audio.test.ts
+++ b/tests/unit/translate-audio.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("workflow", () => ({
+  sleep: vi.fn(async () => {}),
+  getWorkflowMetadata: vi.fn(() => {
+    throw new Error("not in a workflow runtime");
+  }),
+}));
+
+vi.mock("../../src/lib/mux-assets", () => ({
+  getAssetDurationSecondsFromAsset: vi.fn(),
+  getPlaybackIdForAsset: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflow-credentials", () => ({
+  resolveMuxClient: vi.fn(),
+  resolveMuxSigningContext: vi.fn(),
+  resolveProviderApiKey: vi.fn(),
+}));
+
+vi.mock("../../src/lib/client-factory", () => ({
+  getApiKeyFromEnv: vi.fn(),
+  getMuxClientFromEnv: vi.fn(),
+}));
+
+vi.mock("../../src/lib/mux-tracks", () => ({
+  createTextTrackOnMux: vi.fn(),
+}));
+
+const { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } = await import("../../src/lib/mux-assets");
+const { resolveMuxClient } = await import("../../src/lib/workflow-credentials");
+const { getApiKeyFromEnv } = await import("../../src/lib/client-factory");
+const { translateAudio } = await import("../../src/workflows/translate-audio");
+
+const ASSET_ID = "asset-123";
+const CREATED_RENDITION_ID = "rendition-created-1";
+
+// Neither S3 staging nor Mux track upload is exercised here — every scenario
+// targets static rendition lifecycle handling around the dubbing job.
+const BASE_OPTIONS = {
+  uploadToS3: false,
+  uploadToMux: false,
+} as const;
+
+function buildAsset(staticRenditions?: object) {
+  return {
+    id: ASSET_ID,
+    duration: 60,
+    playback_ids: [{ id: "playback-123", policy: "public" }],
+    static_renditions: staticRenditions,
+  };
+}
+
+function readyRenditionAsset(renditionId: string) {
+  return buildAsset({
+    status: "ready",
+    files: [{ id: renditionId, name: "audio.m4a", status: "ready" }],
+  });
+}
+
+function mockMuxClient({
+  initialAsset,
+  polledAsset,
+}: {
+  initialAsset: object;
+  polledAsset?: object;
+}) {
+  const createStaticRendition = vi.fn(async () => ({
+    id: CREATED_RENDITION_ID,
+    status: "preparing",
+  }));
+  const deleteStaticRendition = vi.fn(async () => {});
+  const retrieve = vi.fn(async () => polledAsset ?? initialAsset);
+  const mux = { video: { assets: { createStaticRendition, deleteStaticRendition, retrieve } } };
+
+  vi.mocked(resolveMuxClient).mockResolvedValue({
+    createClient: async () => mux,
+    getSigningKey: () => undefined,
+    getPrivateKey: () => undefined,
+  } as any);
+  vi.mocked(getPlaybackIdForAsset).mockResolvedValue({
+    asset: initialAsset,
+    playbackId: "playback-123",
+    policy: "public",
+  } as any);
+
+  return { createStaticRendition, deleteStaticRendition, retrieve };
+}
+
+function stubElevenLabsFetch({ dubbingStatus = "dubbed" }: { dubbingStatus?: string } = {}) {
+  const fetchMock = vi.fn(async (input: any, init?: any) => {
+    const url = String(input);
+    if (url.endsWith("/v1/dubbing") && init?.method === "POST") {
+      return new Response(JSON.stringify({ dubbing_id: "dub-1" }), { status: 200 });
+    }
+    if (url.endsWith("/v1/dubbing/dub-1")) {
+      return new Response(
+        JSON.stringify({ status: dubbingStatus, target_languages: ["fr"] }),
+        { status: 200 },
+      );
+    }
+    throw new Error(`Unexpected fetch in test: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected promise to reject");
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.mocked(getAssetDurationSecondsFromAsset).mockReturnValue(60);
+  vi.mocked(getApiKeyFromEnv).mockResolvedValue("elevenlabs-key");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("translateAudio static rendition cleanup", () => {
+  it("does not create or delete a rendition that already existed", async () => {
+    const { createStaticRendition, deleteStaticRendition } = mockMuxClient({
+      initialAsset: readyRenditionAsset("rendition-pre-existing"),
+    });
+    stubElevenLabsFetch();
+
+    const result = await translateAudio(ASSET_ID, "fr", BASE_OPTIONS);
+
+    expect(createStaticRendition).not.toHaveBeenCalled();
+    expect(deleteStaticRendition).not.toHaveBeenCalled();
+    expect(result.createdStaticRenditionId).toBeUndefined();
+    expect(result.staticRenditionCleanup).toBe("not_created");
+  });
+
+  it("deletes the rendition it created after a successful dub", async () => {
+    const { createStaticRendition, deleteStaticRendition } = mockMuxClient({
+      initialAsset: buildAsset(),
+      polledAsset: readyRenditionAsset(CREATED_RENDITION_ID),
+    });
+    stubElevenLabsFetch();
+
+    const result = await translateAudio(ASSET_ID, "fr", BASE_OPTIONS);
+
+    expect(createStaticRendition).toHaveBeenCalledWith(ASSET_ID, { resolution: "audio-only" });
+    expect(deleteStaticRendition).toHaveBeenCalledWith(ASSET_ID, CREATED_RENDITION_ID);
+    expect(result.createdStaticRenditionId).toBe(CREATED_RENDITION_ID);
+    expect(result.staticRenditionCleanup).toBe("deleted");
+    expect(result.dubbingId).toBe("dub-1");
+  });
+
+  it("treats re-requesting over an errored rendition as created by this run", async () => {
+    const { createStaticRendition, deleteStaticRendition } = mockMuxClient({
+      initialAsset: buildAsset({
+        status: "errored",
+        files: [{ id: "rendition-errored", name: "audio.m4a", status: "errored" }],
+      }),
+      polledAsset: readyRenditionAsset(CREATED_RENDITION_ID),
+    });
+    stubElevenLabsFetch();
+
+    const result = await translateAudio(ASSET_ID, "fr", BASE_OPTIONS);
+
+    expect(createStaticRendition).toHaveBeenCalledOnce();
+    expect(deleteStaticRendition).toHaveBeenCalledWith(ASSET_ID, CREATED_RENDITION_ID);
+    expect(result.staticRenditionCleanup).toBe("deleted");
+  });
+
+  it("still deletes the rendition it created when dubbing fails", async () => {
+    const { deleteStaticRendition } = mockMuxClient({
+      initialAsset: buildAsset(),
+      polledAsset: readyRenditionAsset(CREATED_RENDITION_ID),
+    });
+    stubElevenLabsFetch({ dubbingStatus: "failed" });
+
+    const error = await captureRejection(translateAudio(ASSET_ID, "fr", BASE_OPTIONS));
+
+    expect((error as Error).message).toContain("dubbing job failed");
+    expect(deleteStaticRendition).toHaveBeenCalledWith(ASSET_ID, CREATED_RENDITION_ID);
+  });
+
+  it("keeps the rendition it created when staticRenditionCleanup is 'keep'", async () => {
+    const { deleteStaticRendition } = mockMuxClient({
+      initialAsset: buildAsset(),
+      polledAsset: readyRenditionAsset(CREATED_RENDITION_ID),
+    });
+    stubElevenLabsFetch();
+
+    const result = await translateAudio(ASSET_ID, "fr", {
+      ...BASE_OPTIONS,
+      staticRenditionCleanup: "keep",
+    });
+
+    expect(deleteStaticRendition).not.toHaveBeenCalled();
+    expect(result.createdStaticRenditionId).toBe(CREATED_RENDITION_ID);
+    expect(result.staticRenditionCleanup).toBe("kept");
+  });
+
+  it("reports delete_failed without masking a successful workflow result", async () => {
+    const { deleteStaticRendition } = mockMuxClient({
+      initialAsset: buildAsset(),
+      polledAsset: readyRenditionAsset(CREATED_RENDITION_ID),
+    });
+    deleteStaticRendition.mockRejectedValue(
+      Object.assign(new Error("Internal server error"), { status: 500 }),
+    );
+    stubElevenLabsFetch();
+
+    const result = await translateAudio(ASSET_ID, "fr", BASE_OPTIONS);
+
+    expect(result.dubbingId).toBe("dub-1");
+    expect(result.staticRenditionCleanup).toBe("delete_failed");
+    expect(result.createdStaticRenditionId).toBe(CREATED_RENDITION_ID);
+  });
+
+  it("treats an already-deleted rendition (404) as deleted", async () => {
+    const { deleteStaticRendition } = mockMuxClient({
+      initialAsset: buildAsset(),
+      polledAsset: readyRenditionAsset(CREATED_RENDITION_ID),
+    });
+    deleteStaticRendition.mockRejectedValue(
+      Object.assign(new Error("Not found"), { status: 404 }),
+    );
+    stubElevenLabsFetch();
+
+    const result = await translateAudio(ASSET_ID, "fr", BASE_OPTIONS);
+
+    expect(result.staticRenditionCleanup).toBe("deleted");
+  });
+});


### PR DESCRIPTION
## Summary

`translateAudio` creates an audio-only static rendition as transient dubbing input when the asset doesn't have one, but never deleted it afterwards — customers were billed for storage of renditions that existed purely to feed ElevenLabs. This PR reaps the rendition the run created, on every exit path (success, dubbing failure, and poll timeout), and makes the outcome observable.

- `requestStaticRenditionCreation` now returns the created rendition's `id` (a step return, so it survives replay); `undefined` on the 409/"already defined" path. Re-requesting over an `errored` rendition counts as created by this run.
- New option `staticRenditionCleanup: "delete" | "keep"`, default `"delete"`. A pre-existing rendition is never deleted regardless of the setting.
- The create-request is hoisted out of the poll helper so the rendition ID is captured before any waiting begins — a poll timeout would otherwise leak the rendition once it became ready later.
- Cleanup runs in a `finally` via a step that never throws: a failed delete can't mask the dub's real outcome or trigger WDK retries. Every outcome is logged with assetId and renditionId (deleted / already gone / failed with status + message).
- The result gains `createdStaticRenditionId` and `staticRenditionCleanup` (`"deleted" | "delete_failed" | "kept" | "not_created"`) so callers can persist cleanup outcomes on their job records. Additive only.

> [!IMPORTANT]
> **Behavioural change:** `translateAudio` now deletes the audio-only static rendition it creates once the workflow finishes. Renditions that already existed on the asset are never touched. Set `staticRenditionCleanup: "keep"` to retain the old behaviour.

Also audited the other workflows: nothing else in the package calls `createStaticRendition` or leaves behind transient Mux resources — remaining track creation is product output, and `editCaptions` track deletion is the existing option-controlled behaviour.

## Example

```typescript
const result = await translateAudio(assetId, "fr");

result.createdStaticRenditionId; // "xxxx" when this run created the rendition, undefined when one already existed
result.staticRenditionCleanup;   // "deleted" | "delete_failed" | "kept" | "not_created"

// Opt out of cleanup:
await translateAudio(assetId, "fr", { staticRenditionCleanup: "keep" });
```

## Suggested review order

1. `src/workflows/translate-audio.ts` — `requestStaticRenditionCreation` / `deleteCreatedStaticRendition` steps, then the workflow body restructure (request hoist → try/finally → extended return)
2. `tests/unit/translate-audio.test.ts` — the seven lifecycle scenarios
3. `docs/API.md`, `docs/WORKFLOWS.md` — param/result documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral change that deletes Mux static renditions by default, which can race concurrent dubs of the same asset and affect storage/billing. Cleanup is non-throwing and never touches pre-existing renditions.
> 
> **Overview**
> **`translateAudio` now reaps the `audio.m4a` static rendition it created** as dubbing input, on success and failure, so customers are not billed for leftover storage. Renditions that already existed on the asset are never deleted.
> 
> New option `staticRenditionCleanup: "delete" | "keep"` (default `"delete"`). Creation is requested in the workflow body (not inside the poll helper) so the rendition ID is known even if waiting times out. Cleanup runs in `finally` via a step that never throws (404 counts as deleted). Result adds `createdStaticRenditionId` and `staticRenditionCleanup` (`deleted` | `delete_failed` | `kept` | `not_created`).
> 
> **Concurrent dubs of one asset share a rendition** — the creating run can delete it while a peer still fetches source audio. Create the rendition before fanning out, or pass `"keep"` and clean up after the batch. Unit tests cover the lifecycle cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db94c3fa6fab0751357b91c20b1e50bcaaaeed13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->