### PR TITLE
fix: Make chunking more conservative for single VTT assets that have a large number of repeated cues

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -215,7 +215,7 @@ npm run aws-sdk-adapter <your-asset-id> -- --s3-bucket <bucket-name>
 
 1. Fetches existing captions from Mux asset
 2. Translates VTT content using your selected provider (default: Claude Sonnet 4.5)
-3. Uses built-in VTT-aware chunking for longer assets by default, while keeping shorter assets in a single request
+3. Uses built-in VTT-aware chunking by default, bounding every request by cue count and text token budget
 4. Uploads translated VTT to S3-compatible storage
 5. Generates presigned URL (1-hour expiry)
 6. Adds new subtitle track to Mux asset

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -502,7 +502,7 @@ console.log(result.presignedUrl); // S3 file URL
 console.log(result.translatedVtt); // Translated VTT content
 ```
 
-By default, `translateCaptions` uses VTT-aware chunking for longer assets. It prefers a single request for shorter media, then splits larger translations by cue-aligned chunks and rebuilds the final VTT locally.
+By default, `translateCaptions` uses VTT-aware chunking. Every asset is split into cue-aligned chunks bounded by `maxCuesPerChunk` and `maxCueTextTokensPerChunk`; assets longer than `minimumAssetDurationSeconds` are additionally grouped into duration-based chunks. The final VTT is rebuilt locally.
 
 ```typescript
 // Override chunking behavior for large assets

--- a/src/lib/content-policy-error.ts
+++ b/src/lib/content-policy-error.ts
@@ -59,6 +59,37 @@ export interface ContentPolicyBlock {
   category?: string;
 }
 
+/**
+ * Thrown when the model stopped for a reason other than a normal `stop`
+ * (e.g. `length` when the output token limit was reached) so the structured
+ * output was never parsed. The AI SDK would otherwise surface a metadata-free
+ * `NoOutputGeneratedError`. Own properties survive workflow step
+ * serialization; detect it with {@link isIncompleteGenerationError}.
+ */
+export class IncompleteGenerationError extends MuxAiError {
+  readonly finishReason: string;
+  readonly rawFinishReason?: string;
+  readonly usage?: TokenUsage;
+
+  constructor(finishReason: string, rawFinishReason?: string, usage?: TokenUsage) {
+    const reason = rawFinishReason ?? finishReason;
+    const message = finishReason === "length" ?
+      `The model reached its output limit before producing a complete response (finish reason: ${reason}).` :
+      `The model stopped before producing a complete response (finish reason: ${reason}).`;
+    super(message, {
+      type: "processing_error",
+      retryable: finishReason !== "length",
+    });
+    this.finishReason = finishReason;
+    this.rawFinishReason = rawFinishReason;
+    this.usage = usage;
+  }
+}
+
+export function isIncompleteGenerationError(error: unknown): error is IncompleteGenerationError {
+  return MuxAiError.is(error) && typeof (error as { finishReason?: unknown }).finishReason === "string";
+}
+
 interface GeneratedOutput<T> {
   finishReason: string;
   rawFinishReason?: string;
@@ -99,10 +130,13 @@ export function rethrowContentPolicyError(error: unknown): never {
 }
 
 /**
- * Reads structured output only after checking for a successful provider
- * response that stopped because of a content policy. AI SDK intentionally
- * leaves output unresolved for non-`stop` finishes, so accessing `output`
- * first would throw a metadata-free `NoOutputGeneratedError`.
+ * Reads structured output only after checking the finish reason. AI SDK
+ * intentionally leaves output unresolved for non-`stop` finishes, so
+ * accessing `output` first would throw a metadata-free
+ * `NoOutputGeneratedError`. Content-policy stops become a
+ * `content_policy_error`; every other non-`stop` finish (`length`, `error`,
+ * `other`, ...) becomes an {@link IncompleteGenerationError} that keeps the
+ * finish reason and token usage.
  */
 export function getGeneratedOutputWithContentPolicyHandling<T>(response: GeneratedOutput<T>): T {
   if (response.finishReason === "content-filter") {
@@ -112,6 +146,15 @@ export function getGeneratedOutputWithContentPolicyHandling<T>(response: Generat
       "CONTENT_FILTER";
 
     throwContentPolicyError({ reason }, getErrorTokenUsage(response));
+  }
+
+  if (response.finishReason !== "stop") {
+    const rawReason = PolicyTokenSchema.safeParse(response.rawFinishReason);
+    throw new IncompleteGenerationError(
+      response.finishReason,
+      rawReason.success ? rawReason.data : undefined,
+      getErrorTokenUsage(response),
+    );
   }
 
   return response.output;

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -2,6 +2,7 @@ import {
   APICallError,
   generateText,
   NoObjectGeneratedError,
+  NoOutputGeneratedError,
   Output,
   RetryError,
   TypeValidationError,
@@ -11,6 +12,7 @@ import { z } from "zod";
 import env from "../env.ts";
 import {
   getGeneratedOutputWithContentPolicyHandling,
+  isIncompleteGenerationError,
   withContentPolicyAwareRetry,
 } from "../lib/content-policy-error.ts";
 import { getLanguageCodePair, getLanguageName } from "../lib/language-codes.ts";
@@ -154,7 +156,10 @@ export interface TranslationOptions<P extends SupportedProvider = SupportedProvi
 export interface TranslationChunkingOptions {
   /** Set to false to translate all cues in a single structured request. Defaults to true. */
   enabled?: boolean;
-  /** Prefer a single request until the asset is at least this long. Defaults to 30 minutes. */
+  /**
+   * Skip duration-based chunking until the asset is at least this long. Defaults to 30 minutes.
+   * Shorter assets are still split by `maxCuesPerChunk` and `maxCueTextTokensPerChunk`.
+   */
   minimumAssetDurationSeconds?: number;
   /** Soft target for chunk duration once chunking starts. Defaults to 30 minutes. */
   targetChunkDurationSeconds?: number;
@@ -394,7 +399,9 @@ export function shouldSplitChunkTranslationError(error: unknown): boolean {
 
   return (
     NoObjectGeneratedError.isInstance(error) ||
+    NoOutputGeneratedError.isInstance(error) ||
     TypeValidationError.isInstance(error) ||
+    isIncompleteGenerationError(error) ||
     isTranslationChunkValidationError(error)
   );
 }
@@ -528,15 +535,23 @@ function buildTranslationChunkRequests(
     };
   }
 
+  // Short assets skip duration-based chunking but still honour the cue and
+  // token budgets: a single request for hundreds of cues can push a model
+  // past its output token limit (observed with repetitive transcripts),
+  // which fails the whole translation instead of one bounded chunk.
   if (
     typeof assetDurationSeconds !== "number" ||
     assetDurationSeconds < resolvedChunking.minimumAssetDurationSeconds
   ) {
     return {
       preamble,
-      chunks: [
-        createTranslationChunkRequest("chunk-0", cues, cueBlocks),
-      ],
+      chunks: splitTranslationChunkRequestByBudget(
+        "chunk-0",
+        cues,
+        cueBlocks,
+        resolvedChunking.maxCuesPerChunk,
+        resolvedChunking.maxCueTextTokensPerChunk,
+      ),
     };
   }
 
@@ -978,7 +993,7 @@ async function translateChunkWithFallback({
 
     const [leftChunk, rightChunk] = splitTranslationChunkAtMidpoint(chunk);
     // The failed whole-chunk attempt burned tokens too; fold its usage into
-    // the error if the split halves also fail.
+    // the result, or into the error if the split halves also fail.
     const failedAttemptUsage = getErrorTokenUsage(error);
     const [leftResult, rightResult] = collectSettledTranslationsOrRethrow(
       await Promise.allSettled([
@@ -1006,7 +1021,11 @@ async function translateChunkWithFallback({
 
     return {
       translatedVtt: concatenateVttSegments([leftResult.translatedVtt, rightResult.translatedVtt]),
-      usage: aggregateTokenUsage([leftResult.usage, rightResult.usage]),
+      usage: aggregateTokenUsage([
+        ...(failedAttemptUsage ? [failedAttemptUsage] : []),
+        leftResult.usage,
+        rightResult.usage,
+      ]),
       scrubbedCueCounts: mergeScrubbedCueCounts(
         leftResult.scrubbedCueCounts,
         rightResult.scrubbedCueCounts,

--- a/tests/unit/chapters-scope.test.ts
+++ b/tests/unit/chapters-scope.test.ts
@@ -70,6 +70,7 @@ beforeEach(() => {
   } as any);
   vi.mocked(extractTimestampedTranscript).mockReturnValue("[0s] Introduction");
   vi.mocked(generateText).mockResolvedValue({
+    finishReason: "stop",
     output: { chapters: [{ startTime: 0, title: "Introduction" }] },
     text: JSON.stringify({ chapters: [{ startTime: 0, title: "Introduction" }] }),
     usage: {

--- a/tests/unit/content-policy-error.test.ts
+++ b/tests/unit/content-policy-error.test.ts
@@ -6,6 +6,8 @@ import { z } from "zod";
 import {
   extractContentPolicyBlock,
   getGeneratedOutputWithContentPolicyHandling,
+  IncompleteGenerationError,
+  isIncompleteGenerationError,
   rethrowContentPolicyError,
   withContentPolicyAwareRetry,
   withContentPolicyErrorHandling,
@@ -347,6 +349,58 @@ describe("content policy errors", () => {
       retryable: false,
       usage: response.usage,
     });
+  });
+
+  it("throws a finish-reason error instead of reading unresolved output", () => {
+    let outputRead = false;
+    const response = {
+      finishReason: "length",
+      rawFinishReason: "MAX_TOKENS",
+      usage: { inputTokens: 23182, outputTokens: 65521, totalTokens: 88703 },
+      get output(): never {
+        outputRead = true;
+        throw new Error("structured output getter should not be read");
+      },
+    };
+
+    const error = captureThrown(() => getGeneratedOutputWithContentPolicyHandling(response));
+
+    expect(outputRead).toBe(false);
+    expect(error).toBeInstanceOf(IncompleteGenerationError);
+    expect(isIncompleteGenerationError(error)).toBe(true);
+    expect(error).toMatchObject({
+      name: "FatalError",
+      publicType: "processing_error",
+      publicMessage: "The model reached its output limit before producing a complete response (finish reason: MAX_TOKENS).",
+      retryable: false,
+      finishReason: "length",
+      rawFinishReason: "MAX_TOKENS",
+      usage: response.usage,
+    });
+  });
+
+  it("marks non-length incomplete generations as retryable and ignores unsafe raw reasons", () => {
+    const error = captureThrown(() => getGeneratedOutputWithContentPolicyHandling({
+      finishReason: "error",
+      rawFinishReason: "<script>alert(1)</script>",
+      output: undefined,
+    }));
+
+    expect(error).toMatchObject({
+      publicMessage: "The model stopped before producing a complete response (finish reason: error).",
+      retryable: true,
+      finishReason: "error",
+      rawFinishReason: undefined,
+    });
+  });
+
+  it("returns structured output for a normal stop", () => {
+    const output = getGeneratedOutputWithContentPolicyHandling({
+      finishReason: "stop",
+      output: { translation: "hola" },
+    });
+
+    expect(output).toEqual({ translation: "hola" });
   });
 
   it("preserves content policy metadata across a serialized workflow step boundary", () => {

--- a/tests/unit/translate-captions-chunking.test.ts
+++ b/tests/unit/translate-captions-chunking.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("ai", async importOriginal => ({
+  ...(await importOriginal<object>()),
+  generateText: vi.fn(),
+}));
+
+vi.mock("../../src/lib/mux-assets", () => ({
+  getAssetDurationSecondsFromAsset: vi.fn(),
+  getPlaybackIdForAsset: vi.fn(),
+}));
+
+vi.mock("../../src/lib/mux-tracks", () => ({
+  createTextTrackOnMux: vi.fn(),
+  fetchVttFromMux: vi.fn(),
+}));
+
+vi.mock("../../src/lib/workflow-credentials", () => ({
+  resolveMuxSigningContext: vi.fn(),
+}));
+
+vi.mock("../../src/lib/providers", async importOriginal => ({
+  ...(await importOriginal<object>()),
+  createLanguageModelFromConfig: vi.fn(),
+  resolveLanguageModelConfig: vi.fn(),
+}));
+
+const { generateText } = await import("ai");
+const { getAssetDurationSecondsFromAsset, getPlaybackIdForAsset } = await import("../../src/lib/mux-assets");
+const { fetchVttFromMux } = await import("../../src/lib/mux-tracks");
+const { resolveMuxSigningContext } = await import("../../src/lib/workflow-credentials");
+const { createLanguageModelFromConfig, resolveLanguageModelConfig } = await import("../../src/lib/providers");
+const { translateCaptions } = await import("../../src/workflows/translate-captions");
+
+const CUE_COUNT = 5;
+
+function buildVtt(cueCount: number): string {
+  const blocks = Array.from({ length: cueCount }, (_, i) => {
+    const start = `00:00:${String(i * 2).padStart(2, "0")}.000`;
+    const end = `00:00:${String(i * 2 + 2).padStart(2, "0")}.000`;
+    return `${i + 1}\n${start} --> ${end}\nHello ${i + 1}`;
+  });
+  return `WEBVTT\n\n${blocks.join("\n\n")}\n`;
+}
+
+const USAGE = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
+
+function requestedCueCount(args: any): number {
+  const userContent = args.messages.find((m: any) => m.role === "user").content as string;
+  return Number(/Return exactly (\d+) translated/.exec(userContent)?.[1] ?? 0);
+}
+
+function successfulTranslation(cueCount: number) {
+  const translations = Array.from({ length: cueCount }, (_, i) => `hola ${i}`);
+  return {
+    finishReason: "stop",
+    output: { translations },
+    text: JSON.stringify({ translations }),
+    usage: USAGE,
+  };
+}
+
+const SHORT_ASSET_OPTIONS = {
+  provider: "openai" as const,
+  uploadToS3: false,
+  uploadToMux: false,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  vi.mocked(getPlaybackIdForAsset).mockResolvedValue({
+    asset: {
+      id: "asset-123",
+      tracks: [
+        { id: "track-1", type: "text", status: "ready", language_code: "en", text_type: "subtitles" },
+      ],
+    },
+    playbackId: "playback-123",
+    policy: "public",
+  } as any);
+  // Well under the default 30 minute duration-chunking threshold.
+  vi.mocked(getAssetDurationSecondsFromAsset).mockReturnValue(CUE_COUNT * 2);
+  vi.mocked(resolveMuxSigningContext).mockResolvedValue(undefined);
+  vi.mocked(fetchVttFromMux).mockResolvedValue(buildVtt(CUE_COUNT));
+  vi.mocked(resolveLanguageModelConfig).mockReturnValue({ provider: "openai", modelId: "gpt-test" } as any);
+  vi.mocked(createLanguageModelFromConfig).mockResolvedValue({} as any);
+});
+
+describe("translateCaptions chunking for short assets", () => {
+  it("splits a short asset by the cue budget instead of sending one request", async () => {
+    vi.mocked(generateText).mockImplementation((async (args: any) =>
+      successfulTranslation(requestedCueCount(args))) as any);
+
+    const result = await translateCaptions("asset-123", "track-1", "es", {
+      ...SHORT_ASSET_OPTIONS,
+      chunking: { maxCuesPerChunk: 2 },
+    });
+
+    const requestedCounts = vi.mocked(generateText).mock.calls.map(([args]) => requestedCueCount(args));
+    expect(requestedCounts).toEqual([2, 2, 1]);
+    expect(result.translatedVtt.match(/hola/g)).toHaveLength(CUE_COUNT);
+    expect(result.translatedVtt.startsWith("WEBVTT")).toBe(true);
+  });
+
+  it("keeps a single request when chunking is disabled", async () => {
+    vi.mocked(generateText).mockImplementation((async (args: any) =>
+      successfulTranslation(requestedCueCount(args))) as any);
+
+    await translateCaptions("asset-123", "track-1", "es", {
+      ...SHORT_ASSET_OPTIONS,
+      chunking: { enabled: false, maxCuesPerChunk: 2 },
+    });
+
+    expect(vi.mocked(generateText)).toHaveBeenCalledTimes(1);
+    expect(requestedCueCount(vi.mocked(generateText).mock.calls[0][0])).toBe(CUE_COUNT);
+  });
+
+  it("bisects a chunk whose generation hit the model's output limit", async () => {
+    vi.mocked(generateText).mockImplementation((async (args: any) => {
+      const cueCount = requestedCueCount(args);
+      if (cueCount > 2) {
+        return {
+          finishReason: "length",
+          rawFinishReason: "MAX_TOKENS",
+          text: "{\"translations\": [\"tocar rápido\", \"tocar rápido\", ",
+          usage: { inputTokens: 100, outputTokens: 65521, totalTokens: 65621 },
+          get output(): never {
+            throw new Error("output must not be read for a non-stop finish");
+          },
+        };
+      }
+      return successfulTranslation(cueCount);
+    }) as any);
+
+    const result = await translateCaptions("asset-123", "track-1", "es", SHORT_ASSET_OPTIONS);
+
+    const requestedCounts = vi.mocked(generateText).mock.calls.map(([args]) => requestedCueCount(args));
+    expect(requestedCounts).toEqual([5, 2, 3, 1, 2]);
+    expect(result.translatedVtt.match(/hola/g)).toHaveLength(CUE_COUNT);
+    // Two truncated attempts (5 cues, then 3 cues) plus three successful calls.
+    expect(result.usage?.outputTokens).toBe(2 * 65521 + 3 * 5);
+  });
+
+  it("surfaces the finish reason when a single cue still cannot be translated", async () => {
+    vi.mocked(generateText).mockResolvedValue({
+      finishReason: "length",
+      rawFinishReason: "MAX_TOKENS",
+      text: "",
+      usage: USAGE,
+      get output(): never {
+        throw new Error("output must not be read for a non-stop finish");
+      },
+    } as any);
+
+    await expect(translateCaptions("asset-123", "track-1", "es", SHORT_ASSET_OPTIONS)).rejects.toMatchObject({
+      publicType: "processing_error",
+      publicMessage: "The model reached its output limit before producing a complete response (finish reason: MAX_TOKENS).",
+      retryable: false,
+      finishReason: "length",
+    });
+  });
+});

--- a/tests/unit/translate-captions-error-usage.test.ts
+++ b/tests/unit/translate-captions-error-usage.test.ts
@@ -119,6 +119,7 @@ describe("translateCaptions error-path token usage", () => {
       const cueCount = Number(/Return exactly (\d+) translated/.exec(userContent)?.[1] ?? 0);
       const translations = Array.from({ length: cueCount }, (_, i) => `hola ${i}`);
       return {
+        finishReason: "stop",
         output: { translations },
         text: JSON.stringify({ translations }),
         usage: CHUNK_USAGE,

--- a/tests/unit/translate-captions.test.ts
+++ b/tests/unit/translate-captions.test.ts
@@ -1,11 +1,13 @@
 import {
   APICallError,
   NoObjectGeneratedError,
+  NoOutputGeneratedError,
   RetryError,
   TypeValidationError,
 } from "ai";
 import { describe, expect, it } from "vitest";
 
+import { IncompleteGenerationError } from "../../src/lib/content-policy-error";
 import { MuxAiError } from "../../src/lib/mux-ai-error";
 import type { TokenUsage } from "../../src/types";
 import {
@@ -150,6 +152,20 @@ describe("shouldSplitChunkTranslationError", () => {
     });
 
     expect(shouldSplitChunkTranslationError(error)).toBe(false);
+  });
+
+  it("allows splitting when the SDK left structured output unresolved", () => {
+    expect(shouldSplitChunkTranslationError(new NoOutputGeneratedError())).toBe(true);
+  });
+
+  it("allows splitting when the model hit its output limit", () => {
+    const error = new IncompleteGenerationError("length", "MAX_TOKENS");
+    expect(shouldSplitChunkTranslationError(error)).toBe(true);
+  });
+
+  it("allows splitting for a serialized incomplete generation error", () => {
+    const serialized = JSON.parse(JSON.stringify(new IncompleteGenerationError("length", "MAX_TOKENS")));
+    expect(shouldSplitChunkTranslationError(serialized)).toBe(true);
   });
 
   it("allows splitting for schema validation failures", () => {


### PR DESCRIPTION
## Summary

A customer `translate-captions` job on Gemini 3.1 Flash Lite failed with `Chunk chunk-0 failed for 0s-1487s: No output generated.` The asset is under the 30 minute `minimumAssetDurationSeconds`, so all 379 cues went in one request; ~240 near-identical hallucinated cues sent the model into a repetition loop until it hit its 65k output token cap (`MAX_TOKENS`). Reproduced locally: 141s and 88k tokens per attempt, retried 3x by WDK. The same region as an 80-cue chunk completes in 3s.

## Changes

- Short assets now go through the cue/token budget (`splitTranslationChunkRequestByBudget`) instead of a single request. `chunking.enabled: false` still means one request.
- Non-`stop`, non-`content-filter` finishes throw `IncompleteGenerationError` (a `MuxAiError`) with `finishReason`, `rawFinishReason`, and `usage`, instead of the metadata-free `NoOutputGeneratedError`. `retryable: false` for `length`. Applies to every workflow using `getGeneratedOutputWithContentPolicyHandling`.
- `shouldSplitChunkTranslationError` also bisects on `NoOutputGeneratedError` and `IncompleteGenerationError`.
- A failed whole-chunk attempt's usage is now folded into the result on a successful bisect.
- Test mocks updated to return `finishReason: "stop"`; docs no longer describe short assets as a single request.

## Suggested review order

1. `src/lib/content-policy-error.ts`
2. `src/workflows/translate-captions.ts`
3. `tests/unit/translate-captions-chunking.test.ts`
4. Remaining tests and docs

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c963211cb87306ce8e231e2987a6e818cde7ed49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
