### PR TITLE
chore: 0.35.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version-only release bump with no runtime or dependency changes in the diff.
> 
> **Overview**
> Bumps the published **`@mux/ai`** package version from **0.34.0** to **0.35.0** in `package.json` and the root entry in `package-lock.json`.
> 
> There are no source, dependency, or API changes in this diff—only the version metadata for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0198658f7e15b733ed5e9eb30557300bc01916c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->