### PR TITLE
perf: reuse asset snapshots in workflows

### DIFF
--- a/src/lib/mux-assets.ts
+++ b/src/lib/mux-assets.ts
@@ -48,13 +48,17 @@ function toPlaybackAsset(asset: MuxAsset): PlaybackAsset {
 export async function getPlaybackIdForAsset(
   assetId: string,
   credentials?: WorkflowCredentialsInput,
+  assetSnapshot?: MuxAsset,
 ): Promise<PlaybackAsset> {
   "use step";
   // Centralize the Mux Video API fetch so callers can reuse the same asset payload
   // for playback IDs, duration, and other derived fields without double-hitting.
   // Note: getMuxAsset still resolves Mux token ID/secret from env or provided
   // credentials to preserve multi-tenant behavior.
-  const asset = await getMuxAsset(assetId, credentials);
+  const asset = assetSnapshot ?? await getMuxAsset(assetId, credentials);
+  if (asset.id !== assetId) {
+    throw new MuxAiError("Asset snapshot does not match the requested asset ID.", { type: "validation_error" });
+  }
   return toPlaybackAsset(asset);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,12 @@ export interface MuxAIOptions {
   /** Optional timeout (ms) for helper utilities that support request limits. */
   timeout?: number;
   /**
+   * Optional asset snapshot to reuse instead of retrieving the asset from Mux.
+   * The snapshot must belong to `assetId`; callers should capture it immediately
+   * before starting the workflow.
+   */
+  assetSnapshot?: MuxAsset;
+  /**
    * Optional credentials for workflow execution.
    * Use encryptForWorkflow when running in Workflow Dev Kit environments.
    */

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -900,7 +900,7 @@ async function askQuestionsInternal(
     provider: provider as SupportedProvider,
   });
   // Fetch asset data and playback ID from Mux
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options?.assetSnapshot);
 
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
   const isAudioOnly = isAudioOnlyAsset(assetData);

--- a/src/workflows/burned-in-captions.ts
+++ b/src/workflows/burned-in-captions.ts
@@ -373,7 +373,7 @@ async function hasBurnedInCaptionsInternal(
     model,
     provider: provider as SupportedProvider,
   });
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options.assetSnapshot);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
   const storyboardScope = resolveRenderableVideoScope(
     scope,

--- a/src/workflows/chapters.ts
+++ b/src/workflows/chapters.ts
@@ -408,7 +408,7 @@ async function generateChaptersInternal(
     provider: provider as SupportedProvider,
   });
   // Fetch asset and transcript
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options.assetSnapshot);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
   const effectiveScope = hasWorkflowScopeBoundaries(scope) ? scope : undefined;
   const resolvedScope = effectiveScope ?

--- a/src/workflows/edit-captions.ts
+++ b/src/workflows/edit-captions.ts
@@ -620,7 +620,7 @@ async function editCaptionsInternal<P extends SupportedProvider = SupportedProvi
   }
 
   // Fetch asset data and playback ID from Mux
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options.assetSnapshot);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
 
   // Resolve signing context for signed playback IDs

--- a/src/workflows/embeddings.ts
+++ b/src/workflows/embeddings.ts
@@ -170,7 +170,7 @@ async function generateEmbeddingsInternal(
 
   const embeddingModel = resolveEmbeddingModelConfig({ ...options, provider, model });
   // Fetch asset and playback ID
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options.assetSnapshot);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
   const effectiveScope = hasWorkflowScopeBoundaries(scope) ? scope : undefined;
   if (effectiveScope) {

--- a/src/workflows/engagement-insights.ts
+++ b/src/workflows/engagement-insights.ts
@@ -680,7 +680,7 @@ async function generateEngagementInsightsInternal(
   });
 
   // Step 1: Fetch asset metadata
-  const { asset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options.assetSnapshot);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(asset);
 
   if (!assetDurationSeconds) {

--- a/src/workflows/moderation.ts
+++ b/src/workflows/moderation.ts
@@ -794,7 +794,7 @@ export async function getModerationScores(
   } = options;
   const credentials = providedCredentials;
   // Fetch asset data and playback ID from Mux via helper
-  const { asset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options.assetSnapshot);
   const videoTrackDurationSeconds = getVideoTrackDurationSecondsFromAsset(asset);
   const videoTrackFps = getVideoTrackMaxFrameRateFromAsset(asset);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(asset);

--- a/src/workflows/summarization.ts
+++ b/src/workflows/summarization.ts
@@ -748,7 +748,7 @@ async function getSummaryAndTagsInternal(
   const workflowCredentials = credentials;
 
   // Fetch asset data from Mux and grab playback/transcript details
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, workflowCredentials);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, workflowCredentials, options?.assetSnapshot);
 
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
   // Detect if asset is audio-only

--- a/src/workflows/translate-audio.ts
+++ b/src/workflows/translate-audio.ts
@@ -566,7 +566,7 @@ export async function translateAudio(
   }
 
   // Fetch asset data and playback ID from Mux
-  const { asset: initialAsset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: initialAsset, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options.assetSnapshot);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(initialAsset);
 
   // Check for audio-only static rendition. Requesting creation happens here

--- a/src/workflows/translate-captions.ts
+++ b/src/workflows/translate-captions.ts
@@ -1224,7 +1224,7 @@ async function translateCaptionsInternal<P extends SupportedProvider = Supported
   }
 
   // Fetch asset data and playback ID from Mux
-  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials);
+  const { asset: assetData, playbackId, policy } = await getPlaybackIdForAsset(assetId, credentials, options.assetSnapshot);
   const assetDurationSeconds = getAssetDurationSecondsFromAsset(assetData);
 
   // Resolve signing context for signed playback IDs

--- a/tests/unit/mux-assets.test.ts
+++ b/tests/unit/mux-assets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isAudioOnlyAsset } from "../../src/lib/mux-assets";
+import { getPlaybackIdForAsset, isAudioOnlyAsset } from "../../src/lib/mux-assets";
 import type { MuxAsset } from "../../src/types";
 
 describe("isAudioOnlyAsset", () => {
@@ -91,5 +91,27 @@ describe("isAudioOnlyAsset", () => {
     };
 
     expect(isAudioOnlyAsset(audioTextAsset as MuxAsset)).toBe(true);
+  });
+});
+
+describe("getPlaybackIdForAsset", () => {
+  const asset = {
+    id: "asset-123",
+    playback_ids: [{ id: "playback-123", policy: "public" }],
+  } as MuxAsset;
+
+  it("uses a supplied asset snapshot", async () => {
+    await expect(getPlaybackIdForAsset("asset-123", undefined, asset)).resolves.toEqual({
+      asset,
+      playbackId: "playback-123",
+      policy: "public",
+    });
+  });
+
+  it("rejects a snapshot for a different asset", async () => {
+    const promise = getPlaybackIdForAsset("asset-other", undefined, asset);
+    await expect(promise).rejects.toThrow(
+      "Asset snapshot does not match the requested asset ID",
+    );
   });
 });


### PR DESCRIPTION
# Overview

Allow callers that already retrieved a Mux asset to pass that snapshot into `@mux/ai` workflows. This removes the second Video asset GET that otherwise happens when a workflow resolves playback metadata.

Companion to [muxinc/robots#533](https://github.com/muxinc/robots/pull/533) for [AIT-411](https://mux1.atlassian.net/browse/AIT-411).

# What was changed

- Added an optional `assetSnapshot` field to shared workflow options.
- Updated playback resolution to use the supplied snapshot after validating its asset ID.
- Threaded the snapshot through every workflow that resolves asset playback metadata.
- Added unit coverage for snapshot reuse and mismatched asset IDs.
- Verified with typecheck, lint, build, and all 490 unit tests.

# Suggested review order

1. `src/types.ts` and `src/lib/mux-assets.ts`
2. The workflow call-site updates in `src/workflows/`
3. `tests/unit/mux-assets.test.ts`
