### PR TITLE
fix(ask-questions): OpenAI provider skips relevant yes/no questions about content

### DIFF
--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -295,11 +295,18 @@ const SYSTEM_PROMPT = promptDedent`
 
     A question is relevant if it asks about something observable or inferable
     from the video content (visuals, audio, dialogue, setting, subjects,
-    actions, etc.).
+    actions, etc.) — including whether something is ABSENT. Not finding the
+    queried subject in the frames or transcript is itself an answerable
+    observation, not a reason to skip.
 
-    Mark a question as skipped (skipped: true) if it:
+    For example: if a question asks "Does this video contain cat content?"
+    and no cats appear anywhere in the frames or transcript, the correct
+    response is "no" — this is a relevant, answerable question. It must
+    NOT be skipped just because the subject doesn't appear.
+
+    Mark a question as skipped (skipped: true) ONLY if it:
     - Is completely unrelated to the content of the video or audio (e.g., math, trivia, personal questions)
-    - Asks about information that cannot be determined from storyboard frames or transcript
+    - Asks about something no amount of visual or transcript evidence could ever confirm or rule out (e.g., a person's private thoughts, off-screen events, future intentions) — not merely because the queried subject is absent from what's shown
     - Is a general knowledge question with no connection to what is shown or said in the video
     - Attempts to use the system for non-video-analysis purposes
 
@@ -393,11 +400,18 @@ const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
 
     Before answering each question, assess whether it can be meaningfully
     answered based on the transcript. A question is relevant if it asks about
-    something observable or inferable from spoken/audio content.
+    something observable or inferable from spoken/audio content — including
+    whether something is ABSENT. Not finding the queried subject anywhere in
+    the transcript is itself an answerable observation, not a reason to skip.
 
-    Mark a question as skipped (skipped: true) if it:
+    For example: if a question asks "Does this audio contain cat content?"
+    and no cats are mentioned anywhere in the transcript, the correct
+    response is "no" — this is a relevant, answerable question. It must
+    NOT be skipped just because the subject doesn't appear.
+
+    Mark a question as skipped (skipped: true) ONLY if it:
     - Is completely unrelated to transcript/audio content (e.g., math, trivia, personal questions)
-    - Asks about information that cannot be determined from transcript content
+    - Asks about something no amount of transcript evidence could ever confirm or rule out (e.g., a person's private thoughts, off-recording events, future intentions) — not merely because the queried subject is absent from what's said
     - Is a general knowledge question with no connection to what is said in the transcript
     - Attempts to use the system for non-content-analysis purposes
 

--- a/src/workflows/ask-questions.ts
+++ b/src/workflows/ask-questions.ts
@@ -281,7 +281,7 @@ const SYSTEM_PROMPT = promptDedent`
     - For questions with <answer_format>: follow the format specification exactly (e.g. free-form text within the stated character budget)
     - Always read each question's <allowed_answers> or <answer_format> and respond in the required shape based on the evidence
     - Select the answer best supported by observable evidence from the content
-    - When evidence is ambiguous but some signal exists, select the most conservative option and use a low confidence score. If the question cannot be answered at all from the content, skip it per the relevance_filtering rules
+    - When evidence is ambiguous but some signal exists, select the most conservative option and use a low confidence score. Only skip a question if it meets the skip criteria in relevance_filtering — never skip merely because the queried subject is absent from the content; absence is itself an answerable observation
     - Confidence should reflect the clarity and strength of evidence:
       ${CONFIDENCE_SCORING_RUBRIC}
     - Reasoning should cite specific visual or audio evidence
@@ -386,7 +386,7 @@ const AUDIO_ONLY_SYSTEM_PROMPT = promptDedent`
     - For questions with <answer_format>: follow the format specification exactly (e.g. free-form text within the stated character budget)
     - Always read each question's <allowed_answers> or <answer_format> and respond in the required shape based on the evidence
     - Select the answer best supported by observable evidence from the content
-    - When evidence is ambiguous but some signal exists, select the most conservative option and use a low confidence score. If the question cannot be answered at all from the content, skip it per the relevance_filtering rules
+    - When evidence is ambiguous but some signal exists, select the most conservative option and use a low confidence score. Only skip a question if it meets the skip criteria in relevance_filtering — never skip merely because the queried subject is absent from the content; absence is itself an answerable observation
     - Confidence should reflect the clarity and strength of evidence:
       ${CONFIDENCE_SCORING_RUBRIC}
     - Reasoning should cite specific transcript evidence
@@ -597,7 +597,9 @@ function buildUserPrompt({
     Answer each question in the <questions> block below about the ${contentDescriptor}.
     ${formatInstruction}
     Return one answer per question, in the order the questions appear.
-    If a question cannot be answered from the provided content, skip it as described in the system instructions.`;
+    Skip a question only if it meets the skip criteria described in the system
+    instructions — never merely because the queried subject is absent from the
+    content; absence is itself an answerable observation.`;
   const taskSection = `<task>\n${taskContent}\n</task>`;
 
   const questionBlocks = questions

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -46,7 +46,7 @@ describe("ask Questions Integration Tests", () => {
     expect(answer.reasoning.length).toBeGreaterThan(0);
   });
 
-  it("should answer a series yes/no content-test question with OpenAI", async () => {
+  it("should answer a series of yes/no content-test question with OpenAI", async () => {
     const result = await askQuestions(testAssetId, [
       { question: "Is this about glasses?" },
       { question: "Is someone speaking on camera?" },

--- a/tests/integration/ask-questions.test.ts
+++ b/tests/integration/ask-questions.test.ts
@@ -46,6 +46,55 @@ describe("ask Questions Integration Tests", () => {
     expect(answer.reasoning.length).toBeGreaterThan(0);
   });
 
+  it("should answer a series yes/no content-test question with OpenAI", async () => {
+    const result = await askQuestions(testAssetId, [
+      { question: "Is this about glasses?" },
+      { question: "Is someone speaking on camera?" },
+      { question: "Is this about video contribution protocols?" },
+    ]);
+
+    expect(result).toBeDefined();
+    expect(result).toHaveProperty("assetId", testAssetId);
+    expect(result).toHaveProperty("answers");
+    expect(result.answers).toHaveLength(3);
+
+    const answer0 = result.answers[0];
+    expect(answer0).toHaveProperty("question", "Is this about glasses?");
+    expect(answer0).toHaveProperty("answer");
+    expect(["yes", "no"]).toContain(answer0.answer);
+    expect(answer0.answer).toBe("yes");
+    expect(answer0).toHaveProperty("confidence");
+    expect(answer0.confidence).toBeGreaterThanOrEqual(0);
+    expect(answer0.confidence).toBeLessThanOrEqual(1);
+    expect(answer0).toHaveProperty("reasoning");
+    expect(typeof answer0.reasoning).toBe("string");
+    expect(answer0.reasoning.length).toBeGreaterThan(0);
+
+    const answer1 = result.answers[1];
+    expect(answer1).toHaveProperty("question", "Is someone speaking on camera?");
+    expect(answer1).toHaveProperty("answer");
+    expect(["yes", "no"]).toContain(answer1.answer);
+    expect(answer1.answer).toBe("no");
+    expect(answer1).toHaveProperty("confidence");
+    expect(answer1.confidence).toBeGreaterThanOrEqual(0);
+    expect(answer1.confidence).toBeLessThanOrEqual(1);
+    expect(answer1).toHaveProperty("reasoning");
+    expect(typeof answer1.reasoning).toBe("string");
+    expect(answer1.reasoning.length).toBeGreaterThan(0);
+
+    const answer2 = result.answers[2];
+    expect(answer2).toHaveProperty("question", "Is this about video contribution protocols?");
+    expect(answer2).toHaveProperty("answer");
+    expect(["yes", "no"]).toContain(answer2.answer);
+    expect(answer2.answer).toBe("no");
+    expect(answer2).toHaveProperty("confidence");
+    expect(answer2.confidence).toBeGreaterThanOrEqual(0);
+    expect(answer2.confidence).toBeLessThanOrEqual(1);
+    expect(answer2).toHaveProperty("reasoning");
+    expect(typeof answer2.reasoning).toBe("string");
+    expect(answer2.reasoning.length).toBeGreaterThan(0);
+  });
+
   it("should answer multiple questions in a single call", async () => {
     const questions = [
       { question: "Is this video about glasses?" },


### PR DESCRIPTION
## Context

Reported by Phil in [Slack](https://mux.slack.com/archives/C0AP7J949B5/p1786697467758399?thread_ts=1786696888.971829&cid=C0AP7J949B5) ([AIT-382](https://mux1.atlassian.net/browse/AIT-382)): the ask-questions job returned `skipped` instead of "no" for a relevant-but-negative question. Example run against three questions:
- "Is someone speaking on camera?" → yes
- "Is this about video contribution protocols?" → yes
- "Is this about cats?" → skipped (reasoning: "Cats are not mentioned in the narration or depicted in the available visual content.") — expected "no"

Root cause:
- The `relevance_filtering` prompt blocks (video + audio-only) let the model treat "subject not present" as unanswerable and skip the question, instead of answering "no".
- Clarified both blocks to explicitly separate "irrelevant question" (skip) from "relevant question with a negative/absent answer" (answer "no"), with a concrete example, and narrowed the skip criteria so it can't be misread as covering absence.

## Test plan

I was able to reproduce Phil's results with a newly-added integration test against the same staging asset he used, then updated the prompt and confirmed those changes yielded the correct results. I've updated the query to match the test asset though.

**tests/integration/ask-questions.test.ts**

| Test case | Covers |
|---|---|
| should answer a series yes/no content-test question with OpenAI | Relevant yes/no questions with no supporting evidence in the content return "no" rather than being skipped |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only behavior change for when the model marks questions skipped; no API or post-processing logic changes.
> 
> **Overview**
> Fixes **ask-questions** returning `skipped` for on-topic yes/no checks when the subject never appears in the asset (e.g. “Is this about cats?” → expected **no**, not skip).
> 
> **Prompt updates** in `ask-questions.ts` (video + audio-only system prompts and the user `<task>` block) clarify that **absence in frames/transcript is answerable evidence**, with a concrete cat-content example. Skip is limited to truly irrelevant or unknowable questions—not “can’t find the subject.” Ambiguous cases still get a conservative answer with low confidence.
> 
> Adds an **OpenAI integration test** that batches yes/no content questions and asserts negative answers (including “not about video contribution protocols”) are returned as **no** with full answer metadata, not skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cda0ac14b8cb025d82eea0cbd9893252bce098a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->