### PR TITLE
chore: bump version to 0.38.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mux/ai",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mux/ai",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mux/ai",
   "type": "module",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "AI library for Mux",
   "author": "Mux",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Bumps `@mux/ai` from 0.37.0 to 0.38.0 in `package.json`/`package-lock.json`. Version-only, no source changes.
- Only commit in this range since `v0.37.0`: #244 (ask-questions prompt fix — relevant yes/no questions no longer get skipped instead of answered "no").

## Test plan

No tests added — version-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime or API changes in the PR diff.
> 
> **Overview**
> **Release prep:** bumps published `@mux/ai` from **0.37.0** to **0.38.0** in `package.json` and the root entry in `package-lock.json`. No library source, tests, or dependency changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb45d7924b80e2a4c247dfefb9631aed5f66c125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->